### PR TITLE
Merkleization refactoring

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -74,10 +74,10 @@ func main() {
 	if _, err := avsOperators.NewAvsOperators(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create AvsOperatorsModel", zap.Error(err))
 	}
-	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create OperatorSharesModel", zap.Error(err))
 	}
-	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerDelegationsModel", zap.Error(err))
 	}
 	if _, err := stakerShares.NewStakerSharesModel(sm, grm, l, cfg); err != nil {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	sm := stateManager.NewEigenStateManager(l, grm)
 
-	if _, err := avsOperators.NewAvsOperators(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := avsOperators.NewAvsOperators(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create AvsOperatorsModel", zap.Error(err))
 	}
 	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, l, cfg); err != nil {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -80,7 +80,7 @@ func main() {
 	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerDelegationsModel", zap.Error(err))
 	}
-	if _, err := stakerShares.NewStakerSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := stakerShares.NewStakerSharesModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerSharesModel", zap.Error(err))
 	}
 

--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -90,7 +90,7 @@ func main() {
 	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create SubmittedDistributionRootsModel", zap.Error(err))
 	}
-	if _, err := rewardSubmissions.NewRewardSubmissionsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := rewardSubmissions.NewRewardSubmissionsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create RewardSubmissionsModel", zap.Error(err))
 	}
 

--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -84,7 +84,7 @@ func main() {
 	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerDelegationsModel", zap.Error(err))
 	}
