### PR TITLE
feat: move HandleStateChange to base

### DIFF
--- a/internal/eigenState/avsOperators/avsOperators_test.go
+++ b/internal/eigenState/avsOperators/avsOperators_test.go
@@ -96,7 +96,7 @@ func Test_AvsOperatorState(t *testing.T) {
 		err = avsOperatorState.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		res, err := avsOperatorState.HandleStateChange(&log)
+		res, err := avsOperatorState.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, res)
 
@@ -143,7 +143,7 @@ func Test_AvsOperatorState(t *testing.T) {
 		err = avsOperatorState.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		stateChange, err := avsOperatorState.HandleStateChange(&log)
+		stateChange, err := avsOperatorState.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, stateChange)
 
@@ -214,7 +214,7 @@ func Test_AvsOperatorState(t *testing.T) {
 			err = avsOperatorState.SetupStateForBlock(log.BlockNumber)
 			assert.Nil(t, err)
 
-			stateChange, err := avsOperatorState.HandleStateChange(log)
+			stateChange, err := avsOperatorState.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, stateChange)
 

--- a/internal/eigenState/operatorShares/operatorShares_test.go
+++ b/internal/eigenState/operatorShares/operatorShares_test.go
@@ -80,7 +80,7 @@ func Test_OperatorSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&log)
+		change, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -109,7 +109,7 @@ func Test_OperatorSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		stateChange, err := model.HandleStateChange(&log)
+		stateChange, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, stateChange)
 
@@ -158,7 +158,7 @@ func Test_OperatorSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		stateChange, err := model.HandleStateChange(&log)
+		stateChange, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, stateChange)
 

--- a/internal/eigenState/rewardSubmissions/rewardSubmissions_test.go
+++ b/internal/eigenState/rewardSubmissions/rewardSubmissions_test.go
@@ -104,7 +104,7 @@ func Test_RewardSubmissions(t *testing.T) {
 			isInteresting := model.IsInterestingLog(log)
 			assert.True(t, isInteresting)
 
-			change, err := model.HandleStateChange(log)
+			change, err := model.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, change)
 
@@ -182,7 +182,7 @@ func Test_RewardSubmissions(t *testing.T) {
 			isInteresting := model.IsInterestingLog(log)
 			assert.True(t, isInteresting)
 
-			change, err := model.HandleStateChange(log)
+			change, err := model.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, change)
 
@@ -257,7 +257,7 @@ func Test_RewardSubmissions(t *testing.T) {
 			isInteresting := model.IsInterestingLog(log)
 			assert.True(t, isInteresting)
 
-			change, err := model.HandleStateChange(log)
+			change, err := model.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, change)
 
@@ -329,7 +329,7 @@ func Test_RewardSubmissions(t *testing.T) {
 			isInteresting := model.IsInterestingLog(log)
 			assert.True(t, isInteresting)
 
-			change, err := model.HandleStateChange(log)
+			change, err := model.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, change)
 
@@ -402,7 +402,7 @@ func Test_RewardSubmissions(t *testing.T) {
 			isInteresting := model.IsInterestingLog(log)
 			assert.True(t, isInteresting)
 
-			change, err := model.HandleStateChange(log)
+			change, err := model.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, change)
 
@@ -487,7 +487,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		isInteresting := model.IsInterestingLog(log)
 		assert.True(t, isInteresting)
 
