### PR TITLE
fix: simplify structs

### DIFF
--- a/internal/eigenState/avsOperators/avsOperators.go
+++ b/internal/eigenState/avsOperators/avsOperators.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Layr-Labs/go-sidecar/internal/eigenState/utils"
 	"github.com/Layr-Labs/go-sidecar/internal/storage"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )

--- a/internal/eigenState/avsOperators/avsOperators_test.go
+++ b/internal/eigenState/avsOperators/avsOperators_test.go
@@ -45,17 +45,17 @@ func teardown(model *eigenStateModel.EigenStateModel) {
 	model.DB().Exec("delete from avs_operator_state_changes")
 }
 
-func getInsertedDeltaRecordsForBlock(blockNumber uint64, model *eigenStateModel.EigenStateModel) ([]*AvsOperatorStateChange, error) {
-	results := []*AvsOperatorStateChange{}
+func getInsertedDeltaRecordsForBlock(blockNumber uint64, model *eigenStateModel.EigenStateModel) ([]*AvsOperatorRegistrationDelta, error) {
+	results := []*AvsOperatorRegistrationDelta{}
 
-	res := model.DB().Model(&AvsOperatorStateChange{}).Where("block_number = ?", blockNumber).Find(&results)
+	res := model.DB().Model(&AvsOperatorRegistrationDelta{}).Where("block_number = ?", blockNumber).Find(&results)
 	return results, res.Error
 }
 
-func getInsertedDeltaRecords(model *eigenStateModel.EigenStateModel) ([]*AvsOperatorStateChange, error) {
-	results := []*AvsOperatorStateChange{}
+func getInsertedDeltaRecords(model *eigenStateModel.EigenStateModel) ([]*AvsOperatorRegistrationDelta, error) {
+	results := []*AvsOperatorRegistrationDelta{}
 
-	res := model.DB().Model(&AvsOperatorStateChange{}).Order("block_number asc").Find(&results)
+	res := model.DB().Model(&AvsOperatorRegistrationDelta{}).Order("block_number asc").Find(&results)
 	return results, res.Error
 }
 
@@ -151,9 +151,9 @@ func Test_AvsOperatorState(t *testing.T) {
 		err = avsOperatorState.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
 
-		states := []RegisteredAvsOperators{}
+		states := []AvsOperatorRegistrationRecord{}
 		statesRes := avsOperatorState.DB().
-			Model(&RegisteredAvsOperators{}).
+			Model(&AvsOperatorRegistrationRecord{}).
 			Raw("select * from registered_avs_operators where block_number = @blockNumber", sql.Named("blockNumber", blockNumber)).
 			Scan(&states)
 
@@ -222,9 +222,9 @@ func Test_AvsOperatorState(t *testing.T) {
 			err = avsOperatorState.CommitFinalState(log.BlockNumber)
 			assert.Nil(t, err)
 
-			states := []RegisteredAvsOperators{}
+			states := []AvsOperatorRegistrationRecord{}
 			statesRes := avsOperatorState.DB().
-				Model(&RegisteredAvsOperators{}).
+				Model(&AvsOperatorRegistrationRecord{}).
 				Raw("select * from registered_avs_operators where block_number = @blockNumber", sql.Named("blockNumber", log.BlockNumber)).
 				Scan(&states)
 

--- a/internal/eigenState/operatorShares/operatorShares_test.go
+++ b/internal/eigenState/operatorShares/operatorShares_test.go
@@ -117,9 +117,9 @@ func Test_OperatorSharesState(t *testing.T) {
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
 
-		states := []OperatorShares{}
+		states := []OperatorSharesRecord{}
 		statesRes := model.DB().
-			Model(&OperatorShares{}).
+			Model(&OperatorSharesRecord{}).
 			Raw("select * from operator_shares where block_number = @blockNumber", sql.Named("blockNumber", blockNumber)).
 			Scan(&states)
 
@@ -163,7 +163,7 @@ func Test_OperatorSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, stateChange)
 
-		stateChangeTyped := stateChange.(*AccumulatedStateChange)
+		stateChangeTyped := stateChange.(*OperatorSharesState)
 
 		assert.Equal(t, "-1670000000000000000000", stateChangeTyped.Shares.String())
 		assert.Equal(t, strings.ToLower("0x32f766cf7BC7dEE7F65573587BECd7AdB2a5CC7f"), stateChangeTyped.Operator)

--- a/internal/eigenState/rewardSubmissions/rewardSubmissions_test.go
+++ b/internal/eigenState/rewardSubmissions/rewardSubmissions_test.go
@@ -122,10 +122,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				{"0xdccf401fd121d8c542e96bc1d0078884422afad2", "5000000000000000000"},
 			}
 
-			typedChange := change.(*RewardSubmissions)
-			assert.Equal(t, len(strategiesAndMultipliers), len(typedChange.Submissions))
+			submissions := change.([]*RewardSubmission)
+			assert.Equal(t, len(strategiesAndMultipliers), len(submissions))
 
-			for i, submission := range typedChange.Submissions {
+			for i, submission := range submissions {
 				assert.Equal(t, strings.ToLower("0x00526A07855f743964F05CccAeCcf7a9E34847fF"), strings.ToLower(submission.Avs))
 				assert.Equal(t, strings.ToLower("0x94373a4919b3240d86ea41593d5eba789fef3848"), strings.ToLower(submission.Token))
 				assert.Equal(t, strings.ToLower("0x58959fBe6661daEA647E20dF7c6d2c7F0d2215fB"), strings.ToLower(submission.RewardHash))
@@ -197,10 +197,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				{"0xd523267698c81a372191136e477fdebfa33d9fb4", "4500000000000000000"},
 			}
 
-			typedChange := change.(*RewardSubmissions)
-			assert.Equal(t, len(strategiesAndMultipliers), len(typedChange.Submissions))
+			submissions := change.([]*RewardSubmission)
+			assert.Equal(t, len(strategiesAndMultipliers), len(submissions))
 
-			for i, submission := range typedChange.Submissions {
+			for i, submission := range submissions {
 				assert.Equal(t, strings.ToLower("0x00526A07855f743964F05CccAeCcf7a9E34847fF"), strings.ToLower(submission.Avs))
 				assert.Equal(t, strings.ToLower("0x3f1c547b21f65e10480de3ad8e19faac46c95034"), strings.ToLower(submission.Token))
 				assert.Equal(t, strings.ToLower("0x69193C881C4BfA9015F1E9B2631e31238BedB93e"), strings.ToLower(submission.RewardHash))
@@ -246,10 +246,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				TransactionIndex: big.NewInt(100).Uint64(),
 				BlockNumber:      blockNumber,
 				Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
-				Arguments:        `[{"Name": "avs", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "rewardsSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
-				EventName:        "AVSRewardsSubmissionCreated",
+				Arguments:        `[{"Name": "avs", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "RewardSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "RewardSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
+				EventName:        "AVSRewardSubmissionCreated",
 				LogIndex:         big.NewInt(12).Uint64(),
-				OutputData:       `{"rewardsSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "amount": 10000000000000000000000, "duration": 2419200, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}]}}`,
+				OutputData:       `{"RewardSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "amount": 10000000000000000000000, "duration": 2419200, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}]}}`,
 			}
 
 			err = model.InitBlock(blockNumber)
@@ -269,10 +269,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				{"0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "1000000000000000000"},
 			}
 
-			typedChange := change.(*RewardSubmissions)
-			assert.Equal(t, len(strategiesAndMultipliers), len(typedChange.Submissions))
+			submissions := change.([]*RewardSubmission)
+			assert.Equal(t, len(strategiesAndMultipliers), len(submissions))
 
-			for i, submission := range typedChange.Submissions {
+			for i, submission := range submissions {
 				assert.Equal(t, strings.ToLower("0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101"), strings.ToLower(submission.Avs))
 				assert.Equal(t, strings.ToLower("0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24"), strings.ToLower(submission.Token))
 				assert.Equal(t, strings.ToLower("0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9"), strings.ToLower(submission.RewardHash))
@@ -318,10 +318,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				TransactionIndex: big.NewInt(100).Uint64(),
 				BlockNumber:      blockNumber,
 				Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
-				Arguments:        `[{"Name": "submitter", "Type": "address", "Value": "0x66ae7d7c4d492e4e012b95977f14715b74498bc5", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 3, "Indexed": true}, {"Name": "rewardsSubmissionHash", "Type": "bytes32", "Value": "0x99ebccb0f68eedbf3dff04c7773d6ff94fc439e0eebdd80918b3785ae8099f96", "Indexed": true}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
-				EventName:        "RewardsSubmissionForAllCreated",
+				Arguments:        `[{"Name": "submitter", "Type": "address", "Value": "0x66ae7d7c4d492e4e012b95977f14715b74498bc5", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 3, "Indexed": true}, {"Name": "RewardSubmissionHash", "Type": "bytes32", "Value": "0x99ebccb0f68eedbf3dff04c7773d6ff94fc439e0eebdd80918b3785ae8099f96", "Indexed": true}, {"Name": "RewardSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
+				EventName:        "RewardSubmissionForAllCreated",
 				LogIndex:         big.NewInt(12).Uint64(),
-				OutputData:       `{"rewardsSubmission": {"token": "0x554c393923c753d146aa34608523ad7946b61662", "amount": 10000000000000000000, "duration": 1814400, "startTimestamp": 1717632000, "strategiesAndMultipliers": [{"strategy": "0xd523267698c81a372191136e477fdebfa33d9fb4", "multiplier": 1000000000000000000}, {"strategy": "0xdccf401fd121d8c542e96bc1d0078884422afad2", "multiplier": 2000000000000000000}]}}`,
+				OutputData:       `{"RewardSubmission": {"token": "0x554c393923c753d146aa34608523ad7946b61662", "amount": 10000000000000000000, "duration": 1814400, "startTimestamp": 1717632000, "strategiesAndMultipliers": [{"strategy": "0xd523267698c81a372191136e477fdebfa33d9fb4", "multiplier": 1000000000000000000}, {"strategy": "0xdccf401fd121d8c542e96bc1d0078884422afad2", "multiplier": 2000000000000000000}]}}`,
 			}
 
 			err = model.InitBlock(blockNumber)
@@ -342,10 +342,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				{"0xdccf401fd121d8c542e96bc1d0078884422afad2", "2000000000000000000"},
 			}
 
-			typedChange := change.(*RewardSubmissions)
-			assert.Equal(t, len(strategiesAndMultipliers), len(typedChange.Submissions))
+			submissions := change.([]*RewardSubmission)
+			assert.Equal(t, len(strategiesAndMultipliers), len(submissions))
 
-			for i, submission := range typedChange.Submissions {
+			for i, submission := range submissions {
 				assert.Equal(t, strings.ToLower("0x66ae7d7c4d492e4e012b95977f14715b74498bc5"), strings.ToLower(submission.Avs))
 				assert.Equal(t, strings.ToLower("0x554c393923c753d146aa34608523ad7946b61662"), strings.ToLower(submission.Token))
 				assert.Equal(t, strings.ToLower("0x99ebccb0f68eedbf3dff04c7773d6ff94fc439e0eebdd80918b3785ae8099f96"), strings.ToLower(submission.RewardHash))
@@ -391,10 +391,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				TransactionIndex: big.NewInt(100).Uint64(),
 				BlockNumber:      blockNumber,
 				Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
-				Arguments:        `[{"Name": "tokenHopper", "Type": "address", "Value": "0x8daae33cb2da8da23595adb19f271ef41e34bd8c", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "rewardsSubmissionHash", "Type": "bytes32", "Value": "0xeb2a1f63fd3274fa701ad2045c04b4f1274c6d7b5ff8a83d75d87e812b589c9c", "Indexed": true}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
-				EventName:        "RewardsSubmissionForAllEarnersCreated",
+				Arguments:        `[{"Name": "tokenHopper", "Type": "address", "Value": "0x8daae33cb2da8da23595adb19f271ef41e34bd8c", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "RewardSubmissionHash", "Type": "bytes32", "Value": "0xeb2a1f63fd3274fa701ad2045c04b4f1274c6d7b5ff8a83d75d87e812b589c9c", "Indexed": true}, {"Name": "RewardSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
+				EventName:        "RewardSubmissionForAllEarnersCreated",
 				LogIndex:         big.NewInt(12).Uint64(),
-				OutputData:       `{"rewardsSubmission": {"token": "0x3b78576f7d6837500ba3de27a60c7f594934027e", "amount": 321855128516280769230770, "duration": 604800, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x43252609bff8a13dfe5e057097f2f45a24387a84", "multiplier": 1000000000000000000}]}}`,
+				OutputData:       `{"RewardSubmission": {"token": "0x3b78576f7d6837500ba3de27a60c7f594934027e", "amount": 321855128516280769230770, "duration": 604800, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x43252609bff8a13dfe5e057097f2f45a24387a84", "multiplier": 1000000000000000000}]}}`,
 			}
 
 			err = model.InitBlock(blockNumber)
@@ -414,10 +414,10 @@ func Test_RewardSubmissions(t *testing.T) {
 				{"0x43252609bff8a13dfe5e057097f2f45a24387a84", "1000000000000000000"},
 			}
 
-			typedChange := change.(*RewardSubmissions)
-			assert.Equal(t, len(strategiesAndMultipliers), len(typedChange.Submissions))
+			submissions := change.([]*RewardSubmission)
+			assert.Equal(t, len(strategiesAndMultipliers), len(submissions))
 
-			for i, submission := range typedChange.Submissions {
+			for i, submission := range submissions {
 				assert.Equal(t, strings.ToLower("0x8daae33cb2da8da23595adb19f271ef41e34bd8c"), strings.ToLower(submission.Avs))
 				assert.Equal(t, strings.ToLower("0x3b78576f7d6837500ba3de27a60c7f594934027e"), strings.ToLower(submission.Token))
 				assert.Equal(t, strings.ToLower("0xeb2a1f63fd3274fa701ad2045c04b4f1274c6d7b5ff8a83d75d87e812b589c9c"), strings.ToLower(submission.RewardHash))
@@ -491,12 +491,12 @@ func Test_RewardSubmissions(t *testing.T) {
 		change, err := model.HandleStateChange(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
-		typedChange := change.(*RewardSubmissions)
+		submissions := change.([]*RewardSubmission)
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
 
-		submissionCounter += len(typedChange.Submissions)
+		submissionCounter += len(submissions)
 
 		query := `select count(*) from reward_submissions where block_number = ?`
 		var count int
@@ -539,12 +539,12 @@ func Test_RewardSubmissions(t *testing.T) {
 		change, err = model.HandleStateChange(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
-		typedChange = change.(*RewardSubmissions)
+		submissions = change.([]*RewardSubmission)
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
 
-		submissionCounter += len(typedChange.Submissions)
+		submissionCounter += len(submissions)
 
 		stateRoot, err = model.GenerateStateRoot(blockNumber)
 		assert.Nil(t, err)
@@ -570,10 +570,10 @@ func Test_RewardSubmissions(t *testing.T) {
 			TransactionIndex: big.NewInt(100).Uint64(),
 			BlockNumber:      blockNumber,
 			Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
-			Arguments:        `[{"Name": "avs", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "rewardsSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
-			EventName:        "AVSRewardsSubmissionCreated",
+			Arguments:        `[{"Name": "avs", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "RewardSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "RewardSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
+			EventName:        "AVSRewardSubmissionCreated",
 			LogIndex:         big.NewInt(12).Uint64(),
-			OutputData:       `{"rewardsSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "amount": 10000000000000000000000, "duration": 2419200, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}]}}`,
+			OutputData:       `{"RewardSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "amount": 10000000000000000000000, "duration": 2419200, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}]}}`,
 		}
 
 		err = model.InitBlock(blockNumber)
@@ -585,12 +585,12 @@ func Test_RewardSubmissions(t *testing.T) {
 		change, err = model.HandleStateChange(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
-		typedChange = change.(*RewardSubmissions)
+		submissions = change.([]*RewardSubmission)
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
 
-		submissionCounter += len(typedChange.Submissions)
+		submissionCounter += len(submissions)
 
 		stateRoot, err = model.GenerateStateRoot(blockNumber)
 		assert.Nil(t, err)
@@ -616,10 +616,10 @@ func Test_RewardSubmissions(t *testing.T) {
 			TransactionIndex: big.NewInt(100).Uint64(),
 			BlockNumber:      blockNumber,
 			Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
-			Arguments:        `[{"Name": "submitter", "Type": "address", "Value": "0x66ae7d7c4d492e4e012b95977f14715b74498bc5", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 3, "Indexed": true}, {"Name": "rewardsSubmissionHash", "Type": "bytes32", "Value": "0x99ebccb0f68eedbf3dff04c7773d6ff94fc439e0eebdd80918b3785ae8099f96", "Indexed": true}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
-			EventName:        "RewardsSubmissionForAllCreated",
+			Arguments:        `[{"Name": "submitter", "Type": "address", "Value": "0x66ae7d7c4d492e4e012b95977f14715b74498bc5", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 3, "Indexed": true}, {"Name": "RewardSubmissionHash", "Type": "bytes32", "Value": "0x99ebccb0f68eedbf3dff04c7773d6ff94fc439e0eebdd80918b3785ae8099f96", "Indexed": true}, {"Name": "RewardSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
+			EventName:        "RewardSubmissionForAllCreated",
 			LogIndex:         big.NewInt(12).Uint64(),
-			OutputData:       `{"rewardsSubmission": {"token": "0x554c393923c753d146aa34608523ad7946b61662", "amount": 10000000000000000000, "duration": 1814400, "startTimestamp": 1717632000, "strategiesAndMultipliers": [{"strategy": "0xd523267698c81a372191136e477fdebfa33d9fb4", "multiplier": 1000000000000000000}, {"strategy": "0xdccf401fd121d8c542e96bc1d0078884422afad2", "multiplier": 2000000000000000000}]}}`,
+			OutputData:       `{"RewardSubmission": {"token": "0x554c393923c753d146aa34608523ad7946b61662", "amount": 10000000000000000000, "duration": 1814400, "startTimestamp": 1717632000, "strategiesAndMultipliers": [{"strategy": "0xd523267698c81a372191136e477fdebfa33d9fb4", "multiplier": 1000000000000000000}, {"strategy": "0xdccf401fd121d8c542e96bc1d0078884422afad2", "multiplier": 2000000000000000000}]}}`,
 		}
 
 		err = model.InitBlock(blockNumber)
@@ -631,12 +631,12 @@ func Test_RewardSubmissions(t *testing.T) {
 		change, err = model.HandleStateChange(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
-		typedChange = change.(*RewardSubmissions)
+		submissions = change.([]*RewardSubmission)
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
 
-		submissionCounter += len(typedChange.Submissions)
+		submissionCounter += len(submissions)
 
 		stateRoot, err = model.GenerateStateRoot(blockNumber)
 		assert.Nil(t, err)
@@ -678,9 +678,9 @@ func Test_RewardSubmissions(t *testing.T) {
 			change, err := model.HandleStateChange(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, change)
-			typedChange := change.(*RewardSubmissions)
+			submissions := change.([]*RewardSubmission)
 
-			submissionCounter += len(typedChange.Submissions)
+			submissionCounter += len(submissions)
 		}
 
 		// First RangePaymentCreated
@@ -713,10 +713,10 @@ func Test_RewardSubmissions(t *testing.T) {
 			TransactionIndex: big.NewInt(100).Uint64(),
 			BlockNumber:      blockNumber,
 			Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
-			Arguments:        `[{"Name": "avs", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "rewardsSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
-			EventName:        "AVSRewardsSubmissionCreated",
+			Arguments:        `[{"Name": "avs", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "RewardSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "RewardSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
+			EventName:        "AVSRewardSubmissionCreated",
 			LogIndex:         big.NewInt(12).Uint64(),
-			OutputData:       `{"rewardsSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "amount": 10000000000000000000000, "duration": 2419200, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}]}}`,
+			OutputData:       `{"RewardSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "amount": 10000000000000000000000, "duration": 2419200, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}]}}`,
 		}
 		handleLog(rewardSubmissionCreatedLog)
 
@@ -725,10 +725,10 @@ func Test_RewardSubmissions(t *testing.T) {
 			TransactionIndex: big.NewInt(100).Uint64(),
 			BlockNumber:      blockNumber,
 			Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
-			Arguments:        `[{"Name": "submitter", "Type": "address", "Value": "0x002b273d4459b5636f971cc7be6443e95517d394", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "rewardsSubmissionHash", "Type": "bytes32", "Value": "0xcb5e9dfd219cc5500e88a349d8f072b77241475b3266a0f2c6cf29b1e09d3211", "Indexed": true}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
-			EventName:        "RewardsSubmissionForAllCreated",
+			Arguments:        `[{"Name": "submitter", "Type": "address", "Value": "0x002b273d4459b5636f971cc7be6443e95517d394", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": true}, {"Name": "RewardSubmissionHash", "Type": "bytes32", "Value": "0xcb5e9dfd219cc5500e88a349d8f072b77241475b3266a0f2c6cf29b1e09d3211", "Indexed": true}, {"Name": "RewardSubmission", "Type": "((address,uint96)[],address,uint256,uint32,uint32)", "Value": null, "Indexed": false}]`,
+			EventName:        "RewardSubmissionForAllCreated",
 			LogIndex:         big.NewInt(12).Uint64(),
-			OutputData:       `{"rewardsSubmission": {"token": "0xdeeeee2b48c121e6728ed95c860e296177849932", "amount": 1000000000000000000000000000, "duration": 5443200, "startTimestamp": 1717027200, "strategiesAndMultipliers": [{"strategy": "0x05037a81bd7b4c9e0f7b430f1f2a22c31a2fd943", "multiplier": 1000000000000000000}, {"strategy": "0x31b6f59e1627cefc9fa174ad03859fc337666af7", "multiplier": 1000000000000000000}, {"strategy": "0x3a8fbdf9e77dfc25d09741f51d3e181b25d0c4e0", "multiplier": 1000000000000000000}, {"strategy": "0x46281e3b7fdcacdba44cadf069a94a588fd4c6ef", "multiplier": 1000000000000000000}, {"strategy": "0x70eb4d3c164a6b4a5f908d4fbb5a9caffb66bab6", "multiplier": 1000000000000000000}, {"strategy": "0x7673a47463f80c6a3553db9e54c8cdcd5313d0ac", "multiplier": 1000000000000000000}, {"strategy": "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", "multiplier": 1000000000000000000}, {"strategy": "0x80528d6e9a2babfc766965e0e26d5ab08d9cfaf9", "multiplier": 1000000000000000000}, {"strategy": "0x9281ff96637710cd9a5cacce9c6fad8c9f54631c", "multiplier": 1000000000000000000}, {"strategy": "0xaccc5a86732be85b5012e8614af237801636f8e5", "multiplier": 1000000000000000000}, {"strategy": "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", "multiplier": 1000000000000000000}]}}`,
+			OutputData:       `{"RewardSubmission": {"token": "0xdeeeee2b48c121e6728ed95c860e296177849932", "amount": 1000000000000000000000000000, "duration": 5443200, "startTimestamp": 1717027200, "strategiesAndMultipliers": [{"strategy": "0x05037a81bd7b4c9e0f7b430f1f2a22c31a2fd943", "multiplier": 1000000000000000000}, {"strategy": "0x31b6f59e1627cefc9fa174ad03859fc337666af7", "multiplier": 1000000000000000000}, {"strategy": "0x3a8fbdf9e77dfc25d09741f51d3e181b25d0c4e0", "multiplier": 1000000000000000000}, {"strategy": "0x46281e3b7fdcacdba44cadf069a94a588fd4c6ef", "multiplier": 1000000000000000000}, {"strategy": "0x70eb4d3c164a6b4a5f908d4fbb5a9caffb66bab6", "multiplier": 1000000000000000000}, {"strategy": "0x7673a47463f80c6a3553db9e54c8cdcd5313d0ac", "multiplier": 1000000000000000000}, {"strategy": "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", "multiplier": 1000000000000000000}, {"strategy": "0x80528d6e9a2babfc766965e0e26d5ab08d9cfaf9", "multiplier": 1000000000000000000}, {"strategy": "0x9281ff96637710cd9a5cacce9c6fad8c9f54631c", "multiplier": 1000000000000000000}, {"strategy": "0xaccc5a86732be85b5012e8614af237801636f8e5", "multiplier": 1000000000000000000}, {"strategy": "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", "multiplier": 1000000000000000000}]}}`,
 		}
 		handleLog(rewardsForAllLog)
 

--- a/internal/eigenState/stakerDelegations/stakerDelegations_test.go
+++ b/internal/eigenState/stakerDelegations/stakerDelegations_test.go
@@ -87,7 +87,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, res)
 
-		typedChange := res.(*AccumulatedStateChange)
+		typedChange := res.(*StakerDelegationDelta)
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", typedChange.Staker)
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", typedChange.Operator)
 
@@ -123,16 +123,16 @@ func Test_DelegatedStakersState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, stateChange)
 
-		typedChange := stateChange.(*AccumulatedStateChange)
+		typedChange := stateChange.(*StakerDelegationDelta)
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", typedChange.Staker)
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", typedChange.Operator)
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
 
-		states := []DelegatedStakers{}
+		states := []StakerDelegationRecord{}
 		statesRes := model.DB().
-			Model(&DelegatedStakers{}).
+			Model(&StakerDelegationRecord{}).
 			Raw("select * from delegated_stakers where block_number = @blockNumber", sql.Named("blockNumber", blockNumber)).
 			Scan(&states)
 
@@ -199,9 +199,9 @@ func Test_DelegatedStakersState(t *testing.T) {
 			err = model.CommitFinalState(log.BlockNumber)
 			assert.Nil(t, err)
 
-			states := []DelegatedStakers{}
+			states := []StakerDelegationRecord{}
 			statesRes := model.DB().
-				Model(&DelegatedStakers{}).
+				Model(&StakerDelegationRecord{}).
 				Raw("select * from delegated_stakers where block_number = @blockNumber", sql.Named("blockNumber", log.BlockNumber)).
 				Scan(&states)
 

--- a/internal/eigenState/stakerShares/stakerShares_test.go
+++ b/internal/eigenState/stakerShares/stakerShares_test.go
@@ -93,14 +93,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
+		deltas := change.([]*StakerSharesDelta)
 
-		assert.Equal(t, 1, len(typedChange.Changes))
+		assert.Equal(t, 1, len(deltas))
 
 		expectedShares, _ := numbers.NewBig257().SetString("159925690037480381", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", typedChange.Changes[0].Strategy)
+		assert.Equal(t, expectedShares, deltas[0].Shares)
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", deltas[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", deltas[0].Strategy)
 
 		teardown(model)
 	})
@@ -131,13 +131,13 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
+		deltas := change.([]*StakerSharesDelta)
+		assert.Equal(t, 1, len(deltas))
 
 		expectedShares, _ := numbers.NewBig257().SetString("-246393621132195985", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
+		assert.Equal(t, expectedShares, deltas[0].Shares)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", deltas[0].Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", deltas[0].Strategy)
 
 		teardown(model)
 	})
@@ -168,13 +168,13 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
+		deltas := change.([]*StakerSharesDelta)
+		assert.Equal(t, 1, len(deltas))
 
 		expectedShares, _ := numbers.NewBig257().SetString("32000000000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x0808D4689B347D499a96f139A5fC5B5101258406"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", typedChange.Changes[0].Strategy)
+		assert.Equal(t, expectedShares, deltas[0].Shares)
+		assert.Equal(t, strings.ToLower("0x0808D4689B347D499a96f139A5fC5B5101258406"), deltas[0].Staker)
+		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", deltas[0].Strategy)
 
 		teardown(model)
 	})
@@ -205,13 +205,13 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
+		deltas := change.([]*StakerSharesDelta)
+		assert.Equal(t, 1, len(deltas))
 
 		expectedShares, _ := numbers.NewBig257().SetString("-1000000000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", typedChange.Changes[0].Strategy)
+		assert.Equal(t, expectedShares, deltas[0].Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), deltas[0].Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", deltas[0].Strategy)
 
 		teardown(model)
 	})
@@ -303,11 +303,11 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "246393621132195985", typedChange.Changes[0].Shares.String())
+		deltas := change.([]*StakerSharesDelta)
+		assert.Equal(t, 1, len(deltas))
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", deltas[0].Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", deltas[0].Strategy)
+		assert.Equal(t, "246393621132195985", deltas[0].Shares.String())
 
 		preparedChange, err := model.Base().(*StakerSharesBaseModel).prepareState(blockNumber)
 		assert.Nil(t, err)
@@ -319,7 +319,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		query := `select * from staker_shares where block_number = ?`
-		results := []*StakerShares{}
+		results := []*StakerSharesRecord{}
 		res = model.DB().Raw(query, blockNumber).Scan(&results)
 		assert.Nil(t, res.Error)
 		assert.Equal(t, 1, len(results))
@@ -381,21 +381,22 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
+		deltas := change.([]*StakerSharesDelta)
 
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "-246393621132195985", typedChange.Changes[0].Shares.String())
+		assert.Equal(t, 1, len(deltas))
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", deltas[0].Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", deltas[0].Strategy)
+		assert.Equal(t, "-246393621132195985", deltas[0].Shares.String())
 
-		slotId := NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
+		// slotId := NewSlotID(deltas[0].Staker, deltas[0].Strategy)
 
-		accumulatedState, ok := model.Base().(*StakerSharesBaseModel).stateAccumulator[originBlockNumber][slotId]
-		assert.True(t, ok)
-		assert.NotNil(t, accumulatedState)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
-		assert.Equal(t, "-246393621132195985", accumulatedState.Shares.String())
+		// TODO: how do i get tests running?
+		// accumulatedState, ok := model.Base().(*StakerSharesBaseModel).stateAccumulator[originBlockNumber][slotId]
+		// assert.True(t, ok)
+		// assert.NotNil(t, accumulatedState)
+		// assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
+		// assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
+		// assert.Equal(t, "-246393621132195985", accumulatedState.Shares.String())
 
 		// Insert the other half of the M1 event that captures the withdrawalRoot associated with the M1 withdrawal
 		// No need to process this event, we just need it to be present in the DB
@@ -426,7 +427,7 @@ func Test_StakerSharesState(t *testing.T) {
 
 		// verify the M1 withdrawal was processed correctly
 		query := `select * from staker_shares where block_number = ?`
-		results := []*StakerShares{}
+		results := []*StakerSharesRecord{}
 		res = model.DB().Raw(query, originBlockNumber).Scan(&results)
 
 		assert.Nil(t, res.Error)
@@ -459,11 +460,11 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange = change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "-246393621132195985", typedChange.Changes[0].Shares.String())
+		deltas = change.([]*StakerSharesDelta)
+		assert.Equal(t, 1, len(deltas))
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", deltas[0].Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", deltas[0].Strategy)
+		assert.Equal(t, "-246393621132195985", deltas[0].Shares.String())
 
 		// M2 WithdrawalMigrated event. Typically occurs in the same block as the M2 WithdrawalQueued event
 		withdrawalMigratedLog := storage.TransactionLog{
@@ -484,20 +485,21 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange = change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "246393621132195985", typedChange.Changes[0].Shares.String())
+		deltas = change.([]*StakerSharesDelta)
+		assert.Equal(t, 1, len(deltas))
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", deltas[0].Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", deltas[0].Strategy)
+		assert.Equal(t, "246393621132195985", deltas[0].Shares.String())
 
-		slotId = NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
+		// slotId = NewSlotID(deltas[0].Staker, deltas[0].Strategy)
 
-		accumulatedState, ok = model.Base().(*StakerSharesBaseModel).stateAccumulator[blockNumber][slotId]
-		assert.True(t, ok)
-		assert.NotNil(t, accumulatedState)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
-		assert.Equal(t, "0", accumulatedState.Shares.String())
+		// TODO: how do i get tests running?
+		// accumulatedState, ok = model.Base().(*StakerSharesBaseModel).stateAccumulator[blockNumber][slotId]
+		// assert.True(t, ok)
+		// assert.NotNil(t, accumulatedState)
+		// assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
+		// assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
+		// assert.Equal(t, "0", accumulatedState.Shares.String())
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
@@ -507,7 +509,7 @@ func Test_StakerSharesState(t *testing.T) {
 			select * from staker_shares
 			where block_number = ?
 		`
-		results = []*StakerShares{}
+		results = []*StakerSharesRecord{}
 		res = model.DB().Raw(query, blockNumber).Scan(&results)
 		assert.Nil(t, res.Error)
 

--- a/internal/pipeline/pipeline_integration_test.go
+++ b/internal/pipeline/pipeline_integration_test.go
@@ -132,7 +132,7 @@ func Test_Pipeline_Integration(t *testing.T) {
 		assert.Nil(t, err)
 
 		query := `select * from delegated_stakers where block_number = @blockNumber`
-		delegatedStakers := make([]stakerDelegations.DelegatedStakers, 0)
+		delegatedStakers := make([]stakerDelegations.StakerDelegationRecord, 0)
 		res := grm.Raw(query, sql.Named("blockNumber", blockNumber)).Scan(&delegatedStakers)
 		assert.Nil(t, res.Error)
 


### PR DESCRIPTION
we replace state and delta accumulators in favor of having only one per model and calculating end records upon `prepareState`. 

we change stateTransitions to return a type, not a pointer to it and simplify some internal structs, sacrificing the small preformance benefit of passing a pointer to a slice rather than the slice itself

TODO: How do i get test running to alter a couple small commented out tests? @seanmcgary im getting
```
# github.com/Layr-Labs/go-sidecar/internal/types/numbers
sidecar/internal/types/numbers/tokenCalculations.go:10:10: fatal error: 'calculations.h' file not found
   10 | #include "calculations.h"
      |          ^~~~~~~~~~~~~~~~
1 error generated.
FAIL	github.com/Layr-Labs/go-sidecar/internal/eigenState/stakerShares [build failed]
```