### PR TITLE
Handle potentially corrupt data after bad shutdown

### DIFF
--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -93,7 +93,7 @@ func main() {
 	// Create new sidecar instance
 	sidecar := sidecar.NewSidecar(&sidecar.SidecarConfig{
 		GenesisBlockNumber: cfg.GetGenesisBlockNumber(),
-	}, cfg, mds, p, l, client)
+	}, cfg, mds, p, sm, l, client)
 
 	// RPC channel to notify the RPC server to shutdown gracefully
 	rpcChannel := make(chan bool)

--- a/internal/eigenState/avsOperators/avsOperators.go
+++ b/internal/eigenState/avsOperators/avsOperators.go
@@ -384,6 +384,10 @@ func (a *AvsOperatorsModel) merkelizeState(blockNumber uint64, avsOperators []Re
 	)
 }
 
+func (a *AvsOperatorsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
+	return a.BaseEigenState.DeleteState("registered_avs_operators", startBlockNumber, endBlockNumber, a.Db)
+}
+
 func encodeOperatorLeaf(operator string, registered bool) []byte {
 	return []byte(fmt.Sprintf("%s:%t", operator, registered))
 }

--- a/internal/eigenState/operatorShares/operatorShares.go
+++ b/internal/eigenState/operatorShares/operatorShares.go
@@ -456,3 +456,7 @@ func encodeStratTree(strategy string, operatorTreeRoot []byte) []byte {
 	strategyBytes := []byte(strategy)
 	return append(strategyBytes, operatorTreeRoot[:]...)
 }
+
+func (osm *OperatorSharesModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
+	return osm.BaseEigenState.DeleteState("operator_shares", startBlockNumber, endBlockNumber, osm.Db)
+}

--- a/internal/eigenState/stakerDelegations/stakerDelegations.go
+++ b/internal/eigenState/stakerDelegations/stakerDelegations.go
@@ -380,3 +380,7 @@ func encodeStakerLeaf(staker string, delegated bool) []byte {
 func encodeOperatorLeaf(operator string, operatorStakersRoot []byte) []byte {
 	return append([]byte(operator), operatorStakersRoot[:]...)
 }
+
+func (s *StakerDelegationsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
+	return s.BaseEigenState.DeleteState("delegated_stakers", startBlockNumber, endBlockNumber, s.Db)
+}

--- a/internal/eigenState/stakerShares/stakerShares.go
+++ b/internal/eigenState/stakerShares/stakerShares.go
@@ -576,3 +576,7 @@ func encodeStratTree(strategy string, stakerTreeRoot []byte) []byte {
 	strategyBytes := []byte(strategy)
 	return append(strategyBytes, stakerTreeRoot[:]...)
 }
+
+func (ss *StakerSharesModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
+	return ss.BaseEigenState.DeleteState("staker_shares", startBlockNumber, endBlockNumber, ss.Db)
+}

--- a/internal/eigenState/types/types.go
+++ b/internal/eigenState/types/types.go
@@ -36,6 +36,13 @@ type IEigenStateModel interface {
 	// ClearAccumulatedState
 	// Clear the accumulated state for the model to free up memory
 	ClearAccumulatedState(blockNumber uint64) error
+
+	// DeleteState used to delete state stored that may be incomplete or corrupted
+	// to allow for reprocessing of the state
+	//
+	// @param startBlockNumber the block number to start deleting state from (inclusive)
+	// @param endBlockNumber the block number to end deleting state from (inclusive). If 0, delete all state from startBlockNumber
+	DeleteState(startBlockNumber uint64, endBlockNumber uint64) error
 }
 
 // StateTransitions

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -35,6 +35,7 @@ type Sidecar struct {
 	Storage        storage.BlockStore
 	Pipeline       *pipeline.Pipeline
 	EthereumClient *ethereum.Client
+	StateManager   *stateManager.EigenStateManager
 	ShutdownChan   chan bool
 }
 
@@ -43,6 +44,7 @@ func NewSidecar(
 	gCfg *config.Config,
 	s storage.BlockStore,
 	p *pipeline.Pipeline,
+	em *stateManager.EigenStateManager,
 	l *zap.Logger,
 	ethClient *ethereum.Client,
 ) *Sidecar {
@@ -53,6 +55,7 @@ func NewSidecar(
 		Storage:        s,
 		Pipeline:       p,
 		EthereumClient: ethClient,
+		StateManager:   em,
 		ShutdownChan:   make(chan bool),
 	}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -15,6 +15,12 @@ type BlockStore interface {
 
 	// Less generic functions
 	GetLatestActiveAvsOperators(blockNumber uint64, avsDirectoryAddress string) ([]*ActiveAvsOperator, error)
+
+	// DeleteCorruptedState deletes all the corrupted state from the database
+	//
+	// @param startBlockNumber: The block number from which to start (inclusive)
+	// @param endBlockNumber: The block number at which to end (inclusive). If 0, it will delete all the corrupted state from the startBlock
+	DeleteCorruptedState(startBlockNumber uint64, endBlockNumber uint64) error
 }
 
 // Tables


### PR DESCRIPTION
On startup:
* Pull the block number of the last stateroot
* If that block number is less than the latest block in the blocks table, delete everything > stateroot block
* Start indexing from stateroot block + 1

Closes #19