### PR TITLE
Use alpine to reduce container size from 3GB to 43MB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ sidecar.db*
 /sqlite
 /sqlite*
 go-sidecar
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@
 FROM golang:1.22-alpine AS build
 
 # Install needed dependencies to build
-RUN apk add --no-cache make
+RUN apk add --no-cache gcc musl-dev linux-headers make
 
 COPY . /build
 WORKDIR /build
 
-RUN make build
+RUN CGO_ENABLED=1 make build
 
 # Pull compiled binaries into a vanilla alpine base image
 FROM alpine:latest

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker run -it --rm \
   -e SIDECAR_SQLITE_DB_FILE_PATH="/sqlite/sidecar.db" \
   -v "$(pwd)/sqlite:/sqlite" \
   --tty -i \
-  public.ecr.aws/z6g0f8n7/go-sidecar:latest /build/bin/cmd/sidecar
+  public.ecr.aws/z6g0f8n7/go-sidecar:latest
 ```
 
 ### Build and run a container locally
@@ -56,7 +56,7 @@ docker run \
   -e "SIDECAR_SQLITE_DB_FILE_PATH=/sqlite/sidecar.db" \
   -v "$(pwd)/sqlite:/sqlite" \
   --tty -i \
-  go-sidecar:latest /build/bin/cmd/sidecar
+  go-sidecar:latest
 ```
 
 ## RPC Routes


### PR DESCRIPTION
Ubuntu/debian is really big, so by following [Ethereum's lead](https://github.com/ethereum/go-ethereum/blob/master/Dockerfile) and using alpine as our base, we reduce the total container size down to 43MB from 3GB.

Also sets the entrypoint to the sidecar binary to make running a better experience.