-	if _, err := stakerShares.NewStakerSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := stakerShares.NewStakerSharesModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerSharesModel", zap.Error(err))
 	}
 	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, l, cfg); err != nil {

--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -78,10 +78,10 @@ func main() {
 	if _, err := avsOperators.NewAvsOperators(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create AvsOperatorsModel", zap.Error(err))
 	}
-	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create OperatorSharesModel", zap.Error(err))
 	}
-	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerDelegationsModel", zap.Error(err))
 	}
 	if _, err := stakerShares.NewStakerSharesModel(sm, grm, l, cfg); err != nil {

--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	sm := stateManager.NewEigenStateManager(l, grm)
 
-	if _, err := avsOperators.NewAvsOperators(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := avsOperators.NewAvsOperators(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create AvsOperatorsModel", zap.Error(err))
 	}
 	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, l, cfg); err != nil {

--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -87,7 +87,7 @@ func main() {
 	if _, err := stakerShares.NewStakerSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerSharesModel", zap.Error(err))
 	}
-	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create SubmittedDistributionRootsModel", zap.Error(err))
 	}
 	if _, err := rewardSubmissions.NewRewardSubmissionsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {

--- a/internal/eigenState/avsOperators/avsOperators.go
+++ b/internal/eigenState/avsOperators/avsOperators.go
@@ -326,7 +326,7 @@ func (a *AvsOperatorsModel) sortValuesForMerkleTree(diffs []*RegisteredAvsOperat
 	inputs := make([]*base.MerkleTreeInput, 0)
 	for _, diff := range diffs {
 		inputs = append(inputs, &base.MerkleTreeInput{
-			SlotID: types.SlotID(fmt.Sprintf("%s_%s", diff.Avs, diff.Operator)),
+			SlotID: NewSlotID(diff.Avs, diff.Operator),
 			Value:  []byte(fmt.Sprintf("%t", diff.Registered)),
 		})
 	}

--- a/internal/eigenState/avsOperators/avsOperators_test.go
+++ b/internal/eigenState/avsOperators/avsOperators_test.go
@@ -37,8 +37,8 @@ func setup() (
 }
 
 func teardown(model *AvsOperatorsModel) {
-	model.Db.Exec("delete from avs_operator_changes")
-	model.Db.Exec("delete from registered_avs_operators")
+	model.DB.Exec("delete from avs_operator_changes")
+	model.DB.Exec("delete from registered_avs_operators")
 }
 
 func Test_AvsOperatorState(t *testing.T) {
@@ -50,7 +50,7 @@ func Test_AvsOperatorState(t *testing.T) {
 
 	t.Run("Should create a new AvsOperatorState", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
-		avsOperatorState, err := NewAvsOperators(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		avsOperatorState, err := NewAvsOperators(esm, grm, l, cfg)
 		assert.Nil(t, err)
 		assert.NotNil(t, avsOperatorState)
 	})
@@ -71,7 +71,7 @@ func Test_AvsOperatorState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		avsOperatorState, err := NewAvsOperators(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		avsOperatorState, err := NewAvsOperators(esm, grm, l, cfg)
 
 		assert.Equal(t, true, avsOperatorState.IsInterestingLog(&log))
 
@@ -102,7 +102,7 @@ func Test_AvsOperatorState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		avsOperatorState, err := NewAvsOperators(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		avsOperatorState, err := NewAvsOperators(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
 		assert.Equal(t, true, avsOperatorState.IsInterestingLog(&log))
@@ -118,7 +118,7 @@ func Test_AvsOperatorState(t *testing.T) {
 		assert.Nil(t, err)
 
 		states := []RegisteredAvsOperators{}
-		statesRes := avsOperatorState.Db.
+		statesRes := avsOperatorState.DB.
 			Model(&RegisteredAvsOperators{}).
 			Raw("select * from registered_avs_operators where block_number = @blockNumber", sql.Named("blockNumber", blockNumber)).
 			Scan(&states)
@@ -170,7 +170,7 @@ func Test_AvsOperatorState(t *testing.T) {
 			},
 		}
 
-		avsOperatorState, err := NewAvsOperators(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		avsOperatorState, err := NewAvsOperators(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
 		for _, log := range logs {
@@ -187,7 +187,7 @@ func Test_AvsOperatorState(t *testing.T) {
 			assert.Nil(t, err)
 
 			states := []RegisteredAvsOperators{}
-			statesRes := avsOperatorState.Db.
+			statesRes := avsOperatorState.DB.
 				Model(&RegisteredAvsOperators{}).
 				Raw("select * from registered_avs_operators where block_number = @blockNumber", sql.Named("blockNumber", log.BlockNumber)).
 				Scan(&states)

--- a/internal/eigenState/base/baseEigenState.go
+++ b/internal/eigenState/base/baseEigenState.go
@@ -76,7 +76,7 @@ func (b *BaseEigenState) DeleteState(tableName string, startBlockNumber uint64, 
 			zap.Uint64("startBlockNumber", startBlockNumber),
 			zap.Uint64("endBlockNumber", endBlockNumber),
 		)
-		return fmt.Errorf("Invalid block range; endBlockNumber must be greater than or equal to startBlockNumber")
+		return errors.New("Invalid block range; endBlockNumber must be greater than or equal to startBlockNumber")
 	}
 
 	// tokenizing the table name apparently doesnt work, so we need to use Sprintf to include it.
@@ -103,6 +103,9 @@ type MerkleTreeInput struct {
 	Value  []byte
 }
 
+// MerkleizeState creates a merkle tree from the given inputs.
+//
+// Each input includes a SlotID and a byte representation of the state that changed
 func (b *BaseEigenState) MerkleizeState(blockNumber uint64, inputs []*MerkleTreeInput) (*merkletree.MerkleTree, error) {
 	om := orderedmap.New[types.SlotID, []byte]()
 

--- a/internal/eigenState/base/baseEigenState.go
+++ b/internal/eigenState/base/baseEigenState.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/Layr-Labs/go-sidecar/internal/eigenState/types"
 	"slices"
 	"strings"
 
@@ -91,4 +92,11 @@ func (b *BaseEigenState) DeleteState(tableName string, startBlockNumber uint64, 
 		return res.Error
 	}
 	return nil
+}
+
+type MerkleTreeInput struct {
+	SlotID types.SlotID
+}
+
+func (b *BaseEigenState) MerkleizeState() {
 }

--- a/internal/eigenState/base/baseEigenState.go
+++ b/internal/eigenState/base/baseEigenState.go
@@ -117,7 +117,7 @@ func (b *BaseEigenState) MerkleizeState(blockNumber uint64, inputs []*MerkleTree
 				return nil, errors.New("slotIDs are not in order")
 			}
 		} else {
-			return nil, errors.New(fmt.Sprintf("duplicate slotID %d", input.SlotID))
+			return nil, errors.New(fmt.Sprintf("duplicate slotID %s", input.SlotID))
 		}
 	}
 
@@ -132,5 +132,5 @@ func (b *BaseEigenState) MerkleizeState(blockNumber uint64, inputs []*MerkleTree
 }
 
 func encodeMerkleLeaf(slotID types.SlotID, value []byte) []byte {
-	return append([]byte(slotID), value[:]...)
+	return append([]byte(slotID), value...)
 }

--- a/internal/eigenState/eigenstate_test.go
+++ b/internal/eigenState/eigenstate_test.go
@@ -53,7 +53,7 @@ func Test_EigenStateManager(t *testing.T) {
 	})
 	t.Run("Should create a state root with states from models", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
-		avsOperatorsModel, err := avsOperators.NewAvsOperators(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		avsOperatorsModel, err := avsOperators.NewAvsOperators(esm, grm, l, cfg)
 		assert.Nil(t, err)
 		assert.NotNil(t, avsOperatorsModel)
 

--- a/internal/eigenState/eigenstate_test.go
+++ b/internal/eigenState/eigenstate_test.go
@@ -57,7 +57,7 @@ func Test_EigenStateManager(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, avsOperatorsModel)
 
-		operatorSharesModel, err := operatorShares.NewOperatorSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		operatorSharesModel, err := operatorShares.NewOperatorSharesModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 		assert.NotNil(t, operatorSharesModel)
 

--- a/internal/eigenState/operatorShares/operatorShares_test.go
+++ b/internal/eigenState/operatorShares/operatorShares_test.go
@@ -39,8 +39,8 @@ func setup() (
 }
 
 func teardown(model *OperatorSharesModel) {
-	model.Db.Exec("delete from operator_share_changes")
-	model.Db.Exec("delete from operator_shares")
+	model.DB.Exec("delete from operator_share_changes")
+	model.DB.Exec("delete from operator_shares")
 }
 
 func Test_OperatorSharesState(t *testing.T) {
@@ -52,7 +52,7 @@ func Test_OperatorSharesState(t *testing.T) {
 
 	t.Run("Should create a new OperatorSharesState", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
-		model, err := NewOperatorSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewOperatorSharesModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 		assert.NotNil(t, model)
 	})
@@ -73,7 +73,7 @@ func Test_OperatorSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewOperatorSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewOperatorSharesModel(esm, grm, l, cfg)
 
 		err = model.InitBlockProcessing(blockNumber)
 		assert.Nil(t, err)
@@ -101,7 +101,7 @@ func Test_OperatorSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewOperatorSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewOperatorSharesModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
 		err = model.InitBlockProcessing(blockNumber)
@@ -115,7 +115,7 @@ func Test_OperatorSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		states := []OperatorShares{}
-		statesRes := model.Db.
+		statesRes := model.DB.
 			Model(&OperatorShares{}).
 			Raw("select * from operator_shares where block_number = @blockNumber", sql.Named("blockNumber", blockNumber)).
 			Scan(&states)
@@ -150,7 +150,7 @@ func Test_OperatorSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewOperatorSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewOperatorSharesModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
 		err = model.InitBlockProcessing(blockNumber)

--- a/internal/eigenState/rewardSubmissions/rewardSubmissions.go
+++ b/internal/eigenState/rewardSubmissions/rewardSubmissions.go
@@ -3,7 +3,6 @@ package rewardSubmissions
 import (
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -17,9 +16,6 @@ import (
 	"github.com/Layr-Labs/go-sidecar/internal/storage"
 	"github.com/Layr-Labs/go-sidecar/internal/types/numbers"
 	"github.com/Layr-Labs/go-sidecar/internal/utils"
-	"github.com/wealdtech/go-merkletree/v2"
-	"github.com/wealdtech/go-merkletree/v2/keccak256"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"gorm.io/gorm"
@@ -58,7 +54,7 @@ func NewSlotID(rewardHash string, strategy string) types.SlotID {
 type RewardSubmissionsModel struct {
 	base.BaseEigenState
 	StateTransitions types.StateTransitions[RewardSubmission]
-	Db               *gorm.DB
+	DB               *gorm.DB
 	Network          config.Network
 	Environment      config.Environment
 	logger           *zap.Logger
@@ -71,8 +67,6 @@ type RewardSubmissionsModel struct {
 func NewRewardSubmissionsModel(
 	esm *stateManager.EigenStateManager,
 	grm *gorm.DB,
-	Network config.Network,
-	Environment config.Environment,
 	logger *zap.Logger,
 	globalConfig *config.Config,
 ) (*RewardSubmissionsModel, error) {
@@ -80,9 +74,7 @@ func NewRewardSubmissionsModel(
 		BaseEigenState: base.BaseEigenState{
 			Logger: logger,
 		},
-		Db:               grm,
-		Network:          Network,
-		Environment:      Environment,
+		DB:               grm,
 		logger:           logger,
 		globalConfig:     globalConfig,
 		stateAccumulator: make(map[uint64]map[types.SlotID]*RewardSubmission),
@@ -277,7 +269,7 @@ func (rs *RewardSubmissionsModel) clonePreviousBlocksToNewBlock(blockNumber uint
 			from reward_submissions
 			where block_number = @previousBlock
 	`
-	res := rs.Db.Exec(query,
+	res := rs.DB.Exec(query,
 		sql.Named("currentBlock", blockNumber),
 		sql.Named("previousBlock", blockNumber-1),
 	)
@@ -299,7 +291,7 @@ func (rs *RewardSubmissionsModel) prepareState(blockNumber uint64) ([]*RewardSub
 	}
 
 	currentBlock := &storage.Block{}
-	err := rs.Db.Where("number = ?", blockNumber).First(currentBlock).Error
+	err := rs.DB.Where("number = ?", blockNumber).First(currentBlock).Error
 	if err != nil {
 		rs.logger.Sugar().Errorw("Failed to fetch block", zap.Error(err), zap.Uint64("blockNumber", blockNumber))
 		return nil, nil, err
@@ -327,7 +319,7 @@ func (rs *RewardSubmissionsModel) prepareState(blockNumber uint64) ([]*RewardSub
 			block_number = @previousBlock
 			and end_timestamp <= @blockTime
 	`
-	res := rs.Db.
+	res := rs.DB.
 		Model(&RewardSubmission{}).
 		Raw(query,
 			sql.Named("previousBlock", blockNumber-1),
@@ -363,7 +355,7 @@ func (rs *RewardSubmissionsModel) CommitFinalState(blockNumber uint64) error {
 	}
 
 	for _, record := range recordsToDelete {
-		res := rs.Db.Delete(&RewardSubmission{}, "reward_hash = ? and strategy = ? and block_number = ?", record.RewardSubmission.RewardHash, record.RewardSubmission.Strategy, blockNumber)
+		res := rs.DB.Delete(&RewardSubmission{}, "reward_hash = ? and strategy = ? and block_number = ?", record.RewardSubmission.RewardHash, record.RewardSubmission.Strategy, blockNumber)
 		if res.Error != nil {
 			rs.logger.Sugar().Errorw("Failed to delete record",
 				zap.Error(res.Error),
@@ -377,7 +369,7 @@ func (rs *RewardSubmissionsModel) CommitFinalState(blockNumber uint64) error {
 	if len(recordsToInsert) > 0 {
 		// records := make([]RewardSubmission, 0)
 		for _, record := range recordsToInsert {
-			res := rs.Db.Model(&RewardSubmission{}).Clauses(clause.Returning{}).Create(&record.RewardSubmission)
+			res := rs.DB.Model(&RewardSubmission{}).Clauses(clause.Returning{}).Create(&record.RewardSubmission)
 			if res.Error != nil {
 				rs.logger.Sugar().Errorw("Failed to insert records", zap.Error(res.Error))
 				fmt.Printf("\n\n%+v\n\n", record.RewardSubmission)
@@ -408,118 +400,36 @@ func (rs *RewardSubmissionsModel) GenerateStateRoot(blockNumber uint64) (types.S
 		combinedResults = append(combinedResults, record)
 	}
 
-	fullTree, err := rs.merkelizeState(blockNumber, combinedResults)
+	inputs := rs.sortValuesForMerkleTree(combinedResults)
+
+	fullTree, err := rs.MerkleizeState(blockNumber, inputs)
 	if err != nil {
 		return "", err
 	}
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
 }
 
-func (rs *RewardSubmissionsModel) sortValuesForMerkleTree(submissions []*RewardSubmissionDiff) []*RewardSubmissionDiff {
-	mappedByAvs := make(map[string][]*RewardSubmissionDiff)
+func (rs *RewardSubmissionsModel) sortValuesForMerkleTree(submissions []*RewardSubmissionDiff) []*base.MerkleTreeInput {
+	inputs := make([]*base.MerkleTreeInput, 0)
 	for _, submission := range submissions {
-		if _, ok := mappedByAvs[submission.RewardSubmission.Avs]; !ok {
-			mappedByAvs[submission.RewardSubmission.Avs] = make([]*RewardSubmissionDiff, 0)
+		slotID := NewSlotID(submission.RewardSubmission.RewardHash, submission.RewardSubmission.Strategy)
+		value := "added"
+		if submission.IsNoLongerActive {
+			value = "removed"
 		}
-		mappedByAvs[submission.RewardSubmission.Avs] = append(mappedByAvs[submission.RewardSubmission.Avs], submission)
-	}
-
-	for _, sub := range mappedByAvs {
-		slices.SortFunc(sub, func(i, j *RewardSubmissionDiff) int {
-			iSlotID := NewSlotID(i.RewardSubmission.RewardHash, i.RewardSubmission.Strategy)
-			jSlotID := NewSlotID(j.RewardSubmission.RewardHash, j.RewardSubmission.Strategy)
-
-			return strings.Compare(string(iSlotID), string(jSlotID))
+		inputs = append(inputs, &base.MerkleTreeInput{
+			SlotID: slotID,
+			Value:  []byte(value),
 		})
 	}
 
-	avsAddresses := make([]string, 0)
-	for key := range mappedByAvs {
-		avsAddresses = append(avsAddresses, key)
-	}
-
-	sort.Slice(avsAddresses, func(i, j int) bool {
-		return avsAddresses[i] < avsAddresses[j]
+	slices.SortFunc(inputs, func(i, j *base.MerkleTreeInput) int {
+		return strings.Compare(string(i.SlotID), string(j.SlotID))
 	})
 
-	sorted := make([]*RewardSubmissionDiff, 0)
-	for _, avs := range avsAddresses {
-		sorted = append(sorted, mappedByAvs[avs]...)
-	}
-	return sorted
-}
-
-func (rs *RewardSubmissionsModel) merkelizeState(blockNumber uint64, rewardSubmissions []*RewardSubmissionDiff) (*merkletree.MerkleTree, error) {
-	// Avs -> slot_id -> string (added/removed)
-	om := orderedmap.New[string, *orderedmap.OrderedMap[types.SlotID, string]]()
-
-	rewardSubmissions = rs.sortValuesForMerkleTree(rewardSubmissions)
-
-	for _, result := range rewardSubmissions {
-		existingAvs, found := om.Get(result.RewardSubmission.Avs)
-		if !found {
-			existingAvs = orderedmap.New[types.SlotID, string]()
-			om.Set(result.RewardSubmission.Avs, existingAvs)
-
-			prev := om.GetPair(result.RewardSubmission.Avs).Prev()
-			if prev != nil && strings.Compare(prev.Key, result.RewardSubmission.Avs) >= 0 {
-				om.Delete(result.RewardSubmission.Avs)
-				return nil, errors.New("avs not in order")
-			}
-		}
-		slotID := NewSlotID(result.RewardSubmission.RewardHash, result.RewardSubmission.Strategy)
-		var state string
-		if result.IsNew {
-			state = "added"
-		} else if result.IsNoLongerActive {
-			state = "removed"
-		} else {
-			return nil, errors.New("invalid state change")
-		}
-		existingAvs.Set(slotID, state)
-
-		prev := existingAvs.GetPair(slotID).Prev()
-		if prev != nil && strings.Compare(string(prev.Key), string(slotID)) >= 0 {
-			existingAvs.Delete(slotID)
-			return nil, errors.New("operator not in order")
-		}
-	}
-
-	avsLeaves := rs.InitializeMerkleTreeBaseStateWithBlock(blockNumber)
-
-	for avs := om.Oldest(); avs != nil; avs = avs.Next() {
-		submissionLeafs := make([][]byte, 0)
-		for submission := avs.Value.Oldest(); submission != nil; submission = submission.Next() {
-			slotID := submission.Key
-			state := submission.Value
-			submissionLeafs = append(submissionLeafs, encodeSubmissionLeaf(slotID, state))
-		}
-
-		avsTree, err := merkletree.NewTree(
-			merkletree.WithData(submissionLeafs),
-			merkletree.WithHashType(keccak256.New()),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		avsLeaves = append(avsLeaves, encodeAvsLeaf(avs.Key, avsTree.Root()))
-	}
-
-	return merkletree.NewTree(
-		merkletree.WithData(avsLeaves),
-		merkletree.WithHashType(keccak256.New()),
-	)
-}
-
-func encodeSubmissionLeaf(slotId types.SlotID, state string) []byte {
-	return []byte(fmt.Sprintf("%s:%s", slotId, state))
-}
-
-func encodeAvsLeaf(avs string, avsSubmissionRoot []byte) []byte {
-	return append([]byte(avs), avsSubmissionRoot...)
+	return inputs
 }
 
 func (rs *RewardSubmissionsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return rs.BaseEigenState.DeleteState("registered_avs_operators", startBlockNumber, endBlockNumber, rs.Db)
+	return rs.BaseEigenState.DeleteState("registered_avs_operators", startBlockNumber, endBlockNumber, rs.DB)
 }

--- a/internal/eigenState/rewardSubmissions/rewardSubmissions.go
+++ b/internal/eigenState/rewardSubmissions/rewardSubmissions.go
@@ -415,7 +415,7 @@ func (rs *RewardSubmissionsModel) GenerateStateRoot(blockNumber uint64) (types.S
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
 }
 
-func (rs *RewardSubmissionsModel) sortRewardSubmissionsForMerkelization(submissions []*RewardSubmissionDiff) []*RewardSubmissionDiff {
+func (rs *RewardSubmissionsModel) sortValuesForMerkleTree(submissions []*RewardSubmissionDiff) []*RewardSubmissionDiff {
 	mappedByAvs := make(map[string][]*RewardSubmissionDiff)
 	for _, submission := range submissions {
 		if _, ok := mappedByAvs[submission.RewardSubmission.Avs]; !ok {
@@ -453,7 +453,7 @@ func (rs *RewardSubmissionsModel) merkelizeState(blockNumber uint64, rewardSubmi
 	// Avs -> slot_id -> string (added/removed)
 	om := orderedmap.New[string, *orderedmap.OrderedMap[types.SlotID, string]]()
 
-	rewardSubmissions = rs.sortRewardSubmissionsForMerkelization(rewardSubmissions)
+	rewardSubmissions = rs.sortValuesForMerkleTree(rewardSubmissions)
 
 	for _, result := range rewardSubmissions {
 		existingAvs, found := om.Get(result.RewardSubmission.Avs)

--- a/internal/eigenState/rewardSubmissions/rewardSubmissions.go
+++ b/internal/eigenState/rewardSubmissions/rewardSubmissions.go
@@ -467,7 +467,7 @@ func (rs *RewardSubmissionsModel) merkelizeState(blockNumber uint64, rewardSubmi
 				return nil, errors.New("avs not in order")
 			}
 		}
-		slotId := NewSlotID(result.RewardSubmission.RewardHash, result.RewardSubmission.Strategy)
+		slotID := NewSlotID(result.RewardSubmission.RewardHash, result.RewardSubmission.Strategy)
 		var state string
 		if result.IsNew {
 			state = "added"
@@ -476,11 +476,11 @@ func (rs *RewardSubmissionsModel) merkelizeState(blockNumber uint64, rewardSubmi
 		} else {
 			return nil, errors.New("invalid state change")
 		}
-		existingAvs.Set(slotId, state)
+		existingAvs.Set(slotID, state)
 
-		prev := existingAvs.GetPair(slotId).Prev()
-		if prev != nil && strings.Compare(string(prev.Key), string(slotId)) >= 0 {
-			existingAvs.Delete(slotId)
+		prev := existingAvs.GetPair(slotID).Prev()
+		if prev != nil && strings.Compare(string(prev.Key), string(slotID)) >= 0 {
+			existingAvs.Delete(slotID)
 			return nil, errors.New("operator not in order")
 		}
 	}

--- a/internal/eigenState/rewardSubmissions/rewardSubmissions_test.go
+++ b/internal/eigenState/rewardSubmissions/rewardSubmissions_test.go
@@ -44,7 +44,7 @@ func teardown(model *RewardSubmissionsModel) {
 		`delete from blocks`,
 	}
 	for _, query := range queries {
-		res := model.Db.Exec(query)
+		res := model.DB.Exec(query)
 		if res.Error != nil {
 			fmt.Printf("Failed to run query: %v\n", res.Error)
 		}
@@ -57,7 +57,7 @@ func createBlock(model *RewardSubmissionsModel, blockNumber uint64) error {
 		Hash:      "some hash",
 		BlockTime: time.Now().Add(time.Hour * time.Duration(blockNumber)),
 	}
-	res := model.Db.Model(&storage.Block{}).Create(block)
+	res := model.DB.Model(&storage.Block{}).Create(block)
 	if res.Error != nil {
 		return res.Error
 	}
@@ -74,7 +74,7 @@ func Test_RewardSubmissions(t *testing.T) {
 	t.Run("Test each event type", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
 
-		model, err := NewRewardSubmissionsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewRewardSubmissionsModel(esm, grm, l, cfg)
 
 		submissionCounter := 0
 
@@ -140,7 +140,7 @@ func Test_RewardSubmissions(t *testing.T) {
 
 			rewards := make([]*RewardSubmission, 0)
 			query := `select * from reward_submissions where block_number = ?`
-			res := model.Db.Raw(query, blockNumber).Scan(&rewards)
+			res := model.DB.Raw(query, blockNumber).Scan(&rewards)
 			assert.Nil(t, res.Error)
 			assert.Equal(t, len(strategiesAndMultipliers), len(rewards))
 
@@ -215,7 +215,7 @@ func Test_RewardSubmissions(t *testing.T) {
 
 			rewards := make([]*RewardSubmission, 0)
 			query := `select * from reward_submissions where block_number = ?`
-			res := model.Db.Raw(query, blockNumber).Scan(&rewards)
+			res := model.DB.Raw(query, blockNumber).Scan(&rewards)
 			assert.Nil(t, res.Error)
 			assert.Equal(t, len(strategiesAndMultipliers), len(rewards))
 
@@ -287,7 +287,7 @@ func Test_RewardSubmissions(t *testing.T) {
 
 			rewards := make([]*RewardSubmission, 0)
 			query := `select * from reward_submissions where block_number = ?`
-			res := model.Db.Raw(query, blockNumber).Scan(&rewards)
+			res := model.DB.Raw(query, blockNumber).Scan(&rewards)
 			assert.Nil(t, res.Error)
 			assert.Equal(t, len(strategiesAndMultipliers), len(rewards))
 
@@ -360,7 +360,7 @@ func Test_RewardSubmissions(t *testing.T) {
 
 			rewards := make([]*RewardSubmission, 0)
 			query := `select * from reward_submissions where block_number = ?`
-			res := model.Db.Raw(query, blockNumber).Scan(&rewards)
+			res := model.DB.Raw(query, blockNumber).Scan(&rewards)
 			assert.Nil(t, res.Error)
 			assert.Equal(t, len(strategiesAndMultipliers), len(rewards))
 
@@ -384,7 +384,7 @@ func Test_RewardSubmissions(t *testing.T) {
 	t.Run("multi-block test", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
 
-		model, err := NewRewardSubmissionsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewRewardSubmissionsModel(esm, grm, l, cfg)
 
 		submissionCounter := 0
 
@@ -424,7 +424,7 @@ func Test_RewardSubmissions(t *testing.T) {
 
 		query := `select count(*) from reward_submissions where block_number = ?`
 		var count int
-		res := model.Db.Raw(query, blockNumber).Scan(&count)
+		res := model.DB.Raw(query, blockNumber).Scan(&count)
 
 		assert.Nil(t, res.Error)
 		assert.Equal(t, submissionCounter, count)
@@ -476,7 +476,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.True(t, len(stateRoot) > 0)
 
 		query = `select count(*) from reward_submissions where block_number = ?`
-		res = model.Db.Raw(query, blockNumber).Scan(&count)
+		res = model.DB.Raw(query, blockNumber).Scan(&count)
 
 		assert.Nil(t, res.Error)
 		assert.Equal(t, submissionCounter, count)
@@ -522,7 +522,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.True(t, len(stateRoot) > 0)
 
 		query = `select count(*) from reward_submissions where block_number = ?`
-		res = model.Db.Raw(query, blockNumber).Scan(&count)
+		res = model.DB.Raw(query, blockNumber).Scan(&count)
 
 		assert.Nil(t, res.Error)
 		assert.Equal(t, submissionCounter, count)
@@ -568,7 +568,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.True(t, len(stateRoot) > 0)
 
 		query = `select count(*) from reward_submissions where block_number = ?`
-		res = model.Db.Raw(query, blockNumber).Scan(&count)
+		res = model.DB.Raw(query, blockNumber).Scan(&count)
 
 		assert.Nil(t, res.Error)
 		assert.Equal(t, submissionCounter, count)
@@ -581,7 +581,7 @@ func Test_RewardSubmissions(t *testing.T) {
 	t.Run("single block, multiple events", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
 
-		model, err := NewRewardSubmissionsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewRewardSubmissionsModel(esm, grm, l, cfg)
 
 		submissionCounter := 0
 
@@ -658,7 +658,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		// check that we're starting with 0 rows
 		query := `select count(*) from reward_submissions`
 		var count int
-		res := model.Db.Raw(query).Scan(&count)
+		res := model.DB.Raw(query).Scan(&count)
 		assert.Nil(t, res.Error)
 		assert.Equal(t, 0, count)
 
@@ -674,7 +674,7 @@ func Test_RewardSubmissions(t *testing.T) {
 
 		// Verify we have the right number of rows
 		query = `select count(*) from reward_submissions where block_number = ?`
-		res = model.Db.Raw(query, blockNumber).Scan(&count)
+		res = model.DB.Raw(query, blockNumber).Scan(&count)
 		assert.Nil(t, res.Error)
 		assert.Equal(t, submissionCounter, count)
 

--- a/internal/eigenState/stakerDelegations/stakerDelegations.go
+++ b/internal/eigenState/stakerDelegations/stakerDelegations.go
@@ -14,9 +14,6 @@ import (
 	"github.com/Layr-Labs/go-sidecar/internal/eigenState/types"
 	"github.com/Layr-Labs/go-sidecar/internal/storage"
 	"github.com/Layr-Labs/go-sidecar/internal/utils"
-	"github.com/wealdtech/go-merkletree/v2"
-	"github.com/wealdtech/go-merkletree/v2/keccak256"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"gorm.io/gorm"
@@ -47,8 +44,6 @@ type StakerDelegationsModel struct {
 	base.BaseEigenState
 	StateTransitions types.StateTransitions[AccumulatedStateChange]
 	DB               *gorm.DB
-	Network          config.Network
-	Environment      config.Environment
 	logger           *zap.Logger
 	globalConfig     *config.Config
 
@@ -66,8 +61,6 @@ type DelegatedStakersDiff struct {
 func NewStakerDelegationsModel(
 	esm *stateManager.EigenStateManager,
 	grm *gorm.DB,
-	Network config.Network,
-	Environment config.Environment,
 	logger *zap.Logger,
 	globalConfig *config.Config,
 ) (*StakerDelegationsModel, error) {
@@ -76,8 +69,6 @@ func NewStakerDelegationsModel(
 			Logger: logger,
 		},
 		DB:               grm,
-		Network:          Network,
-		Environment:      Environment,
 		logger:           logger,
 		globalConfig:     globalConfig,
 		stateAccumulator: make(map[uint64]map[types.SlotID]*AccumulatedStateChange),
@@ -108,8 +99,8 @@ func (s *StakerDelegationsModel) GetStateTransitions() (types.StateTransitions[A
 		staker := strings.ToLower(arguments[0].Value.(string))
 		operator := strings.ToLower(arguments[1].Value.(string))
 
-		slotId := NewSlotID(staker, operator)
-		record, ok := s.stateAccumulator[log.BlockNumber][slotId]
+		slotID := NewSlotID(staker, operator)
+		record, ok := s.stateAccumulator[log.BlockNumber][slotID]
 		if !ok {
 			// if the record doesn't exist, create a new one
 			record = &AccumulatedStateChange{
@@ -117,15 +108,15 @@ func (s *StakerDelegationsModel) GetStateTransitions() (types.StateTransitions[A
 				Operator:    operator,
 				BlockNumber: log.BlockNumber,
 			}
-			s.stateAccumulator[log.BlockNumber][slotId] = record
+			s.stateAccumulator[log.BlockNumber][slotID] = record
 		}
 		if log.EventName == "StakerUndelegated" {
 			if ok {
 				// In this situation, we've encountered a delegate and undelegate in the same block
 				// which functionally results in no state change at all so we want to remove the record
 				// from the accumulated state.
-				delete(s.stateAccumulator[log.BlockNumber], slotId)
-				return nil, nil
+				delete(s.stateAccumulator[log.BlockNumber], slotID)
+				return nil, nil //nolint:nilnil
 			}
 			record.Delegated = false
 		} else if log.EventName == "StakerDelegated" {
@@ -163,7 +154,7 @@ func (s *StakerDelegationsModel) IsInterestingLog(log *storage.TransactionLog) b
 	return s.BaseEigenState.IsInterestingLog(addresses, log)
 }
 
-// StartBlockProcessing Initialize state accumulator for the block.
+// InitBlockProcessing initialize state accumulator for the block.
 func (s *StakerDelegationsModel) InitBlockProcessing(blockNumber uint64) error {
 	s.stateAccumulator[blockNumber] = make(map[types.SlotID]*AccumulatedStateChange)
 	return nil
@@ -186,7 +177,7 @@ func (s *StakerDelegationsModel) HandleStateChange(log *storage.TransactionLog) 
 			return change, nil
 		}
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }
 
 func (s *StakerDelegationsModel) clonePreviousBlocksToNewBlock(blockNumber uint64) error {
@@ -309,73 +300,27 @@ func (s *StakerDelegationsModel) GenerateStateRoot(blockNumber uint64) (types.St
 		})
 	}
 
-	fullTree, err := s.merkelizeState(blockNumber, combinedResults)
+	inputs := s.sortValuesForMerkleTree(combinedResults)
+
+	fullTree, err := s.MerkleizeState(blockNumber, inputs)
 	if err != nil {
 		return "", err
 	}
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
 }
 
-// merkelizeState generates a merkle tree for the given block number and delegated stakers.
-// Changes are stored in the following format:
-// Operator -> staker:delegated.
-func (s *StakerDelegationsModel) merkelizeState(blockNumber uint64, delegatedStakers []DelegatedStakersDiff) (*merkletree.MerkleTree, error) {
-	om := orderedmap.New[string, *orderedmap.OrderedMap[string, bool]]()
-
-	for _, result := range delegatedStakers {
-		existingOperator, found := om.Get(result.Operator)
-		if !found {
-			existingOperator = orderedmap.New[string, bool]()
-			om.Set(result.Operator, existingOperator)
-
-			prev := om.GetPair(result.Operator).Prev()
-			if prev != nil && strings.Compare(prev.Key, result.Operator) >= 0 {
-				om.Delete(result.Operator)
-				return nil, fmt.Errorf("operators not in order")
-			}
-		}
-		existingOperator.Set(result.Staker, result.Delegated)
-
-		prev := existingOperator.GetPair(result.Staker).Prev()
-		if prev != nil && strings.Compare(prev.Key, result.Staker) >= 0 {
-			existingOperator.Delete(result.Staker)
-			return nil, fmt.Errorf("stakers not in order")
-		}
+func (s *StakerDelegationsModel) sortValuesForMerkleTree(diffs []DelegatedStakersDiff) []*base.MerkleTreeInput {
+	inputs := make([]*base.MerkleTreeInput, 0)
+	for _, diff := range diffs {
+		inputs = append(inputs, &base.MerkleTreeInput{
+			SlotID: NewSlotID(diff.Staker, diff.Operator),
+			Value:  []byte(fmt.Sprintf("%t", diff.Delegated)),
+		})
 	}
-
-	operatorLeaves := s.InitializeMerkleTreeBaseStateWithBlock(blockNumber)
-
-	for op := om.Oldest(); op != nil; op = op.Next() {
-		stakerLeafs := make([][]byte, 0)
-		for staker := op.Value.Oldest(); staker != nil; staker = staker.Next() {
-			operatorAddr := staker.Key
-			delegated := staker.Value
-			stakerLeafs = append(stakerLeafs, encodeStakerLeaf(operatorAddr, delegated))
-		}
-
-		avsTree, err := merkletree.NewTree(
-			merkletree.WithData(stakerLeafs),
-			merkletree.WithHashType(keccak256.New()),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		operatorLeaves = append(operatorLeaves, encodeOperatorLeaf(op.Key, avsTree.Root()))
-	}
-
-	return merkletree.NewTree(
-		merkletree.WithData(operatorLeaves),
-		merkletree.WithHashType(keccak256.New()),
-	)
-}
-
-func encodeStakerLeaf(staker string, delegated bool) []byte {
-	return []byte(fmt.Sprintf("%s:%t", staker, delegated))
-}
-
-func encodeOperatorLeaf(operator string, operatorStakersRoot []byte) []byte {
-	return append([]byte(operator), operatorStakersRoot...)
+	slices.SortFunc(inputs, func(i, j *base.MerkleTreeInput) int {
+		return strings.Compare(string(i.SlotID), string(j.SlotID))
+	})
+	return inputs
 }
 
 func (s *StakerDelegationsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {

--- a/internal/eigenState/stakerDelegations/stakerDelegations_test.go
+++ b/internal/eigenState/stakerDelegations/stakerDelegations_test.go
@@ -37,8 +37,8 @@ func setup() (
 }
 
 func teardown(model *StakerDelegationsModel) {
-	model.Db.Exec("delete from staker_delegation_changes")
-	model.Db.Exec("delete from delegated_stakers")
+	model.DB.Exec("delete from staker_delegation_changes")
+	model.DB.Exec("delete from delegated_stakers")
 }
 
 func Test_DelegatedStakersState(t *testing.T) {
@@ -126,7 +126,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 		assert.Nil(t, err)
 
 		states := []DelegatedStakers{}
-		statesRes := model.Db.
+		statesRes := model.DB.
 			Model(&DelegatedStakers{}).
 			Raw("select * from delegated_stakers where block_number = @blockNumber", sql.Named("blockNumber", blockNumber)).
 			Scan(&states)
@@ -195,7 +195,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 			assert.Nil(t, err)
 
 			states := []DelegatedStakers{}
-			statesRes := model.Db.
+			statesRes := model.DB.
 				Model(&DelegatedStakers{}).
 				Raw("select * from delegated_stakers where block_number = @blockNumber", sql.Named("blockNumber", log.BlockNumber)).
 				Scan(&states)

--- a/internal/eigenState/stakerDelegations/stakerDelegations_test.go
+++ b/internal/eigenState/stakerDelegations/stakerDelegations_test.go
@@ -50,7 +50,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 
 	t.Run("Should create a new StakerDelegationsModel", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
-		model, err := NewStakerDelegationsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerDelegationsModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 		assert.NotNil(t, model)
 	})
@@ -71,7 +71,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewStakerDelegationsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerDelegationsModel(esm, grm, l, cfg)
 
 		assert.Equal(t, true, model.IsInterestingLog(&log))
 
@@ -106,7 +106,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewStakerDelegationsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerDelegationsModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
 		assert.Equal(t, true, model.IsInterestingLog(&log))
@@ -178,7 +178,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 			},
 		}
 
-		model, err := NewStakerDelegationsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerDelegationsModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
 		for _, log := range logs {

--- a/internal/eigenState/stakerShares/stakerShares_test.go
+++ b/internal/eigenState/stakerShares/stakerShares_test.go
@@ -47,7 +47,7 @@ func teardown(model *StakerSharesModel) {
 	}
 	for _, query := range queries {
 
-		model.Db.Raw(query)
+		model.DB.Raw(query)
 	}
 }
 
@@ -316,7 +316,7 @@ func Test_StakerSharesState(t *testing.T) {
 
 		query := `select * from staker_shares where block_number = ?`
 		results := []*StakerShares{}
-		res = model.Db.Raw(query, blockNumber).Scan(&results)
+		res = model.DB.Raw(query, blockNumber).Scan(&results)
 		assert.Nil(t, res.Error)
 		assert.Equal(t, 1, len(results))
 
@@ -384,7 +384,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
 		assert.Equal(t, "-246393621132195985", typedChange.Changes[0].Shares.String())
 
-		slotId := NewSlotId(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
+		slotId := NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
 
 		accumulatedState, ok := model.stateAccumulator[originBlockNumber][slotId]
 		assert.True(t, ok)
@@ -423,7 +423,7 @@ func Test_StakerSharesState(t *testing.T) {
 		// verify the M1 withdrawal was processed correctly
 		query := `select * from staker_shares where block_number = ?`
 		results := []*StakerShares{}
-		res = model.Db.Raw(query, originBlockNumber).Scan(&results)
+		res = model.DB.Raw(query, originBlockNumber).Scan(&results)
 
 		assert.Nil(t, res.Error)
 		assert.Equal(t, 1, len(results))
@@ -486,7 +486,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
 		assert.Equal(t, "246393621132195985", typedChange.Changes[0].Shares.String())
 
-		slotId = NewSlotId(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
+		slotId = NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
 
 		accumulatedState, ok = model.stateAccumulator[blockNumber][slotId]
 		assert.True(t, ok)
@@ -504,7 +504,7 @@ func Test_StakerSharesState(t *testing.T) {
 			where block_number = ?
 		`
 		results = []*StakerShares{}
-		res = model.Db.Raw(query, blockNumber).Scan(&results)
+		res = model.DB.Raw(query, blockNumber).Scan(&results)
 		assert.Nil(t, res.Error)
 
 		assert.Equal(t, 1, len(results))

--- a/internal/eigenState/stakerShares/stakerShares_test.go
+++ b/internal/eigenState/stakerShares/stakerShares_test.go
@@ -46,7 +46,6 @@ func teardown(model *StakerSharesModel) {
 		`delete from transaction_logs`,
 	}
 	for _, query := range queries {
-
 		model.DB.Raw(query)
 	}
 }
@@ -60,7 +59,7 @@ func Test_StakerSharesState(t *testing.T) {
 
 	t.Run("Should create a new OperatorSharesState", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
-		model, err := NewStakerSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 		assert.NotNil(t, model)
 	})
@@ -81,7 +80,7 @@ func Test_StakerSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewStakerSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 
 		err = model.InitBlockProcessing(blockNumber)
 		assert.Nil(t, err)
@@ -118,7 +117,7 @@ func Test_StakerSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewStakerSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 
 		err = model.InitBlockProcessing(blockNumber)
 		assert.Nil(t, err)
@@ -154,7 +153,7 @@ func Test_StakerSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewStakerSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 
 		err = model.InitBlockProcessing(blockNumber)
 		assert.Nil(t, err)
@@ -190,7 +189,7 @@ func Test_StakerSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewStakerSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 
 		err = model.InitBlockProcessing(blockNumber)
 		assert.Nil(t, err)
@@ -287,7 +286,7 @@ func Test_StakerSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		model, err := NewStakerSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 
 		err = model.InitBlockProcessing(blockNumber)
 		assert.Nil(t, err)
@@ -324,7 +323,7 @@ func Test_StakerSharesState(t *testing.T) {
 	})
 	t.Run("Should handle an M1 withdrawal and migration to M2 correctly", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
-		model, err := NewStakerSharesModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
 		originBlockNumber := uint64(101)

--- a/internal/eigenState/stateManager/stateManager.go
+++ b/internal/eigenState/stateManager/stateManager.go
@@ -26,14 +26,14 @@ type StateRoot struct {
 type EigenStateManager struct {
 	StateModels map[int]types.IEigenStateModel
 	logger      *zap.Logger
-	Db          *gorm.DB
+	DB          *gorm.DB
 }
 
 func NewEigenStateManager(logger *zap.Logger, grm *gorm.DB) *EigenStateManager {
 	return &EigenStateManager{
 		StateModels: make(map[int]types.IEigenStateModel),
 		logger:      logger,
-		Db:          grm,
+		DB:          grm,
 	}
 }
 
@@ -138,7 +138,7 @@ func (e *EigenStateManager) WriteStateRoot(
 		StateRoot:      string(stateroot),
 	}
 
-	result := e.Db.Model(&StateRoot{}).Clauses(clause.Returning{}).Create(&root)
+	result := e.DB.Model(&StateRoot{}).Clauses(clause.Returning{}).Create(&root)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -147,7 +147,7 @@ func (e *EigenStateManager) WriteStateRoot(
 
 func (e *EigenStateManager) GetStateRootForBlock(blockNumber uint64) (*StateRoot, error) {
 	root := &StateRoot{}
-	result := e.Db.Model(&StateRoot{}).Where("eth_block_number = ?", blockNumber).First(&root)
+	result := e.DB.Model(&StateRoot{}).Where("eth_block_number = ?", blockNumber).First(&root)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -173,10 +173,10 @@ func (e *EigenStateManager) GetSortedModelIndexes() []int {
 
 func (e *EigenStateManager) GetLatestStateRoot() (*StateRoot, error) {
 	root := &StateRoot{}
-	result := e.Db.Model(&StateRoot{}).Order("eth_block_number desc").First(&root)
+	result := e.DB.Model(&StateRoot{}).Order("eth_block_number desc").First(&root)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
+			return root, nil
 		}
 		return nil, result.Error
 	}

--- a/internal/eigenState/stateManager/stateManager_test.go
+++ b/internal/eigenState/stateManager/stateManager_test.go
@@ -38,7 +38,7 @@ func setup() (
 }
 
 func teardown(model *EigenStateManager) {
-	model.Db.Exec("delete from state_roots")
+	model.DB.Exec("delete from state_roots")
 }
 
 func Test_StateManager(t *testing.T) {

--- a/internal/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
+++ b/internal/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
@@ -41,7 +41,7 @@ func teardown(model *SubmittedDistributionRootsModel) {
 		`delete from submitted_distribution_roots`,
 	}
 	for _, query := range queries {
-		model.Db.Raw(query)
+		model.DB.Raw(query)
 	}
 }
 
@@ -99,7 +99,7 @@ func Test_SubmittedDistributionRoots(t *testing.T) {
 
 		query := `SELECT * FROM submitted_distribution_roots WHERE block_number = ?`
 		var roots []*SubmittedDistributionRoots
-		res := model.Db.Raw(query, blockNumber).Scan(&roots)
+		res := model.DB.Raw(query, blockNumber).Scan(&roots)
 
 		assert.Nil(t, res.Error)
 		assert.Equal(t, 1, len(roots))
@@ -152,7 +152,7 @@ func Test_SubmittedDistributionRoots(t *testing.T) {
 
 		query := `SELECT * FROM submitted_distribution_roots WHERE block_number = ?`
 		var roots []*SubmittedDistributionRoots
-		res := model.Db.Raw(query, blockNumber).Scan(&roots)
+		res := model.DB.Raw(query, blockNumber).Scan(&roots)
 
 		assert.Nil(t, res.Error)
 		assert.Equal(t, 2, len(roots))

--- a/internal/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
+++ b/internal/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
@@ -53,7 +53,7 @@ func Test_SubmittedDistributionRoots(t *testing.T) {
 	}
 
 	esm := stateManager.NewEigenStateManager(l, grm)
-	model, err := NewSubmittedDistributionRootsModel(esm, grm, cfg.Network, cfg.Environment, l, cfg)
+	model, err := NewSubmittedDistributionRootsModel(esm, grm, l, cfg)
 
 	insertedRoots := make([]*SubmittedDistributionRoots, 0)
 

--- a/internal/eigenState/types/types.go
+++ b/internal/eigenState/types/types.go
@@ -48,3 +48,5 @@ type IEigenStateModel interface {
 // StateTransitions
 // Map of block number to function that will transition the state to the next block.
 type StateTransitions[T interface{}] map[uint64]func(log *storage.TransactionLog) (*T, error)
+
+type SlotID string

--- a/internal/pipeline/pipeline_integration_test.go
+++ b/internal/pipeline/pipeline_integration_test.go
@@ -98,7 +98,7 @@ func setup() (
 
 	sm := stateManager.NewEigenStateManager(l, grm)
 
-	if _, err := avsOperators.NewAvsOperators(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := avsOperators.NewAvsOperators(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create AvsOperatorsModel", zap.Error(err))
 	}
 	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, l, cfg); err != nil {

--- a/internal/pipeline/pipeline_integration_test.go
+++ b/internal/pipeline/pipeline_integration_test.go
@@ -101,10 +101,10 @@ func setup() (
 	if _, err := avsOperators.NewAvsOperators(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create AvsOperatorsModel", zap.Error(err))
 	}
-	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := operatorShares.NewOperatorSharesModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create OperatorSharesModel", zap.Error(err))
 	}
-	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerDelegationsModel", zap.Error(err))
 	}
 	if _, err := stakerShares.NewStakerSharesModel(sm, grm, l, cfg); err != nil {

--- a/internal/pipeline/pipeline_integration_test.go
+++ b/internal/pipeline/pipeline_integration_test.go
@@ -113,7 +113,7 @@ func setup() (
 	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create SubmittedDistributionRootsModel", zap.Error(err))
 	}
-	if _, err := rewardSubmissions.NewRewardSubmissionsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := rewardSubmissions.NewRewardSubmissionsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create RewardSubmissionsModel", zap.Error(err))
 	}
 

--- a/internal/pipeline/pipeline_integration_test.go
+++ b/internal/pipeline/pipeline_integration_test.go
@@ -110,7 +110,7 @@ func setup() (
 	if _, err := stakerShares.NewStakerSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerSharesModel", zap.Error(err))
 	}
-	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create SubmittedDistributionRootsModel", zap.Error(err))
 	}
 	if _, err := rewardSubmissions.NewRewardSubmissionsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {

--- a/internal/pipeline/pipeline_integration_test.go
+++ b/internal/pipeline/pipeline_integration_test.go
@@ -107,7 +107,7 @@ func setup() (
 	if _, err := stakerDelegations.NewStakerDelegationsModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerDelegationsModel", zap.Error(err))
 	}
-	if _, err := stakerShares.NewStakerSharesModel(sm, grm, cfg.Network, cfg.Environment, l, cfg); err != nil {
+	if _, err := stakerShares.NewStakerSharesModel(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to create StakerSharesModel", zap.Error(err))
 	}
 	if _, err := submittedDistributionRoots.NewSubmittedDistributionRootsModel(sm, grm, l, cfg); err != nil {


### PR DESCRIPTION
Refactor the merkleization for each model to make them all consistent and DRY up the pattern.

Each tree is uniform in structure:

`SlotID -> <value>` where value is a byte array representing the state change, specified by each model.

This also allows us to properly sort the data before building a tree out of it to ensure consistency.

Also cleaned up some linter errors to start making a dent in tidying things up more.


Closes #31 