-		change, err := model.HandleStateChange(log)
+		change, err := model.HandleLog(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 		typedChange := change.(*RewardSubmissions)
@@ -535,7 +535,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		isInteresting = model.IsInterestingLog(log)
 		assert.True(t, isInteresting)
 
-		change, err = model.HandleStateChange(log)
+		change, err = model.HandleLog(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 		typedChange = change.(*RewardSubmissions)
@@ -581,7 +581,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		isInteresting = model.IsInterestingLog(log)
 		assert.True(t, isInteresting)
 
-		change, err = model.HandleStateChange(log)
+		change, err = model.HandleLog(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 		typedChange = change.(*RewardSubmissions)
@@ -627,7 +627,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		isInteresting = model.IsInterestingLog(log)
 		assert.True(t, isInteresting)
 
-		change, err = model.HandleStateChange(log)
+		change, err = model.HandleLog(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 		typedChange = change.(*RewardSubmissions)
@@ -674,7 +674,7 @@ func Test_RewardSubmissions(t *testing.T) {
 			isInteresting := model.IsInterestingLog(log)
 			assert.True(t, isInteresting)
 
-			change, err := model.HandleStateChange(log)
+			change, err := model.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, change)
 			typedChange := change.(*RewardSubmissions)

--- a/internal/eigenState/stakerDelegations/stakerDelegations_test.go
+++ b/internal/eigenState/stakerDelegations/stakerDelegations_test.go
@@ -82,7 +82,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		res, err := model.HandleStateChange(&log)
+		res, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, res)
 
@@ -118,7 +118,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		stateChange, err := model.HandleStateChange(&log)
+		stateChange, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, stateChange)
 
@@ -191,7 +191,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 			err = model.SetupStateForBlock(log.BlockNumber)
 			assert.Nil(t, err)
 
-			stateChange, err := model.HandleStateChange(log)
+			stateChange, err := model.HandleLog(log)
 			assert.Nil(t, err)
 			assert.NotNil(t, stateChange)
 

--- a/internal/eigenState/stakerShares/stakerShares.go
+++ b/internal/eigenState/stakerShares/stakerShares.go
@@ -357,7 +357,7 @@ func (ss *StakerSharesModel) GetStateTransitions() ([]uint64, types.StateTransit
 	stateChanges := make(types.StateTransitions)
 
 	stateChanges[0] = func(log *storage.TransactionLog) (interface{}, error) {
-		var parsedRecords []*AccumulatedStateChange
+		parsedRecords := make([]*AccumulatedStateChange, 0)
 		var err error
 
 		contractAddresses := ss.globalConfig.GetContractsMapForChain()
@@ -397,9 +397,6 @@ func (ss *StakerSharesModel) GetStateTransitions() ([]uint64, types.StateTransit
 		}
 		if err != nil {
 			return nil, err
-		}
-		if parsedRecords == nil {
-			return nil, nil
 		}
 
 		// Sanity check to make sure we've got an initialized accumulator map for the block

--- a/internal/eigenState/stakerShares/stakerShares_test.go
+++ b/internal/eigenState/stakerShares/stakerShares_test.go
@@ -88,7 +88,7 @@ func Test_StakerSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&log)
+		change, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -126,7 +126,7 @@ func Test_StakerSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&log)
+		change, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -163,7 +163,7 @@ func Test_StakerSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&log)
+		change, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -200,7 +200,7 @@ func Test_StakerSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&log)
+		change, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -298,7 +298,7 @@ func Test_StakerSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&log)
+		change, err := model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -376,7 +376,7 @@ func Test_StakerSharesState(t *testing.T) {
 		err = model.SetupStateForBlock(originBlockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&shareWithdrawalQueued)
+		change, err := model.HandleLog(&shareWithdrawalQueued)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -416,7 +416,7 @@ func Test_StakerSharesState(t *testing.T) {
 			t.Fatal(res.Error)
 		}
 
-		change, err = model.HandleStateChange(&withdrawalQueued)
+		change, err = model.HandleLog(&withdrawalQueued)
 		assert.Nil(t, err)
 		assert.Nil(t, change) // should be nil since the handler doesnt care about this event
 
@@ -454,7 +454,7 @@ func Test_StakerSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		change, err = model.HandleStateChange(&log)
+		change, err = model.HandleLog(&log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -479,7 +479,7 @@ func Test_StakerSharesState(t *testing.T) {
 			DeletedAt:        time.Time{},
 		}
 
-		change, err = model.HandleStateChange(&withdrawalMigratedLog)
+		change, err = model.HandleLog(&withdrawalMigratedLog)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 

--- a/internal/eigenState/stakerShares/stakerShares_test.go
+++ b/internal/eigenState/stakerShares/stakerShares_test.go
@@ -418,7 +418,7 @@ func Test_StakerSharesState(t *testing.T) {
 
 		change, err = model.HandleLog(&withdrawalQueued)
 		assert.Nil(t, err)
-		assert.Nil(t, change) // should be nil since the handler doesnt care about this event
+		assert.Len(t, change.(*AccumulatedStateChanges).Changes, 0)
 
 		err = model.CommitFinalState(originBlockNumber)
 		assert.Nil(t, err)

--- a/internal/eigenState/stateManager/stateManager.go
+++ b/internal/eigenState/stateManager/stateManager.go
@@ -57,7 +57,7 @@ func (e *EigenStateManager) HandleLogStateChange(log *storage.TransactionLog) er
 				zap.Uint64("logIndex", log.LogIndex),
 				zap.String("eventName", log.EventName),
 			)
-			_, err := state.HandleStateChange(log)
+			_, err := state.HandleLog(log)
 			if err != nil {
 				return err
 			}

--- a/internal/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
+++ b/internal/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
@@ -82,7 +82,7 @@ func Test_SubmittedDistributionRoots(t *testing.T) {
 		isInteresting := model.IsInterestingLog(log)
 		assert.True(t, isInteresting)
 
-		change, err := model.HandleStateChange(log)
+		change, err := model.HandleLog(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
@@ -135,7 +135,7 @@ func Test_SubmittedDistributionRoots(t *testing.T) {
 		isInteresting := model.IsInterestingLog(log)
 		assert.True(t, isInteresting)
 
-		change, err := model.HandleStateChange(log)
+		change, err := model.HandleLog(log)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 

--- a/internal/eigenState/types/types.go
+++ b/internal/eigenState/types/types.go
@@ -23,11 +23,11 @@ type IEigenStateModel interface {
 	// Perform any necessary cleanup for processing a block
 	CleanupProcessedStateForBlock(blockNumber uint64) error
 
-	// HandleStateChange
+	// HandleLog
 	// Allow the state model to handle the state change
 	//
 	// Returns the saved value. Listed as an interface because go generics suck
-	HandleStateChange(log *storage.TransactionLog) (interface{}, error)
+	HandleLog(log *storage.TransactionLog) (interface{}, error)
 
 	// CommitFinalState
 	// Once all state changes are processed, commit the final state to the database
@@ -47,6 +47,6 @@ type IEigenStateModel interface {
 
 // StateTransitions
 // Map of block number to function that will transition the state to the next block.
-type StateTransitions[T interface{}] map[uint64]func(log *storage.TransactionLog) (*T, error)
+type StateTransitions map[uint64]func(log *storage.TransactionLog) (interface{}, error)
 
 type SlotID string

--- a/scripts/goTest.sh
+++ b/scripts/goTest.sh
@@ -7,4 +7,4 @@ export PYTHONPATH="${PROJECT_ROOT}/sqlite-extensions:$PYTHONPATH"
 export CGO_ENABLED=1
 export TESTING=true
 
-go test $@
+go test $@ 


### PR DESCRIPTION
This PR aims to remove duplication between models in their log handling so the code is more readable and easier to reason about.

- Move log handlers for state transitions to base class
- Made `StateTransitions` a non generic to play nicer with new abstraction. this seems ok since return value is not used
- HandleStateChange -> HandleLog