### PR TITLE
feat: move merklization to base

### DIFF
--- a/internal/eigenState/base/baseEigenState.go
+++ b/internal/eigenState/base/baseEigenState.go
@@ -153,6 +153,13 @@ func (b *BaseEigenState) MerkleizeState(blockNumber uint64, stateDiffs []*StateD
 		return strings.Compare(string(a.SlotID), string(b.SlotID))
 	})
 
+	// check for duplicates
+	for i := 0; i < len(sortedDiffs)-1; i++ {
+		if sortedDiffs[i].SlotID == sortedDiffs[i+1].SlotID {
+			return "", xerrors.Errorf("Duplicate slotID found: %s", sortedDiffs[i].SlotID)
+		}
+	}
+
 	leaves := b.InitializeStateTreeForBlock(blockNumber)
 	for _, diff := range sortedDiffs {
 		leaves = append(leaves, encodeMerkleLeaf(diff.SlotID, diff.Value))


### PR DESCRIPTION
- moves merklization logic into base model
- removes a bunch of the diff structs from various models
- BREAKING: changes the definition of a submission root slot id to be `rootIndex || root` rather than `root || rootIndex` in order to get the desired ordering effect when sorting by slot id