### PR TITLE
Fix query that was returning empty string

### DIFF
--- a/internal/indexer/restakedStrategies.go
+++ b/internal/indexer/restakedStrategies.go
@@ -128,6 +128,9 @@ func (idx *Indexer) getAndInsertRestakedStrategiesWithMulticall(
 	blockNumber := block.Number
 	pairs := make([]*contractCaller.OperatorRestakedStrategy, 0)
 	for _, avsOperator := range avsOperators {
+		if avsOperator == nil || avsOperator.Operator == "" || avsOperator.Avs == "" {
+			return fmt.Errorf("Invalid AVS operator - %v", avsOperator)
+		}
 		pairs = append(pairs, &contractCaller.OperatorRestakedStrategy{
 			Operator: avsOperator.Operator,
 			Avs:      avsOperator.Avs,

--- a/internal/indexer/restakedStrategies_test.go
+++ b/internal/indexer/restakedStrategies_test.go
@@ -157,8 +157,6 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 		})
 	})
 	t.Run("Integration - gets restaked strategies for avs/operator multicall", func(t *testing.T) {
-		avs := "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"
-		operator := "0xA8C128BD6f5A314b46202Dd7C68E7E2422eD61F2"
 
 		block := &storage.Block{
 			Number:    uint64(1191600),
@@ -168,8 +166,8 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 		avsOperator := []*contractCaller.OperatorRestakedStrategy{
 			{
-				Avs:      avs,
-				Operator: operator,
+				Avs:      "0xD4A7E1Bd8015057293f0D0A557088c286942e84b",
+				Operator: "0xA8C128BD6f5A314b46202Dd7C68E7E2422eD61F2",
 			},
 		}
 

--- a/internal/storage/sqlite/storage.go
+++ b/internal/storage/sqlite/storage.go
@@ -186,7 +186,7 @@ func (s *SqliteBlockStore) GetLatestActiveAvsOperators(blockNumber uint64, avsDi
 		WITH latest_status AS (
 			SELECT
 				lower(json_extract(tl.arguments, '$[0].Value')) as operator,
-				lower(json_extract(tl.arguments, '$[2].Value')) as avs,
+				lower(json_extract(tl.arguments, '$[1].Value')) as avs,
 				lower(json_extract(tl.output_data, '$.status')) as status,
 				ROW_NUMBER() OVER (
 					PARTITION BY

--- a/pkg/multicall/multicall.go
+++ b/pkg/multicall/multicall.go
@@ -134,7 +134,7 @@ func DoMultiCallMany[A any](mc MulticallClient, requests ...*MultiCallMetaData[A
 	// unwind results
 	unwoundResults := utils.Map(res, func(d DeserializedMulticall3Result, i uint64) A {
 		// force these back to A
-		return any(d.Value).(A)
+		return d.Value.(A)
 	})
 	return &unwoundResults, nil
 }


### PR DESCRIPTION
Query was referencing the wrong field when getting the AVS