### PR TITLE
WIP: add withdrawals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ test-db
 *.dylib
 *.dylib.dSYM
 /sqlite-extensions/build
+internal/eigenState/compile.sh

--- a/internal/eigenState/bindings/DelegationManagerM2/binding.go
+++ b/internal/eigenState/bindings/DelegationManagerM2/binding.go
@@ -1,0 +1,4352 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package DelegationManager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IDelegationManagerOperatorDetails is an auto generated low-level Go binding around an user-defined struct.
+type IDelegationManagerOperatorDetails struct {
+	EarningsReceiver         common.Address
+	DelegationApprover       common.Address
+	StakerOptOutWindowBlocks uint32
+}
+
+// IDelegationManagerQueuedWithdrawalParams is an auto generated low-level Go binding around an user-defined struct.
+type IDelegationManagerQueuedWithdrawalParams struct {
+	Strategies []common.Address
+	Shares     []*big.Int
+	Withdrawer common.Address
+}
+
+// IDelegationManagerWithdrawal is an auto generated low-level Go binding around an user-defined struct.
+type IDelegationManagerWithdrawal struct {
+	Staker      common.Address
+	DelegatedTo common.Address
+	Withdrawer  common.Address
+	Nonce       *big.Int
+	StartBlock  uint32
+	Strategies  []common.Address
+	Shares      []*big.Int
+}
+
+// ISignatureUtilsSignatureWithExpiry is an auto generated low-level Go binding around an user-defined struct.
+type ISignatureUtilsSignatureWithExpiry struct {
+	Signature []byte
+	Expiry    *big.Int
+}
+
+// IStrategyManagerDeprecatedStructQueuedWithdrawal is an auto generated low-level Go binding around an user-defined struct.
+type IStrategyManagerDeprecatedStructQueuedWithdrawal struct {
+	Strategies           []common.Address
+	Shares               []*big.Int
+	Staker               common.Address
+	WithdrawerAndNonce   IStrategyManagerDeprecatedStructWithdrawerAndNonce
+	WithdrawalStartBlock uint32
+	DelegatedAddress     common.Address
+}
+
+// IStrategyManagerDeprecatedStructWithdrawerAndNonce is an auto generated low-level Go binding around an user-defined struct.
+type IStrategyManagerDeprecatedStructWithdrawerAndNonce struct {
+	Withdrawer common.Address
+	Nonce      *big.Int
+}
+
+// DelegationManagerMetaData contains all meta data concerning the DelegationManager contract.
+var DelegationManagerMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_strategyManager\",\"type\":\"address\",\"internalType\":\"contractIStrategyManager\"},{\"name\":\"_slasher\",\"type\":\"address\",\"internalType\":\"contractISlasher\"},{\"name\":\"_eigenPodManager\",\"type\":\"address\",\"internalType\":\"contractIEigenPodManager\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DELEGATION_APPROVAL_TYPEHASH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"DOMAIN_TYPEHASH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_STAKER_OPT_OUT_WINDOW_BLOCKS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_WITHDRAWAL_DELAY_BLOCKS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"STAKER_DELEGATION_TYPEHASH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"beaconChainETHStrategy\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateCurrentStakerDelegationDigestHash\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateDelegationApprovalDigestHash\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"approverSalt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateStakerDelegationDigestHash\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_stakerNonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateWithdrawalRoot\",\"inputs\":[{\"name\":\"withdrawal\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManager.Withdrawal\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startBlock\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"shares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"completeQueuedWithdrawal\",\"inputs\":[{\"name\":\"withdrawal\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManager.Withdrawal\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startBlock\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"shares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]},{\"name\":\"tokens\",\"type\":\"address[]\",\"internalType\":\"contractIERC20[]\"},{\"name\":\"middlewareTimesIndex\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"receiveAsTokens\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"completeQueuedWithdrawals\",\"inputs\":[{\"name\":\"withdrawals\",\"type\":\"tuple[]\",\"internalType\":\"structIDelegationManager.Withdrawal[]\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startBlock\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"shares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]},{\"name\":\"tokens\",\"type\":\"address[][]\",\"internalType\":\"contractIERC20[][]\"},{\"name\":\"middlewareTimesIndexes\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"},{\"name\":\"receiveAsTokens\",\"type\":\"bool[]\",\"internalType\":\"bool[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"cumulativeWithdrawalsQueued\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decreaseDelegatedShares\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"},{\"name\":\"shares\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegateTo\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"approverSignatureAndExpiry\",\"type\":\"tuple\",\"internalType\":\"structISignatureUtils.SignatureWithExpiry\",\"components\":[{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"approverSalt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegateToBySignature\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stakerSignatureAndExpiry\",\"type\":\"tuple\",\"internalType\":\"structISignatureUtils.SignatureWithExpiry\",\"components\":[{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"approverSignatureAndExpiry\",\"type\":\"tuple\",\"internalType\":\"structISignatureUtils.SignatureWithExpiry\",\"components\":[{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"approverSalt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegatedTo\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"delegationApprover\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"delegationApproverSaltIsSpent\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"domainSeparator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"earningsReceiver\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenPodManager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenPodManager\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getDelegatableShares\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getOperatorShares\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getWithdrawalDelay\",\"inputs\":[{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"increaseDelegatedShares\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"},{\"name\":\"shares\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"initialOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_pauserRegistry\",\"type\":\"address\",\"internalType\":\"contractIPauserRegistry\"},{\"name\":\"initialPausedStatus\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_minWithdrawalDelayBlocks\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"_withdrawalDelayBlocks\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isDelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isOperator\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"migrateQueuedWithdrawals\",\"inputs\":[{\"name\":\"withdrawalsToMigrate\",\"type\":\"tuple[]\",\"internalType\":\"structIStrategyManager.DeprecatedStruct_QueuedWithdrawal[]\",\"components\":[{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"shares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"},{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawerAndNonce\",\"type\":\"tuple\",\"internalType\":\"structIStrategyManager.DeprecatedStruct_WithdrawerAndNonce\",\"components\":[{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint96\",\"internalType\":\"uint96\"}]},{\"name\":\"withdrawalStartBlock\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"delegatedAddress\",\"type\":\"address\",\"internalType\":\"address\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"minWithdrawalDelayBlocks\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"modifyOperatorDetails\",\"inputs\":[{\"name\":\"newOperatorDetails\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManager.OperatorDetails\",\"components\":[{\"name\":\"earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"operatorDetails\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManager.OperatorDetails\",\"components\":[{\"name\":\"earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorShares\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"pauseAll\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pauserRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIPauserRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingWithdrawals\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"queueWithdrawals\",\"inputs\":[{\"name\":\"queuedWithdrawalParams\",\"type\":\"tuple[]\",\"internalType\":\"structIDelegationManager.QueuedWithdrawalParams[]\",\"components\":[{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"shares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerAsOperator\",\"inputs\":[{\"name\":\"registeringOperatorDetails\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManager.OperatorDetails\",\"components\":[{\"name\":\"earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]},{\"name\":\"metadataURI\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMinWithdrawalDelayBlocks\",\"inputs\":[{\"name\":\"newMinWithdrawalDelayBlocks\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setPauserRegistry\",\"inputs\":[{\"name\":\"newPauserRegistry\",\"type\":\"address\",\"internalType\":\"contractIPauserRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setStrategyWithdrawalDelayBlocks\",\"inputs\":[{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"withdrawalDelayBlocks\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"slasher\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractISlasher\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"stakerNonce\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"stakerOptOutWindowBlocks\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"strategyManager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategyManager\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"strategyWithdrawalDelayBlocks\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"undelegate\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"withdrawalRoots\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateOperatorMetadataURI\",\"inputs\":[{\"name\":\"metadataURI\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MinWithdrawalDelayBlocksSet\",\"inputs\":[{\"name\":\"previousValue\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newValue\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorDetailsModified\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOperatorDetails\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIDelegationManager.OperatorDetails\",\"components\":[{\"name\":\"earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorMetadataURIUpdated\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operatorDetails\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIDelegationManager.OperatorDetails\",\"components\":[{\"name\":\"earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorSharesDecreased\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"staker\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIStrategy\"},{\"name\":\"shares\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorSharesIncreased\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"staker\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIStrategy\"},{\"name\":\"shares\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PauserRegistrySet\",\"inputs\":[{\"name\":\"pauserRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIPauserRegistry\"},{\"name\":\"newPauserRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIPauserRegistry\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakerDelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakerForceUndelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakerUndelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StrategyWithdrawalDelayBlocksSet\",\"inputs\":[{\"name\":\"strategy\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIStrategy\"},{\"name\":\"previousValue\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newValue\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalCompleted\",\"inputs\":[{\"name\":\"withdrawalRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalMigrated\",\"inputs\":[{\"name\":\"oldWithdrawalRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"newWithdrawalRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalQueued\",\"inputs\":[{\"name\":\"withdrawalRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"withdrawal\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIDelegationManager.Withdrawal\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startBlock\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"shares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]}],\"anonymous\":false}]",
+	Bin: "0x6101006040523480156200001257600080fd5b506040516200618138038062006181833981016040819052620000359162000140565b6001600160a01b0380841660805280821660c052821660a0526200005862000065565b50504660e0525062000194565b600054610100900460ff1615620000d25760405162461bcd60e51b815260206004820152602760248201527f496e697469616c697a61626c653a20636f6e747261637420697320696e697469604482015266616c697a696e6760c81b606482015260840160405180910390fd5b60005460ff908116101562000125576000805460ff191660ff9081179091556040519081527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b565b6001600160a01b03811681146200013d57600080fd5b50565b6000806000606084860312156200015657600080fd5b8351620001638162000127565b6020850151909350620001768162000127565b6040850151909250620001898162000127565b809150509250925092565b60805160a05160c05160e051615f516200023060003960006127790152600081816105e7015281816110ae0152818161142a01528181611e0d01528181612ad2015281816141390152614625015260006107d701526000818161052f0152818161107c015281816113f80152818161172001528181611ea101528181612b9f01528181612d220152818161425f01526146cb0152615f516000f3fe608060405234801561001057600080fd5b50600436106103785760003560e01c806360d7faed116101d3578063b7f06ebe11610104578063cf80873e116100a2578063f16172b01161007c578063f16172b01461097d578063f2fde38b14610990578063f698da25146109a3578063fabc1cbc146109ab57600080fd5b8063cf80873e14610936578063da8be86414610957578063eea9064b1461096a57600080fd5b8063c488375a116100de578063c488375a14610853578063c5e480db14610873578063c94b511114610919578063ca661c041461092c57600080fd5b8063b7f06ebe146107f9578063bb45fef21461081c578063c448feb81461084a57600080fd5b8063886f1195116101715780639104c3191161014b5780639104c3191461078457806399be81c81461079f578063a1788484146107b2578063b1344271146107d257600080fd5b8063886f1195146107405780638da5cb5b14610753578063900413471461076457600080fd5b80636d70f7ae116101ad5780636d70f7ae146106e7578063715018a6146106fa578063778e55f3146107025780637f5480711461072d57600080fd5b806360d7faed14610698578063635bbd10146106ab57806365da1264146106be57600080fd5b806329c77d4f116102ad5780634fc40b611161024b5780635ac86ab7116102255780635ac86ab71461062e5780635c975abb146106515780635cfe8d2c146106595780635f966f141461066c57600080fd5b80634fc40b6114610609578063595c6a6714610613578063597b36da1461061b57600080fd5b80633cdeb5e0116102875780633cdeb5e0146105695780633e28391d1461059857806343377382146105bb5780634665bcda146105e257600080fd5b806329c77d4f146104f7578063334043961461051757806339b70e381461052a57600080fd5b8063136439dd1161031a5780631bbce091116102f45780631bbce0911461049757806320606b70146104aa57806322bf40e4146104d157806328a573ae146104e457600080fd5b8063136439dd146104385780631522bf021461044b578063169283651461045e57600080fd5b80630dd8dd02116103565780630dd8dd02146103dd5780630f589e59146103fd57806310d67a2f14610412578063132d49671461042557600080fd5b80630449ca391461037d57806304a4f979146103a35780630b9f487a146103ca575b600080fd5b61039061038b366004614adb565b6109be565b6040519081526020015b60405180910390f35b6103907f14bde674c9f64b2ad00eaaee4a8bed1fabef35c7507e3c5b9cfc9436909a2dad81565b6103906103d8366004614b41565b610a43565b6103f06103eb366004614adb565b610b05565b60405161039a9190614b9c565b61041061040b366004614c39565b610e6e565b005b610410610420366004614c8c565b610fbe565b610410610433366004614cb0565b611071565b610410610446366004614cf1565b611128565b610410610459366004614d0a565b611267565b61039061046c366004614c8c565b6001600160a01b0316600090815260996020526040902060010154600160a01b900463ffffffff1690565b6103906104a5366004614cb0565b61127b565b6103907f8cad95687ba82c2ce50e74f7b754645e5117c3a5bec8151c0726d5857980a86681565b6104106104df366004614d75565b6112a9565b6104106104f2366004614cb0565b6113ed565b610390610505366004614c8c565b609b6020526000908152604090205481565b610410610525366004614e1c565b61149d565b6105517f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b03909116815260200161039a565b610551610577366004614c8c565b6001600160a01b039081166000908152609960205260409020600101541690565b6105ab6105a6366004614c8c565b6115da565b604051901515815260200161039a565b6103907f39111bc4a4d688e1f685123d7497d4615370152a8ee4a0593e647bd06ad8bb0b81565b6105517f000000000000000000000000000000000000000000000000000000000000000081565b6103906213c68081565b6104106115fa565b61039061062936600461513b565b6116c1565b6105ab61063c366004615177565b606654600160ff9092169190911b9081161490565b606654610390565b6104106106673660046151ed565b6116f1565b61055161067a366004614c8c565b6001600160a01b039081166000908152609960205260409020541690565b6104106106a636600461534d565b61199c565b6104106106b9366004614cf1565b611a37565b6105516106cc366004614c8c565b609a602052600090815260409020546001600160a01b031681565b6105ab6106f5366004614c8c565b611a48565b610410611a68565b6103906107103660046153dc565b609860209081526000928352604080842090915290825290205481565b61041061073b3660046154bd565b611a7c565b606554610551906001600160a01b031681565b6033546001600160a01b0316610551565b61077761077236600461554d565b611b81565b60405161039a91906155d7565b61055173beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac081565b6104106107ad3660046155ea565b611c5b565b6103906107c0366004614c8c565b609f6020526000908152604090205481565b6105517f000000000000000000000000000000000000000000000000000000000000000081565b6105ab610807366004614cf1565b609e6020526000908152604090205460ff1681565b6105ab61082a36600461561f565b609c60209081526000928352604080842090915290825290205460ff1681565b610390609d5481565b610390610861366004614c8c565b60a16020526000908152604090205481565b6108e3610881366004614c8c565b6040805160608082018352600080835260208084018290529284018190526001600160a01b03948516815260998352839020835191820184528054851682526001015493841691810191909152600160a01b90920463ffffffff169082015290565b6040805182516001600160a01b039081168252602080850151909116908201529181015163ffffffff169082015260600161039a565b61039061092736600461564b565b611d2d565b61039062034bc081565b610949610944366004614c8c565b611de6565b60405161039a9291906156cc565b6103f0610965366004614c8c565b61219e565b6104106109783660046156f1565b612662565b61041061098b366004615749565b61266e565b61041061099e366004614c8c565b6126ff565b610390612775565b6104106109b9366004614cf1565b6127b3565b609d54600090815b83811015610a3b57600060a160008787858181106109e6576109e6615765565b90506020020160208101906109fb9190614c8c565b6001600160a01b03166001600160a01b0316815260200190815260200160002054905082811115610a2a578092505b50610a3481615791565b90506109c6565b509392505050565b604080517f14bde674c9f64b2ad00eaaee4a8bed1fabef35c7507e3c5b9cfc9436909a2dad6020808301919091526001600160a01b038681168385015288811660608401528716608083015260a0820185905260c08083018590528351808403909101815260e0909201909252805191012060009081610ac1612775565b60405161190160f01b602082015260228101919091526042810183905260620160408051808303601f19018152919052805160209091012098975050505050505050565b60665460609060019060029081161415610b3a5760405162461bcd60e51b8152600401610b31906157ac565b60405180910390fd5b6000836001600160401b03811115610b5457610b54614ebe565b604051908082528060200260200182016040528015610b7d578160200160208202803683370190505b50336000908152609a60205260408120549192506001600160a01b03909116905b85811015610e6357868682818110610bb857610bb8615765565b9050602002810190610bca91906157e3565b610bd8906020810190615803565b9050878783818110610bec57610bec615765565b9050602002810190610bfe91906157e3565b610c089080615803565b905014610c7d5760405162461bcd60e51b815260206004820152603860248201527f44656c65676174696f6e4d616e616765722e717565756557697468647261776160448201527f6c3a20696e707574206c656e677468206d69736d6174636800000000000000006064820152608401610b31565b33878783818110610c9057610c90615765565b9050602002810190610ca291906157e3565b610cb3906060810190604001614c8c565b6001600160a01b031614610d2f5760405162461bcd60e51b815260206004820152603c60248201527f44656c65676174696f6e4d616e616765722e717565756557697468647261776160448201527f6c3a2077697468647261776572206d757374206265207374616b6572000000006064820152608401610b31565b610e343383898985818110610d4657610d46615765565b9050602002810190610d5891906157e3565b610d69906060810190604001614c8c565b8a8a86818110610d7b57610d7b615765565b9050602002810190610d8d91906157e3565b610d979080615803565b808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508e92508d9150889050818110610ddd57610ddd615765565b9050602002810190610def91906157e3565b610dfd906020810190615803565b8080602002602001604051908101604052809392919081815260200183836020028082843760009201919091525061290f92505050565b838281518110610e4657610e46615765565b602090810291909101015280610e5b81615791565b915050610b9e565b509095945050505050565b336000908152609960205260409020546001600160a01b031615610f085760405162461bcd60e51b815260206004820152604560248201527f44656c65676174696f6e4d616e616765722e726567697374657241734f70657260448201527f61746f723a206f70657261746f722068617320616c72656164792072656769736064820152641d195c995960da1b608482015260a401610b31565b610f123384612ecf565b604080518082019091526060815260006020820152610f34338083600061316b565b336001600160a01b03167f8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e285604051610f6d919061584c565b60405180910390a2336001600160a01b03167f02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b67080908484604051610fb092919061589e565b60405180910390a250505050565b606560009054906101000a90046001600160a01b03166001600160a01b031663eab66d7a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015611011573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061103591906158cd565b6001600160a01b0316336001600160a01b0316146110655760405162461bcd60e51b8152600401610b31906158ea565b61106e81613510565b50565b336001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001614806110d05750336001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016145b6110ec5760405162461bcd60e51b8152600401610b3190615934565b6110f5836115da565b15611123576001600160a01b038084166000908152609a60205260409020541661112181858585613607565b505b505050565b60655460405163237dfb4760e11b81523360048201526001600160a01b03909116906346fbf68e90602401602060405180830381865afa158015611170573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906111949190615991565b6111b05760405162461bcd60e51b8152600401610b31906159ae565b606654818116146112295760405162461bcd60e51b815260206004820152603860248201527f5061757361626c652e70617573653a20696e76616c696420617474656d70742060448201527f746f20756e70617573652066756e6374696f6e616c69747900000000000000006064820152608401610b31565b606681905560405181815233907fab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d906020015b60405180910390a250565b61126f613682565b611121848484846136dc565b6001600160a01b0383166000908152609b60205260408120546112a085828686611d2d565b95945050505050565b600054610100900460ff16158080156112c95750600054600160ff909116105b806112e35750303b1580156112e3575060005460ff166001145b6113465760405162461bcd60e51b815260206004820152602e60248201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160448201526d191e481a5b9a5d1a585b1a5e995960921b6064820152608401610b31565b6000805460ff191660011790558015611369576000805461ff0019166101001790555b6113738888613902565b61137b6139e8565b60975561138789613a7f565b61139086613ad1565b61139c858585856136dc565b80156113e2576000805461ff0019169055604051600181527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b505050505050505050565b336001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016148061144c5750336001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016145b6114685760405162461bcd60e51b8152600401610b3190615934565b611471836115da565b15611123576001600160a01b038084166000908152609a60205260409020541661112181858585613bcb565b606654600290600490811614156114c65760405162461bcd60e51b8152600401610b31906157ac565b600260c95414156115195760405162461bcd60e51b815260206004820152601f60248201527f5265656e7472616e637947756172643a207265656e7472616e742063616c6c006044820152606401610b31565b600260c95560005b888110156115c9576115b98a8a8381811061153e5761153e615765565b905060200281019061155091906159f6565b89898481811061156257611562615765565b90506020028101906115749190615803565b89898681811061158657611586615765565b9050602002013588888781811061159f5761159f615765565b90506020020160208101906115b49190615a0c565b613c46565b6115c281615791565b9050611521565b5050600160c9555050505050505050565b6001600160a01b039081166000908152609a602052604090205416151590565b60655460405163237dfb4760e11b81523360048201526001600160a01b03909116906346fbf68e90602401602060405180830381865afa158015611642573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906116669190615991565b6116825760405162461bcd60e51b8152600401610b31906159ae565b600019606681905560405190815233907fab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d9060200160405180910390a2565b6000816040516020016116d49190615a9d565b604051602081830303815290604052805190602001209050919050565b60005b815181101561199857600082828151811061171157611711615765565b602002602001015190506000807f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663cd293f6f846040518263ffffffff1660e01b815260040161176a9190615ab0565b60408051808303816000875af1158015611788573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906117ac9190615b5c565b91509150811561198a576040808401516001600160a01b0381166000908152609f602052918220805491928291906117e383615791565b919050555060006040518060e00160405280846001600160a01b031681526020018760a001516001600160a01b031681526020018760600151600001516001600160a01b03168152602001838152602001876080015163ffffffff16815260200187600001518152602001876020015181525090506000611863826116c1565b6000818152609e602052604090205490915060ff16156118f95760405162461bcd60e51b815260206004820152604560248201527f44656c65676174696f6e4d616e616765722e6d6967726174655175657565645760448201527f69746864726177616c733a207769746864726177616c20616c72656164792065606482015264786973747360d81b608482015260a401610b31565b6000818152609e602052604090819020805460ff19166001179055517f9009ab153e8014fbfb02f2217f5cde7aa7f9ad734ae85ca3ee3f4ca2fdd499f9906119449083908590615b8a565b60405180910390a160408051868152602081018390527fdc00758b65eef71dc3780c04ebe36cab6bdb266c3a698187e29e0f0dca012630910160405180910390a1505050505b8360010193505050506116f4565b5050565b606654600290600490811614156119c55760405162461bcd60e51b8152600401610b31906157ac565b600260c9541415611a185760405162461bcd60e51b815260206004820152601f60248201527f5265656e7472616e637947756172643a207265656e7472616e742063616c6c006044820152606401610b31565b600260c955611a2a8686868686613c46565b5050600160c95550505050565b611a3f613682565b61106e81613ad1565b6001600160a01b0390811660009081526099602052604090205416151590565b611a70613682565b611a7a6000613a7f565b565b4283602001511015611b005760405162461bcd60e51b815260206004820152604160248201527f44656c65676174696f6e4d616e616765722e64656c6567617465546f4279536960448201527f676e61747572653a207374616b6572207369676e6174757265206578706972656064820152601960fa1b608482015260a401610b31565b6000609b6000876001600160a01b03166001600160a01b031681526020019081526020016000205490506000611b3c8783888860200151611d2d565b6001600160a01b0388166000908152609b602052604090206001840190558551909150611b6c9088908390614430565b611b788787868661316b565b50505050505050565b6060600082516001600160401b03811115611b9e57611b9e614ebe565b604051908082528060200260200182016040528015611bc7578160200160208202803683370190505b50905060005b8351811015610a3b576001600160a01b03851660009081526098602052604081208551909190869084908110611c0557611c05615765565b60200260200101516001600160a01b03166001600160a01b0316815260200190815260200160002054828281518110611c4057611c40615765565b6020908102919091010152611c5481615791565b9050611bcd565b611c6433611a48565b611ce65760405162461bcd60e51b815260206004820152604760248201527f44656c65676174696f6e4d616e616765722e7570646174654f70657261746f7260448201527f4d657461646174615552493a2063616c6c6572206d75737420626520616e206f6064820152663832b930ba37b960c91b608482015260a401610b31565b336001600160a01b03167f02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b67080908383604051611d2192919061589e565b60405180910390a25050565b604080517f39111bc4a4d688e1f685123d7497d4615370152a8ee4a0593e647bd06ad8bb0b6020808301919091526001600160a01b0387811683850152851660608301526080820186905260a08083018590528351808403909101815260c0909201909252805191012060009081611da3612775565b60405161190160f01b602082015260228101919091526042810183905260620160408051808303601f190181529190528051602090910120979650505050505050565b6040516360f4062b60e01b81526001600160a01b03828116600483015260609182916000917f0000000000000000000000000000000000000000000000000000000000000000909116906360f4062b90602401602060405180830381865afa158015611e56573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611e7a9190615ba3565b6040516394f649dd60e01b81526001600160a01b03868116600483015291925060009182917f0000000000000000000000000000000000000000000000000000000000000000909116906394f649dd90602401600060405180830381865afa158015611eea573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f19168201604052611f129190810190615c17565b9150915060008313611f2957909590945092505050565b606080835160001415611fe3576040805160018082528183019092529060208083019080368337505060408051600180825281830190925292945090506020808301908036833701905050905073beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac082600081518110611f9e57611f9e615765565b60200260200101906001600160a01b031690816001600160a01b0316815250508481600081518110611fd257611fd2615765565b602002602001018181525050612191565b8351611ff0906001615cd1565b6001600160401b0381111561200757612007614ebe565b604051908082528060200260200182016040528015612030578160200160208202803683370190505b50915081516001600160401b0381111561204c5761204c614ebe565b604051908082528060200260200182016040528015612075578160200160208202803683370190505b50905060005b845181101561210f5784818151811061209657612096615765565b60200260200101518382815181106120b0576120b0615765565b60200260200101906001600160a01b031690816001600160a01b0316815250508381815181106120e2576120e2615765565b60200260200101518282815181106120fc576120fc615765565b602090810291909101015260010161207b565b5073beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac082600184516121349190615ce9565b8151811061214457612144615765565b60200260200101906001600160a01b031690816001600160a01b0316815250508481600184516121749190615ce9565b8151811061218457612184615765565b6020026020010181815250505b9097909650945050505050565b606654606090600190600290811614156121ca5760405162461bcd60e51b8152600401610b31906157ac565b6121d3836115da565b6122535760405162461bcd60e51b8152602060048201526044602482018190527f44656c65676174696f6e4d616e616765722e756e64656c65676174653a207374908201527f616b6572206d7573742062652064656c65676174656420746f20756e64656c656064820152636761746560e01b608482015260a401610b31565b61225c83611a48565b156122cf5760405162461bcd60e51b815260206004820152603d60248201527f44656c65676174696f6e4d616e616765722e756e64656c65676174653a206f7060448201527f657261746f72732063616e6e6f7420626520756e64656c6567617465640000006064820152608401610b31565b6001600160a01b03831661234b5760405162461bcd60e51b815260206004820152603c60248201527f44656c65676174696f6e4d616e616765722e756e64656c65676174653a20636160448201527f6e6e6f7420756e64656c6567617465207a65726f2061646472657373000000006064820152608401610b31565b6001600160a01b038084166000818152609a60205260409020549091169033148061237e5750336001600160a01b038216145b806123a557506001600160a01b038181166000908152609960205260409020600101541633145b6124175760405162461bcd60e51b815260206004820152603d60248201527f44656c65676174696f6e4d616e616765722e756e64656c65676174653a20636160448201527f6c6c65722063616e6e6f7420756e64656c6567617465207374616b65720000006064820152608401610b31565b60008061242386611de6565b9092509050336001600160a01b0387161461247957826001600160a01b0316866001600160a01b03167ff0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a60405160405180910390a35b826001600160a01b0316866001600160a01b03167ffee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af4467660405160405180910390a36001600160a01b0386166000908152609a6020526040902080546001600160a01b031916905581516124fb576040805160008152602081019091529450612659565b81516001600160401b0381111561251457612514614ebe565b60405190808252806020026020018201604052801561253d578160200160208202803683370190505b50945060005b8251811015612657576040805160018082528183019092526000916020808301908036833750506040805160018082528183019092529293506000929150602080830190803683370190505090508483815181106125a3576125a3615765565b6020026020010151826000815181106125be576125be615765565b60200260200101906001600160a01b031690816001600160a01b0316815250508383815181106125f0576125f0615765565b60200260200101518160008151811061260b5761260b615765565b60200260200101818152505061262489878b858561290f565b88848151811061263657612636615765565b6020026020010181815250505050808061264f90615791565b915050612543565b505b50505050919050565b6111233384848461316b565b61267733611a48565b6126f55760405162461bcd60e51b815260206004820152604360248201527f44656c65676174696f6e4d616e616765722e6d6f646966794f70657261746f7260448201527f44657461696c733a2063616c6c6572206d75737420626520616e206f706572616064820152623a37b960e91b608482015260a401610b31565b61106e3382612ecf565b612707613682565b6001600160a01b03811661276c5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b6064820152608401610b31565b61106e81613a7f565b60007f00000000000000000000000000000000000000000000000000000000000000004614156127a6575060975490565b6127ae6139e8565b905090565b606560009054906101000a90046001600160a01b03166001600160a01b031663eab66d7a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612806573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061282a91906158cd565b6001600160a01b0316336001600160a01b03161461285a5760405162461bcd60e51b8152600401610b31906158ea565b6066541981196066541916146128d85760405162461bcd60e51b815260206004820152603860248201527f5061757361626c652e756e70617573653a20696e76616c696420617474656d7060448201527f7420746f2070617573652066756e6374696f6e616c69747900000000000000006064820152608401610b31565b606681905560405181815233907f3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c9060200161125c565b60006001600160a01b0386166129a65760405162461bcd60e51b815260206004820152605060248201527f44656c65676174696f6e4d616e616765722e5f72656d6f76655368617265734160448201527f6e6451756575655769746864726177616c3a207374616b65722063616e6e6f7460648201526f206265207a65726f206164647265737360801b608482015260a401610b31565b8251612a305760405162461bcd60e51b815260206004820152604d60248201527f44656c65676174696f6e4d616e616765722e5f72656d6f76655368617265734160448201527f6e6451756575655769746864726177616c3a207374726174656769657320636160648201526c6e6e6f7420626520656d70747960981b608482015260a401610b31565b60005b8351811015612ddd576001600160a01b03861615612a8957612a898688868481518110612a6257612a62615765565b6020026020010151868581518110612a7c57612a7c615765565b6020026020010151613607565b73beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac06001600160a01b0316848281518110612ab957612ab9615765565b60200260200101516001600160a01b03161415612b82577f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663beffbb8988858481518110612b1257612b12615765565b60200260200101516040518363ffffffff1660e01b8152600401612b4b9291906001600160a01b03929092168252602082015260400190565b600060405180830381600087803b158015612b6557600080fd5b505af1158015612b79573d6000803e3d6000fd5b50505050612dd5565b846001600160a01b0316876001600160a01b03161480612c5457507f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316639b4da03d858381518110612bde57612bde615765565b60200260200101516040518263ffffffff1660e01b8152600401612c1191906001600160a01b0391909116815260200190565b602060405180830381865afa158015612c2e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612c529190615991565b155b612d205760405162461bcd60e51b8152602060048201526084602482018190527f44656c65676174696f6e4d616e616765722e5f72656d6f76655368617265734160448301527f6e6451756575655769746864726177616c3a2077697468647261776572206d7560648301527f73742062652073616d652061646472657373206173207374616b657220696620908201527f746869726450617274795472616e7366657273466f7262696464656e2061726560a482015263081cd95d60e21b60c482015260e401610b31565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316638c80d4e588868481518110612d6257612d62615765565b6020026020010151868581518110612d7c57612d7c615765565b60200260200101516040518463ffffffff1660e01b8152600401612da293929190615d00565b600060405180830381600087803b158015612dbc57600080fd5b505af1158015612dd0573d6000803e3d6000fd5b505050505b600101612a33565b506001600160a01b0386166000908152609f60205260408120805491829190612e0583615791565b919050555060006040518060e00160405280896001600160a01b03168152602001886001600160a01b03168152602001876001600160a01b031681526020018381526020014363ffffffff1681526020018681526020018581525090506000612e6d826116c1565b6000818152609e602052604090819020805460ff19166001179055519091507f9009ab153e8014fbfb02f2217f5cde7aa7f9ad734ae85ca3ee3f4ca2fdd499f990612ebb9083908590615b8a565b60405180910390a198975050505050505050565b6000612ede6020830183614c8c565b6001600160a01b03161415612f785760405162461bcd60e51b815260206004820152605460248201527f44656c65676174696f6e4d616e616765722e5f7365744f70657261746f72446560448201527f7461696c733a2063616e6e6f742073657420606561726e696e677352656365696064820152737665726020746f207a65726f206164647265737360601b608482015260a401610b31565b6213c680612f8c6060830160408401615d24565b63ffffffff1611156130415760405162461bcd60e51b815260206004820152606c60248201527f44656c65676174696f6e4d616e616765722e5f7365744f70657261746f72446560448201527f7461696c733a207374616b65724f70744f757457696e646f77426c6f636b732060648201527f63616e6e6f74206265203e204d41585f5354414b45525f4f50545f4f55545f5760848201526b494e444f575f424c4f434b5360a01b60a482015260c401610b31565b6001600160a01b0382166000908152609960205260409081902060010154600160a01b900463ffffffff169061307d9060608401908401615d24565b63ffffffff1610156131135760405162461bcd60e51b815260206004820152605360248201527f44656c65676174696f6e4d616e616765722e5f7365744f70657261746f72446560448201527f7461696c733a207374616b65724f70744f757457696e646f77426c6f636b732060648201527218d85b9b9bdd08189948191958dc99585cd959606a1b608482015260a401610b31565b6001600160a01b038216600090815260996020526040902081906131378282615d61565b505060405133907ffebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac90611d2190849061584c565b606654600090600190811614156131945760405162461bcd60e51b8152600401610b31906157ac565b61319d856115da565b1561321a5760405162461bcd60e51b815260206004820152604160248201527f44656c65676174696f6e4d616e616765722e5f64656c65676174653a2073746160448201527f6b657220697320616c7265616479206163746976656c792064656c65676174656064820152601960fa1b608482015260a401610b31565b61322384611a48565b6132a35760405162461bcd60e51b815260206004820152604560248201527f44656c65676174696f6e4d616e616765722e5f64656c65676174653a206f706560448201527f7261746f72206973206e6f74207265676973746572656420696e20456967656e6064820152642630bcb2b960d91b608482015260a401610b31565b6001600160a01b038085166000908152609960205260409020600101541680158015906132d95750336001600160a01b03821614155b80156132ee5750336001600160a01b03861614155b1561345b57428460200151101561336d5760405162461bcd60e51b815260206004820152603760248201527f44656c65676174696f6e4d616e616765722e5f64656c65676174653a2061707060448201527f726f766572207369676e617475726520657870697265640000000000000000006064820152608401610b31565b6001600160a01b0381166000908152609c6020908152604080832086845290915290205460ff16156134075760405162461bcd60e51b815260206004820152603760248201527f44656c65676174696f6e4d616e616765722e5f64656c65676174653a2061707060448201527f726f76657253616c7420616c7265616479207370656e740000000000000000006064820152608401610b31565b6001600160a01b0381166000908152609c6020908152604080832086845282528220805460ff19166001179055850151613448908890889085908890610a43565b905061345982828760000151614430565b505b6001600160a01b038681166000818152609a602052604080822080546001600160a01b031916948a169485179055517fc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d87433049190a36000806134ba88611de6565b9150915060005b82518110156113e257613508888a8584815181106134e1576134e1615765565b60200260200101518585815181106134fb576134fb615765565b6020026020010151613bcb565b6001016134c1565b6001600160a01b03811661359e5760405162461bcd60e51b815260206004820152604960248201527f5061757361626c652e5f73657450617573657252656769737472793a206e657760448201527f50617573657252656769737472792063616e6e6f7420626520746865207a65726064820152686f206164647265737360b81b608482015260a401610b31565b606554604080516001600160a01b03928316815291831660208301527f6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6910160405180910390a1606580546001600160a01b0319166001600160a01b0392909216919091179055565b6001600160a01b0380851660009081526098602090815260408083209386168352929052908120805483929061363e908490615ce9565b92505081905550836001600160a01b03167f6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd848484604051610fb093929190615d00565b6033546001600160a01b03163314611a7a5760405162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e65726044820152606401610b31565b8281146137645760405162461bcd60e51b815260206004820152604a60248201527f44656c65676174696f6e4d616e616765722e5f7365745374726174656779576960448201527f746864726177616c44656c6179426c6f636b733a20696e707574206c656e67746064820152690d040dad2e6dac2e8c6d60b31b608482015260a401610b31565b8260005b818110156138fa57600086868381811061378457613784615765565b90506020020160208101906137999190614c8c565b6001600160a01b038116600090815260a160205260408120549192508686858181106137c7576137c7615765565b90506020020135905062034bc081111561388b5760405162461bcd60e51b815260206004820152607360248201527f44656c65676174696f6e4d616e616765722e5f7365745374726174656779576960448201527f746864726177616c44656c6179426c6f636b733a205f7769746864726177616c60648201527f44656c6179426c6f636b732063616e6e6f74206265203e204d41585f5749544860848201527244524157414c5f44454c41595f424c4f434b5360681b60a482015260c401610b31565b6001600160a01b038316600081815260a160209081526040918290208490558151928352820184905281018290527f0e7efa738e8b0ce6376a0c1af471655540d2e9a81647d7b09ed823018426576d9060600160405180910390a1505050806138f390615791565b9050613768565b505050505050565b6065546001600160a01b031615801561392357506001600160a01b03821615155b6139a55760405162461bcd60e51b815260206004820152604760248201527f5061757361626c652e5f696e697469616c697a655061757365723a205f696e6960448201527f7469616c697a6550617573657228292063616e206f6e6c792062652063616c6c6064820152666564206f6e636560c81b608482015260a401610b31565b606681905560405181815233907fab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d9060200160405180910390a261199882613510565b604080518082018252600a81526922b4b3b2b72630bcb2b960b11b60209182015281517f8cad95687ba82c2ce50e74f7b754645e5117c3a5bec8151c0726d5857980a866818301527f71b625cfad44bac63b13dba07f2e1d6084ee04b6f8752101ece6126d584ee6ea81840152466060820152306080808301919091528351808303909101815260a0909101909252815191012090565b603380546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b62034bc0811115613b8a5760405162461bcd60e51b815260206004820152607160248201527f44656c65676174696f6e4d616e616765722e5f7365744d696e5769746864726160448201527f77616c44656c6179426c6f636b733a205f6d696e5769746864726177616c446560648201527f6c6179426c6f636b732063616e6e6f74206265203e204d41585f5749544844526084820152704157414c5f44454c41595f424c4f434b5360781b60a482015260c401610b31565b609d5460408051918252602082018390527fafa003cd76f87ff9d62b35beea889920f33c0c42b8d45b74954d61d50f4b6b69910160405180910390a1609d55565b6001600160a01b03808516600090815260986020908152604080832093861683529290529081208054839290613c02908490615cd1565b92505081905550836001600160a01b03167f1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c848484604051610fb093929190615d00565b6000613c5461062987615dc4565b6000818152609e602052604090205490915060ff16613cd55760405162461bcd60e51b81526020600482015260436024820152600080516020615efc83398151915260448201527f645769746864726177616c3a20616374696f6e206973206e6f7420696e20717560648201526265756560e81b608482015260a401610b31565b609d544390613cea60a0890160808a01615d24565b63ffffffff16613cfa9190615cd1565b1115613d825760405162461bcd60e51b815260206004820152605f6024820152600080516020615efc83398151915260448201527f645769746864726177616c3a206d696e5769746864726177616c44656c61794260648201527f6c6f636b7320706572696f6420686173206e6f74207965742070617373656400608482015260a401610b31565b613d926060870160408801614c8c565b6001600160a01b0316336001600160a01b031614613e1f5760405162461bcd60e51b81526020600482015260506024820152600080516020615efc83398151915260448201527f645769746864726177616c3a206f6e6c7920776974686472617765722063616e60648201526f1031b7b6b83632ba329030b1ba34b7b760811b608482015260a401610b31565b8115613ea157613e3260a0870187615803565b85149050613ea15760405162461bcd60e51b81526020600482015260426024820152600080516020615efc83398151915260448201527f645769746864726177616c3a20696e707574206c656e677468206d69736d61746064820152610c6d60f31b608482015260a401610b31565b6000818152609e60205260409020805460ff1916905581156140065760005b613ecd60a0880188615803565b9050811015614000574360a16000613ee860a08b018b615803565b85818110613ef857613ef8615765565b9050602002016020810190613f0d9190614c8c565b6001600160a01b03168152602081019190915260400160002054613f3760a08a0160808b01615d24565b63ffffffff16613f479190615cd1565b1115613f655760405162461bcd60e51b8152600401610b3190615dd6565b613ff8613f756020890189614c8c565b33613f8360a08b018b615803565b85818110613f9357613f93615765565b9050602002016020810190613fa89190614c8c565b613fb560c08c018c615803565b86818110613fc557613fc5615765565b905060200201358a8a87818110613fde57613fde615765565b9050602002016020810190613ff39190614c8c565b6145ea565b600101613ec0565b506143f5565b336000908152609a60205260408120546001600160a01b0316905b61402e60a0890189615803565b90508110156143f2574360a1600061404960a08c018c615803565b8581811061405957614059615765565b905060200201602081019061406e9190614c8c565b6001600160a01b0316815260208101919091526040016000205461409860a08b0160808c01615d24565b63ffffffff166140a89190615cd1565b11156140c65760405162461bcd60e51b8152600401610b3190615dd6565b73beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac06140e860a08a018a615803565b838181106140f8576140f8615765565b905060200201602081019061410d9190614c8c565b6001600160a01b0316141561425d57600061412b60208a018a614c8c565b905060006001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016630e81073c8361416c60c08e018e615803565b8781811061417c5761417c615765565b6040516001600160e01b031960e087901b1681526001600160a01b03909416600485015260200291909101356024830152506044016020604051808303816000875af11580156141d0573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906141f49190615ba3565b6001600160a01b038084166000908152609a602052604090205491925016801561425557614255818461422a60a08f018f615803565b8881811061423a5761423a615765565b905060200201602081019061424f9190614c8c565b85613bcb565b5050506143ea565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663c4623ea13389898581811061429f5761429f615765565b90506020020160208101906142b49190614c8c565b6142c160a08d018d615803565b868181106142d1576142d1615765565b90506020020160208101906142e69190614c8c565b6142f360c08e018e615803565b8781811061430357614303615765565b60405160e088901b6001600160e01b03191681526001600160a01b03968716600482015294861660248601529290941660448401526020909102013560648201526084019050600060405180830381600087803b15801561436357600080fd5b505af1158015614377573d6000803e3d6000fd5b505050506001600160a01b038216156143ea576143ea823361439c60a08c018c615803565b858181106143ac576143ac615765565b90506020020160208101906143c19190614c8c565b6143ce60c08d018d615803565b868181106143de576143de615765565b90506020020135613bcb565b600101614021565b50505b6040518181527fc97098c2f658800b4df29001527f7324bcdffcf6e8751a699ab920a1eced5b1d9060200160405180910390a1505050505050565b6001600160a01b0383163b1561454a57604051630b135d3f60e11b808252906001600160a01b03851690631626ba7e906144709086908690600401615e5e565b602060405180830381865afa15801561448d573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906144b19190615ebb565b6001600160e01b031916146111235760405162461bcd60e51b815260206004820152605360248201527f454950313237315369676e61747572655574696c732e636865636b5369676e6160448201527f747572655f454950313237313a2045524331323731207369676e6174757265206064820152721d995c9a599a58d85d1a5bdb8819985a5b1959606a1b608482015260a401610b31565b826001600160a01b031661455e838361472a565b6001600160a01b0316146111235760405162461bcd60e51b815260206004820152604760248201527f454950313237315369676e61747572655574696c732e636865636b5369676e6160448201527f747572655f454950313237313a207369676e6174757265206e6f742066726f6d6064820152661039b4b3b732b960c91b608482015260a401610b31565b6001600160a01b03831673beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac014156146955760405162387b1360e81b81526001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000169063387b13009061465e90889088908790600401615d00565b600060405180830381600087803b15801561467857600080fd5b505af115801561468c573d6000803e3d6000fd5b50505050614723565b60405163c608c7f360e01b81526001600160a01b03858116600483015284811660248301526044820184905282811660648301527f0000000000000000000000000000000000000000000000000000000000000000169063c608c7f390608401600060405180830381600087803b15801561470f57600080fd5b505af11580156113e2573d6000803e3d6000fd5b5050505050565b60008060006147398585614746565b91509150610a3b816147b6565b60008082516041141561477d5760208301516040840151606085015160001a61477187828585614971565b945094505050506147af565b8251604014156147a7576020830151604084015161479c868383614a5e565b9350935050506147af565b506000905060025b9250929050565b60008160048111156147ca576147ca615ee5565b14156147d35750565b60018160048111156147e7576147e7615ee5565b14156148355760405162461bcd60e51b815260206004820152601860248201527f45434453413a20696e76616c6964207369676e617475726500000000000000006044820152606401610b31565b600281600481111561484957614849615ee5565b14156148975760405162461bcd60e51b815260206004820152601f60248201527f45434453413a20696e76616c6964207369676e6174757265206c656e677468006044820152606401610b31565b60038160048111156148ab576148ab615ee5565b14156149045760405162461bcd60e51b815260206004820152602260248201527f45434453413a20696e76616c6964207369676e6174757265202773272076616c604482015261756560f01b6064820152608401610b31565b600481600481111561491857614918615ee5565b141561106e5760405162461bcd60e51b815260206004820152602260248201527f45434453413a20696e76616c6964207369676e6174757265202776272076616c604482015261756560f01b6064820152608401610b31565b6000807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08311156149a85750600090506003614a55565b8460ff16601b141580156149c057508460ff16601c14155b156149d15750600090506004614a55565b6040805160008082526020820180845289905260ff881692820192909252606081018690526080810185905260019060a0016020604051602081039080840390855afa158015614a25573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b038116614a4e57600060019250925050614a55565b9150600090505b94509492505050565b6000806001600160ff1b03831681614a7b60ff86901c601b615cd1565b9050614a8987828885614971565b935093505050935093915050565b60008083601f840112614aa957600080fd5b5081356001600160401b03811115614ac057600080fd5b6020830191508360208260051b85010111156147af57600080fd5b60008060208385031215614aee57600080fd5b82356001600160401b03811115614b0457600080fd5b614b1085828601614a97565b90969095509350505050565b6001600160a01b038116811461106e57600080fd5b8035614b3c81614b1c565b919050565b600080600080600060a08688031215614b5957600080fd5b8535614b6481614b1c565b94506020860135614b7481614b1c565b93506040860135614b8481614b1c565b94979396509394606081013594506080013592915050565b6020808252825182820181905260009190848201906040850190845b81811015614bd457835183529284019291840191600101614bb8565b50909695505050505050565b600060608284031215614bf257600080fd5b50919050565b60008083601f840112614c0a57600080fd5b5081356001600160401b03811115614c2157600080fd5b6020830191508360208285010111156147af57600080fd5b600080600060808486031215614c4e57600080fd5b614c588585614be0565b925060608401356001600160401b03811115614c7357600080fd5b614c7f86828701614bf8565b9497909650939450505050565b600060208284031215614c9e57600080fd5b8135614ca981614b1c565b9392505050565b600080600060608486031215614cc557600080fd5b8335614cd081614b1c565b92506020840135614ce081614b1c565b929592945050506040919091013590565b600060208284031215614d0357600080fd5b5035919050565b60008060008060408587031215614d2057600080fd5b84356001600160401b0380821115614d3757600080fd5b614d4388838901614a97565b90965094506020870135915080821115614d5c57600080fd5b50614d6987828801614a97565b95989497509550505050565b60008060008060008060008060c0898b031215614d9157600080fd5b8835614d9c81614b1c565b97506020890135614dac81614b1c565b9650604089013595506060890135945060808901356001600160401b0380821115614dd657600080fd5b614de28c838d01614a97565b909650945060a08b0135915080821115614dfb57600080fd5b50614e088b828c01614a97565b999c989b5096995094979396929594505050565b6000806000806000806000806080898b031215614e3857600080fd5b88356001600160401b0380821115614e4f57600080fd5b614e5b8c838d01614a97565b909a50985060208b0135915080821115614e7457600080fd5b614e808c838d01614a97565b909850965060408b0135915080821115614e9957600080fd5b614ea58c838d01614a97565b909650945060608b0135915080821115614dfb57600080fd5b634e487b7160e01b600052604160045260246000fd5b60405160e081016001600160401b0381118282101715614ef657614ef6614ebe565b60405290565b604080519081016001600160401b0381118282101715614ef657614ef6614ebe565b60405160c081016001600160401b0381118282101715614ef657614ef6614ebe565b604051601f8201601f191681016001600160401b0381118282101715614f6857614f68614ebe565b604052919050565b63ffffffff8116811461106e57600080fd5b8035614b3c81614f70565b60006001600160401b03821115614fa657614fa6614ebe565b5060051b60200190565b600082601f830112614fc157600080fd5b81356020614fd6614fd183614f8d565b614f40565b82815260059290921b84018101918181019086841115614ff557600080fd5b8286015b8481101561501957803561500c81614b1c565b8352918301918301614ff9565b509695505050505050565b600082601f83011261503557600080fd5b81356020615045614fd183614f8d565b82815260059290921b8401810191818101908684111561506457600080fd5b8286015b848110156150195780358352918301918301615068565b600060e0828403121561509157600080fd5b615099614ed4565b90506150a482614b31565b81526150b260208301614b31565b60208201526150c360408301614b31565b6040820152606082013560608201526150de60808301614f82565b608082015260a08201356001600160401b03808211156150fd57600080fd5b61510985838601614fb0565b60a084015260c084013591508082111561512257600080fd5b5061512f84828501615024565b60c08301525092915050565b60006020828403121561514d57600080fd5b81356001600160401b0381111561516357600080fd5b61516f8482850161507f565b949350505050565b60006020828403121561518957600080fd5b813560ff81168114614ca957600080fd5b6000604082840312156151ac57600080fd5b6151b4614efc565b905081356151c181614b1c565b815260208201356bffffffffffffffffffffffff811681146151e257600080fd5b602082015292915050565b6000602080838503121561520057600080fd5b82356001600160401b038082111561521757600080fd5b818501915085601f83011261522b57600080fd5b8135615239614fd182614f8d565b81815260059190911b8301840190848101908883111561525857600080fd5b8585015b83811015615332578035858111156152745760008081fd5b860160e0818c03601f190181131561528c5760008081fd5b615294614f1e565b89830135888111156152a65760008081fd5b6152b48e8c83870101614fb0565b825250604080840135898111156152cb5760008081fd5b6152d98f8d83880101615024565b8c8401525060606152eb818601614b31565b82840152608091506152ff8f83870161519a565b9083015261530f60c08501614f82565b9082015261531e838301614b31565b60a08201528552505091860191860161525c565b5098975050505050505050565b801515811461106e57600080fd5b60008060008060006080868803121561536557600080fd5b85356001600160401b038082111561537c57600080fd5b9087019060e0828a03121561539057600080fd5b909550602087013590808211156153a657600080fd5b506153b388828901614a97565b9095509350506040860135915060608601356153ce8161533f565b809150509295509295909350565b600080604083850312156153ef57600080fd5b82356153fa81614b1c565b9150602083013561540a81614b1c565b809150509250929050565b60006040828403121561542757600080fd5b61542f614efc565b905081356001600160401b038082111561544857600080fd5b818401915084601f83011261545c57600080fd5b813560208282111561547057615470614ebe565b615482601f8301601f19168201614f40565b9250818352868183860101111561549857600080fd5b8181850182850137600081838501015282855280860135818601525050505092915050565b600080600080600060a086880312156154d557600080fd5b85356154e081614b1c565b945060208601356154f081614b1c565b935060408601356001600160401b038082111561550c57600080fd5b61551889838a01615415565b9450606088013591508082111561552e57600080fd5b5061553b88828901615415565b95989497509295608001359392505050565b6000806040838503121561556057600080fd5b823561556b81614b1c565b915060208301356001600160401b0381111561558657600080fd5b61559285828601614fb0565b9150509250929050565b600081518084526020808501945080840160005b838110156155cc578151875295820195908201906001016155b0565b509495945050505050565b602081526000614ca9602083018461559c565b600080602083850312156155fd57600080fd5b82356001600160401b0381111561561357600080fd5b614b1085828601614bf8565b6000806040838503121561563257600080fd5b823561563d81614b1c565b946020939093013593505050565b6000806000806080858703121561566157600080fd5b843561566c81614b1c565b935060208501359250604085013561568381614b1c565b9396929550929360600135925050565b600081518084526020808501945080840160005b838110156155cc5781516001600160a01b0316875295820195908201906001016156a7565b6040815260006156df6040830185615693565b82810360208401526112a0818561559c565b60008060006060848603121561570657600080fd5b833561571181614b1c565b925060208401356001600160401b0381111561572c57600080fd5b61573886828701615415565b925050604084013590509250925092565b60006060828403121561575b57600080fd5b614ca98383614be0565b634e487b7160e01b600052603260045260246000fd5b634e487b7160e01b600052601160045260246000fd5b60006000198214156157a5576157a561577b565b5060010190565b60208082526019908201527f5061757361626c653a20696e6465782069732070617573656400000000000000604082015260600190565b60008235605e198336030181126157f957600080fd5b9190910192915050565b6000808335601e1984360301811261581a57600080fd5b8301803591506001600160401b0382111561583457600080fd5b6020019150600581901b36038213156147af57600080fd5b60608101823561585b81614b1c565b6001600160a01b03908116835260208401359061587782614b1c565b166020830152604083013561588b81614f70565b63ffffffff811660408401525092915050565b60208152816020820152818360408301376000818301604090810191909152601f909201601f19160101919050565b6000602082840312156158df57600080fd5b8151614ca981614b1c565b6020808252602a908201527f6d73672e73656e646572206973206e6f74207065726d697373696f6e6564206160408201526939903ab73830bab9b2b960b11b606082015260800190565b60208082526037908201527f44656c65676174696f6e4d616e616765723a206f6e6c7953747261746567794d60408201527f616e616765724f72456967656e506f644d616e61676572000000000000000000606082015260800190565b6000602082840312156159a357600080fd5b8151614ca98161533f565b60208082526028908201527f6d73672e73656e646572206973206e6f74207065726d697373696f6e6564206160408201526739903830bab9b2b960c11b606082015260800190565b6000823560de198336030181126157f957600080fd5b600060208284031215615a1e57600080fd5b8135614ca98161533f565b600060018060a01b03808351168452806020840151166020850152806040840151166040850152506060820151606084015263ffffffff608083015116608084015260a082015160e060a0850152615a8460e0850182615693565b905060c083015184820360c08601526112a0828261559c565b602081526000614ca96020830184615a29565b602081526000825160e06020840152615acd610100840182615693565b90506020840151601f19848303016040850152615aea828261559c565b915050604084015160018060a01b03808216606086015260608601519150808251166080860152506bffffffffffffffffffffffff60208201511660a0850152506080840151615b4260c085018263ffffffff169052565b5060a08401516001600160a01b03811660e0850152610a3b565b60008060408385031215615b6f57600080fd5b8251615b7a8161533f565b6020939093015192949293505050565b82815260406020820152600061516f6040830184615a29565b600060208284031215615bb557600080fd5b5051919050565b600082601f830112615bcd57600080fd5b81516020615bdd614fd183614f8d565b82815260059290921b84018101918181019086841115615bfc57600080fd5b8286015b848110156150195780518352918301918301615c00565b60008060408385031215615c2a57600080fd5b82516001600160401b0380821115615c4157600080fd5b818501915085601f830112615c5557600080fd5b81516020615c65614fd183614f8d565b82815260059290921b84018101918181019089841115615c8457600080fd5b948201945b83861015615cab578551615c9c81614b1c565b82529482019490820190615c89565b91880151919650909350505080821115615cc457600080fd5b5061559285828601615bbc565b60008219821115615ce457615ce461577b565b500190565b600082821015615cfb57615cfb61577b565b500390565b6001600160a01b039384168152919092166020820152604081019190915260600190565b600060208284031215615d3657600080fd5b8135614ca981614f70565b80546001600160a01b0319166001600160a01b0392909216919091179055565b8135615d6c81614b1c565b615d768183615d41565b50600181016020830135615d8981614b1c565b615d938183615d41565b506040830135615da281614f70565b815463ffffffff60a01b191660a09190911b63ffffffff60a01b161790555050565b6000615dd0368361507f565b92915050565b6020808252606e90820152600080516020615efc83398151915260408201527f645769746864726177616c3a207769746864726177616c44656c6179426c6f6360608201527f6b7320706572696f6420686173206e6f74207965742070617373656420666f7260808201526d207468697320737472617465677960901b60a082015260c00190565b82815260006020604081840152835180604085015260005b81811015615e9257858101830151858201606001528201615e76565b81811115615ea4576000606083870101525b50601f01601f191692909201606001949350505050565b600060208284031215615ecd57600080fd5b81516001600160e01b031981168114614ca957600080fd5b634e487b7160e01b600052602160045260246000fdfe44656c65676174696f6e4d616e616765722e5f636f6d706c6574655175657565a2646970667358221220680acf892215031d4b3cb5685bd4eb376f14a3a7578ba3d1ca07cf150f2333ca64736f6c634300080c0033",
+}
+
+// DelegationManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use DelegationManagerMetaData.ABI instead.
+var DelegationManagerABI = DelegationManagerMetaData.ABI
+
+// DelegationManagerBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use DelegationManagerMetaData.Bin instead.
+var DelegationManagerBin = DelegationManagerMetaData.Bin
+
+// DeployDelegationManager deploys a new Ethereum contract, binding an instance of DelegationManager to it.
+func DeployDelegationManager(auth *bind.TransactOpts, backend bind.ContractBackend, _strategyManager common.Address, _slasher common.Address, _eigenPodManager common.Address) (common.Address, *types.Transaction, *DelegationManager, error) {
+	parsed, err := DelegationManagerMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(DelegationManagerBin), backend, _strategyManager, _slasher, _eigenPodManager)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &DelegationManager{DelegationManagerCaller: DelegationManagerCaller{contract: contract}, DelegationManagerTransactor: DelegationManagerTransactor{contract: contract}, DelegationManagerFilterer: DelegationManagerFilterer{contract: contract}}, nil
+}
+
+// DelegationManager is an auto generated Go binding around an Ethereum contract.
+type DelegationManager struct {
+	DelegationManagerCaller     // Read-only binding to the contract
+	DelegationManagerTransactor // Write-only binding to the contract
+	DelegationManagerFilterer   // Log filterer for contract events
+}
+
+// DelegationManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type DelegationManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type DelegationManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type DelegationManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type DelegationManagerSession struct {
+	Contract     *DelegationManager // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// DelegationManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type DelegationManagerCallerSession struct {
+	Contract *DelegationManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// DelegationManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type DelegationManagerTransactorSession struct {
+	Contract     *DelegationManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// DelegationManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type DelegationManagerRaw struct {
+	Contract *DelegationManager // Generic contract binding to access the raw methods on
+}
+
+// DelegationManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type DelegationManagerCallerRaw struct {
+	Contract *DelegationManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// DelegationManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type DelegationManagerTransactorRaw struct {
+	Contract *DelegationManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewDelegationManager creates a new instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManager(address common.Address, backend bind.ContractBackend) (*DelegationManager, error) {
+	contract, err := bindDelegationManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManager{DelegationManagerCaller: DelegationManagerCaller{contract: contract}, DelegationManagerTransactor: DelegationManagerTransactor{contract: contract}, DelegationManagerFilterer: DelegationManagerFilterer{contract: contract}}, nil
+}
+
+// NewDelegationManagerCaller creates a new read-only instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManagerCaller(address common.Address, caller bind.ContractCaller) (*DelegationManagerCaller, error) {
+	contract, err := bindDelegationManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerCaller{contract: contract}, nil
+}
+
+// NewDelegationManagerTransactor creates a new write-only instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*DelegationManagerTransactor, error) {
+	contract, err := bindDelegationManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerTransactor{contract: contract}, nil
+}
+
+// NewDelegationManagerFilterer creates a new log filterer instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*DelegationManagerFilterer, error) {
+	contract, err := bindDelegationManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerFilterer{contract: contract}, nil
+}
+
+// bindDelegationManager binds a generic wrapper to an already deployed contract.
+func bindDelegationManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := DelegationManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_DelegationManager *DelegationManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _DelegationManager.Contract.DelegationManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_DelegationManager *DelegationManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegationManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_DelegationManager *DelegationManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegationManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_DelegationManager *DelegationManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _DelegationManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_DelegationManager *DelegationManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_DelegationManager *DelegationManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _DelegationManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// DELEGATIONAPPROVALTYPEHASH is a free data retrieval call binding the contract method 0x04a4f979.
+//
+// Solidity: function DELEGATION_APPROVAL_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) DELEGATIONAPPROVALTYPEHASH(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "DELEGATION_APPROVAL_TYPEHASH")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DELEGATIONAPPROVALTYPEHASH is a free data retrieval call binding the contract method 0x04a4f979.
+//
+// Solidity: function DELEGATION_APPROVAL_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) DELEGATIONAPPROVALTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.DELEGATIONAPPROVALTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// DELEGATIONAPPROVALTYPEHASH is a free data retrieval call binding the contract method 0x04a4f979.
+//
+// Solidity: function DELEGATION_APPROVAL_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) DELEGATIONAPPROVALTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.DELEGATIONAPPROVALTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// DOMAINTYPEHASH is a free data retrieval call binding the contract method 0x20606b70.
+//
+// Solidity: function DOMAIN_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) DOMAINTYPEHASH(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "DOMAIN_TYPEHASH")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DOMAINTYPEHASH is a free data retrieval call binding the contract method 0x20606b70.
+//
+// Solidity: function DOMAIN_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) DOMAINTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.DOMAINTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// DOMAINTYPEHASH is a free data retrieval call binding the contract method 0x20606b70.
+//
+// Solidity: function DOMAIN_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) DOMAINTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.DOMAINTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// MAXSTAKEROPTOUTWINDOWBLOCKS is a free data retrieval call binding the contract method 0x4fc40b61.
+//
+// Solidity: function MAX_STAKER_OPT_OUT_WINDOW_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) MAXSTAKEROPTOUTWINDOWBLOCKS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "MAX_STAKER_OPT_OUT_WINDOW_BLOCKS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXSTAKEROPTOUTWINDOWBLOCKS is a free data retrieval call binding the contract method 0x4fc40b61.
+//
+// Solidity: function MAX_STAKER_OPT_OUT_WINDOW_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) MAXSTAKEROPTOUTWINDOWBLOCKS() (*big.Int, error) {
+	return _DelegationManager.Contract.MAXSTAKEROPTOUTWINDOWBLOCKS(&_DelegationManager.CallOpts)
+}
+
+// MAXSTAKEROPTOUTWINDOWBLOCKS is a free data retrieval call binding the contract method 0x4fc40b61.
+//
+// Solidity: function MAX_STAKER_OPT_OUT_WINDOW_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) MAXSTAKEROPTOUTWINDOWBLOCKS() (*big.Int, error) {
+	return _DelegationManager.Contract.MAXSTAKEROPTOUTWINDOWBLOCKS(&_DelegationManager.CallOpts)
+}
+
+// MAXWITHDRAWALDELAYBLOCKS is a free data retrieval call binding the contract method 0xca661c04.
+//
+// Solidity: function MAX_WITHDRAWAL_DELAY_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) MAXWITHDRAWALDELAYBLOCKS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "MAX_WITHDRAWAL_DELAY_BLOCKS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXWITHDRAWALDELAYBLOCKS is a free data retrieval call binding the contract method 0xca661c04.
+//
+// Solidity: function MAX_WITHDRAWAL_DELAY_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) MAXWITHDRAWALDELAYBLOCKS() (*big.Int, error) {
+	return _DelegationManager.Contract.MAXWITHDRAWALDELAYBLOCKS(&_DelegationManager.CallOpts)
+}
+
+// MAXWITHDRAWALDELAYBLOCKS is a free data retrieval call binding the contract method 0xca661c04.
+//
+// Solidity: function MAX_WITHDRAWAL_DELAY_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) MAXWITHDRAWALDELAYBLOCKS() (*big.Int, error) {
+	return _DelegationManager.Contract.MAXWITHDRAWALDELAYBLOCKS(&_DelegationManager.CallOpts)
+}
+
+// STAKERDELEGATIONTYPEHASH is a free data retrieval call binding the contract method 0x43377382.
+//
+// Solidity: function STAKER_DELEGATION_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) STAKERDELEGATIONTYPEHASH(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "STAKER_DELEGATION_TYPEHASH")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// STAKERDELEGATIONTYPEHASH is a free data retrieval call binding the contract method 0x43377382.
+//
+// Solidity: function STAKER_DELEGATION_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) STAKERDELEGATIONTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.STAKERDELEGATIONTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// STAKERDELEGATIONTYPEHASH is a free data retrieval call binding the contract method 0x43377382.
+//
+// Solidity: function STAKER_DELEGATION_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) STAKERDELEGATIONTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.STAKERDELEGATIONTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// BeaconChainETHStrategy is a free data retrieval call binding the contract method 0x9104c319.
+//
+// Solidity: function beaconChainETHStrategy() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) BeaconChainETHStrategy(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "beaconChainETHStrategy")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// BeaconChainETHStrategy is a free data retrieval call binding the contract method 0x9104c319.
+//
+// Solidity: function beaconChainETHStrategy() view returns(address)
+func (_DelegationManager *DelegationManagerSession) BeaconChainETHStrategy() (common.Address, error) {
+	return _DelegationManager.Contract.BeaconChainETHStrategy(&_DelegationManager.CallOpts)
+}
+
+// BeaconChainETHStrategy is a free data retrieval call binding the contract method 0x9104c319.
+//
+// Solidity: function beaconChainETHStrategy() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) BeaconChainETHStrategy() (common.Address, error) {
+	return _DelegationManager.Contract.BeaconChainETHStrategy(&_DelegationManager.CallOpts)
+}
+
+// CalculateCurrentStakerDelegationDigestHash is a free data retrieval call binding the contract method 0x1bbce091.
+//
+// Solidity: function calculateCurrentStakerDelegationDigestHash(address staker, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateCurrentStakerDelegationDigestHash(opts *bind.CallOpts, staker common.Address, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateCurrentStakerDelegationDigestHash", staker, operator, expiry)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateCurrentStakerDelegationDigestHash is a free data retrieval call binding the contract method 0x1bbce091.
+//
+// Solidity: function calculateCurrentStakerDelegationDigestHash(address staker, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateCurrentStakerDelegationDigestHash(staker common.Address, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateCurrentStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, operator, expiry)
+}
+
+// CalculateCurrentStakerDelegationDigestHash is a free data retrieval call binding the contract method 0x1bbce091.
+//
+// Solidity: function calculateCurrentStakerDelegationDigestHash(address staker, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateCurrentStakerDelegationDigestHash(staker common.Address, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateCurrentStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, operator, expiry)
+}
+
+// CalculateDelegationApprovalDigestHash is a free data retrieval call binding the contract method 0x0b9f487a.
+//
+// Solidity: function calculateDelegationApprovalDigestHash(address staker, address operator, address _delegationApprover, bytes32 approverSalt, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateDelegationApprovalDigestHash(opts *bind.CallOpts, staker common.Address, operator common.Address, _delegationApprover common.Address, approverSalt [32]byte, expiry *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateDelegationApprovalDigestHash", staker, operator, _delegationApprover, approverSalt, expiry)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateDelegationApprovalDigestHash is a free data retrieval call binding the contract method 0x0b9f487a.
+//
+// Solidity: function calculateDelegationApprovalDigestHash(address staker, address operator, address _delegationApprover, bytes32 approverSalt, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateDelegationApprovalDigestHash(staker common.Address, operator common.Address, _delegationApprover common.Address, approverSalt [32]byte, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateDelegationApprovalDigestHash(&_DelegationManager.CallOpts, staker, operator, _delegationApprover, approverSalt, expiry)
+}
+
+// CalculateDelegationApprovalDigestHash is a free data retrieval call binding the contract method 0x0b9f487a.
+//
+// Solidity: function calculateDelegationApprovalDigestHash(address staker, address operator, address _delegationApprover, bytes32 approverSalt, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateDelegationApprovalDigestHash(staker common.Address, operator common.Address, _delegationApprover common.Address, approverSalt [32]byte, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateDelegationApprovalDigestHash(&_DelegationManager.CallOpts, staker, operator, _delegationApprover, approverSalt, expiry)
+}
+
+// CalculateStakerDelegationDigestHash is a free data retrieval call binding the contract method 0xc94b5111.
+//
+// Solidity: function calculateStakerDelegationDigestHash(address staker, uint256 _stakerNonce, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateStakerDelegationDigestHash(opts *bind.CallOpts, staker common.Address, _stakerNonce *big.Int, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateStakerDelegationDigestHash", staker, _stakerNonce, operator, expiry)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateStakerDelegationDigestHash is a free data retrieval call binding the contract method 0xc94b5111.
+//
+// Solidity: function calculateStakerDelegationDigestHash(address staker, uint256 _stakerNonce, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateStakerDelegationDigestHash(staker common.Address, _stakerNonce *big.Int, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, _stakerNonce, operator, expiry)
+}
+
+// CalculateStakerDelegationDigestHash is a free data retrieval call binding the contract method 0xc94b5111.
+//
+// Solidity: function calculateStakerDelegationDigestHash(address staker, uint256 _stakerNonce, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateStakerDelegationDigestHash(staker common.Address, _stakerNonce *big.Int, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, _stakerNonce, operator, expiry)
+}
+
+// CalculateWithdrawalRoot is a free data retrieval call binding the contract method 0x597b36da.
+//
+// Solidity: function calculateWithdrawalRoot((address,address,address,uint256,uint32,address[],uint256[]) withdrawal) pure returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateWithdrawalRoot(opts *bind.CallOpts, withdrawal IDelegationManagerWithdrawal) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateWithdrawalRoot", withdrawal)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateWithdrawalRoot is a free data retrieval call binding the contract method 0x597b36da.
+//
+// Solidity: function calculateWithdrawalRoot((address,address,address,uint256,uint32,address[],uint256[]) withdrawal) pure returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateWithdrawalRoot(withdrawal IDelegationManagerWithdrawal) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateWithdrawalRoot(&_DelegationManager.CallOpts, withdrawal)
+}
+
+// CalculateWithdrawalRoot is a free data retrieval call binding the contract method 0x597b36da.
+//
+// Solidity: function calculateWithdrawalRoot((address,address,address,uint256,uint32,address[],uint256[]) withdrawal) pure returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateWithdrawalRoot(withdrawal IDelegationManagerWithdrawal) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateWithdrawalRoot(&_DelegationManager.CallOpts, withdrawal)
+}
+
+// CumulativeWithdrawalsQueued is a free data retrieval call binding the contract method 0xa1788484.
+//
+// Solidity: function cumulativeWithdrawalsQueued(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) CumulativeWithdrawalsQueued(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "cumulativeWithdrawalsQueued", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CumulativeWithdrawalsQueued is a free data retrieval call binding the contract method 0xa1788484.
+//
+// Solidity: function cumulativeWithdrawalsQueued(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) CumulativeWithdrawalsQueued(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.CumulativeWithdrawalsQueued(&_DelegationManager.CallOpts, arg0)
+}
+
+// CumulativeWithdrawalsQueued is a free data retrieval call binding the contract method 0xa1788484.
+//
+// Solidity: function cumulativeWithdrawalsQueued(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) CumulativeWithdrawalsQueued(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.CumulativeWithdrawalsQueued(&_DelegationManager.CallOpts, arg0)
+}
+
+// DelegatedTo is a free data retrieval call binding the contract method 0x65da1264.
+//
+// Solidity: function delegatedTo(address ) view returns(address)
+func (_DelegationManager *DelegationManagerCaller) DelegatedTo(opts *bind.CallOpts, arg0 common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "delegatedTo", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// DelegatedTo is a free data retrieval call binding the contract method 0x65da1264.
+//
+// Solidity: function delegatedTo(address ) view returns(address)
+func (_DelegationManager *DelegationManagerSession) DelegatedTo(arg0 common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegatedTo(&_DelegationManager.CallOpts, arg0)
+}
+
+// DelegatedTo is a free data retrieval call binding the contract method 0x65da1264.
+//
+// Solidity: function delegatedTo(address ) view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) DelegatedTo(arg0 common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegatedTo(&_DelegationManager.CallOpts, arg0)
+}
+
+// DelegationApprover is a free data retrieval call binding the contract method 0x3cdeb5e0.
+//
+// Solidity: function delegationApprover(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerCaller) DelegationApprover(opts *bind.CallOpts, operator common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "delegationApprover", operator)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// DelegationApprover is a free data retrieval call binding the contract method 0x3cdeb5e0.
+//
+// Solidity: function delegationApprover(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerSession) DelegationApprover(operator common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegationApprover(&_DelegationManager.CallOpts, operator)
+}
+
+// DelegationApprover is a free data retrieval call binding the contract method 0x3cdeb5e0.
+//
+// Solidity: function delegationApprover(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) DelegationApprover(operator common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegationApprover(&_DelegationManager.CallOpts, operator)
+}
+
+// DelegationApproverSaltIsSpent is a free data retrieval call binding the contract method 0xbb45fef2.
+//
+// Solidity: function delegationApproverSaltIsSpent(address , bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) DelegationApproverSaltIsSpent(opts *bind.CallOpts, arg0 common.Address, arg1 [32]byte) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "delegationApproverSaltIsSpent", arg0, arg1)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// DelegationApproverSaltIsSpent is a free data retrieval call binding the contract method 0xbb45fef2.
+//
+// Solidity: function delegationApproverSaltIsSpent(address , bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) DelegationApproverSaltIsSpent(arg0 common.Address, arg1 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.DelegationApproverSaltIsSpent(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// DelegationApproverSaltIsSpent is a free data retrieval call binding the contract method 0xbb45fef2.
+//
+// Solidity: function delegationApproverSaltIsSpent(address , bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) DelegationApproverSaltIsSpent(arg0 common.Address, arg1 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.DelegationApproverSaltIsSpent(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) DomainSeparator(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "domainSeparator")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) DomainSeparator() ([32]byte, error) {
+	return _DelegationManager.Contract.DomainSeparator(&_DelegationManager.CallOpts)
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) DomainSeparator() ([32]byte, error) {
+	return _DelegationManager.Contract.DomainSeparator(&_DelegationManager.CallOpts)
+}
+
+// EarningsReceiver is a free data retrieval call binding the contract method 0x5f966f14.
+//
+// Solidity: function earningsReceiver(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerCaller) EarningsReceiver(opts *bind.CallOpts, operator common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "earningsReceiver", operator)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// EarningsReceiver is a free data retrieval call binding the contract method 0x5f966f14.
+//
+// Solidity: function earningsReceiver(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerSession) EarningsReceiver(operator common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.EarningsReceiver(&_DelegationManager.CallOpts, operator)
+}
+
+// EarningsReceiver is a free data retrieval call binding the contract method 0x5f966f14.
+//
+// Solidity: function earningsReceiver(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) EarningsReceiver(operator common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.EarningsReceiver(&_DelegationManager.CallOpts, operator)
+}
+
+// EigenPodManager is a free data retrieval call binding the contract method 0x4665bcda.
+//
+// Solidity: function eigenPodManager() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) EigenPodManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "eigenPodManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// EigenPodManager is a free data retrieval call binding the contract method 0x4665bcda.
+//
+// Solidity: function eigenPodManager() view returns(address)
+func (_DelegationManager *DelegationManagerSession) EigenPodManager() (common.Address, error) {
+	return _DelegationManager.Contract.EigenPodManager(&_DelegationManager.CallOpts)
+}
+
+// EigenPodManager is a free data retrieval call binding the contract method 0x4665bcda.
+//
+// Solidity: function eigenPodManager() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) EigenPodManager() (common.Address, error) {
+	return _DelegationManager.Contract.EigenPodManager(&_DelegationManager.CallOpts)
+}
+
+// GetDelegatableShares is a free data retrieval call binding the contract method 0xcf80873e.
+//
+// Solidity: function getDelegatableShares(address staker) view returns(address[], uint256[])
+func (_DelegationManager *DelegationManagerCaller) GetDelegatableShares(opts *bind.CallOpts, staker common.Address) ([]common.Address, []*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getDelegatableShares", staker)
+
+	if err != nil {
+		return *new([]common.Address), *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+	out1 := *abi.ConvertType(out[1], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, out1, err
+
+}
+
+// GetDelegatableShares is a free data retrieval call binding the contract method 0xcf80873e.
+//
+// Solidity: function getDelegatableShares(address staker) view returns(address[], uint256[])
+func (_DelegationManager *DelegationManagerSession) GetDelegatableShares(staker common.Address) ([]common.Address, []*big.Int, error) {
+	return _DelegationManager.Contract.GetDelegatableShares(&_DelegationManager.CallOpts, staker)
+}
+
+// GetDelegatableShares is a free data retrieval call binding the contract method 0xcf80873e.
+//
+// Solidity: function getDelegatableShares(address staker) view returns(address[], uint256[])
+func (_DelegationManager *DelegationManagerCallerSession) GetDelegatableShares(staker common.Address) ([]common.Address, []*big.Int, error) {
+	return _DelegationManager.Contract.GetDelegatableShares(&_DelegationManager.CallOpts, staker)
+}
+
+// GetOperatorShares is a free data retrieval call binding the contract method 0x90041347.
+//
+// Solidity: function getOperatorShares(address operator, address[] strategies) view returns(uint256[])
+func (_DelegationManager *DelegationManagerCaller) GetOperatorShares(opts *bind.CallOpts, operator common.Address, strategies []common.Address) ([]*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getOperatorShares", operator, strategies)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// GetOperatorShares is a free data retrieval call binding the contract method 0x90041347.
+//
+// Solidity: function getOperatorShares(address operator, address[] strategies) view returns(uint256[])
+func (_DelegationManager *DelegationManagerSession) GetOperatorShares(operator common.Address, strategies []common.Address) ([]*big.Int, error) {
+	return _DelegationManager.Contract.GetOperatorShares(&_DelegationManager.CallOpts, operator, strategies)
+}
+
+// GetOperatorShares is a free data retrieval call binding the contract method 0x90041347.
+//
+// Solidity: function getOperatorShares(address operator, address[] strategies) view returns(uint256[])
+func (_DelegationManager *DelegationManagerCallerSession) GetOperatorShares(operator common.Address, strategies []common.Address) ([]*big.Int, error) {
+	return _DelegationManager.Contract.GetOperatorShares(&_DelegationManager.CallOpts, operator, strategies)
+}
+
+// GetWithdrawalDelay is a free data retrieval call binding the contract method 0x0449ca39.
+//
+// Solidity: function getWithdrawalDelay(address[] strategies) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) GetWithdrawalDelay(opts *bind.CallOpts, strategies []common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getWithdrawalDelay", strategies)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetWithdrawalDelay is a free data retrieval call binding the contract method 0x0449ca39.
+//
+// Solidity: function getWithdrawalDelay(address[] strategies) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) GetWithdrawalDelay(strategies []common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.GetWithdrawalDelay(&_DelegationManager.CallOpts, strategies)
+}
+
+// GetWithdrawalDelay is a free data retrieval call binding the contract method 0x0449ca39.
+//
+// Solidity: function getWithdrawalDelay(address[] strategies) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) GetWithdrawalDelay(strategies []common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.GetWithdrawalDelay(&_DelegationManager.CallOpts, strategies)
+}
+
+// IsDelegated is a free data retrieval call binding the contract method 0x3e28391d.
+//
+// Solidity: function isDelegated(address staker) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) IsDelegated(opts *bind.CallOpts, staker common.Address) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "isDelegated", staker)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsDelegated is a free data retrieval call binding the contract method 0x3e28391d.
+//
+// Solidity: function isDelegated(address staker) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) IsDelegated(staker common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsDelegated(&_DelegationManager.CallOpts, staker)
+}
+
+// IsDelegated is a free data retrieval call binding the contract method 0x3e28391d.
+//
+// Solidity: function isDelegated(address staker) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) IsDelegated(staker common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsDelegated(&_DelegationManager.CallOpts, staker)
+}
+
+// IsOperator is a free data retrieval call binding the contract method 0x6d70f7ae.
+//
+// Solidity: function isOperator(address operator) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) IsOperator(opts *bind.CallOpts, operator common.Address) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "isOperator", operator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsOperator is a free data retrieval call binding the contract method 0x6d70f7ae.
+//
+// Solidity: function isOperator(address operator) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) IsOperator(operator common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsOperator(&_DelegationManager.CallOpts, operator)
+}
+
+// IsOperator is a free data retrieval call binding the contract method 0x6d70f7ae.
+//
+// Solidity: function isOperator(address operator) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) IsOperator(operator common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsOperator(&_DelegationManager.CallOpts, operator)
+}
+
+// MinWithdrawalDelayBlocks is a free data retrieval call binding the contract method 0xc448feb8.
+//
+// Solidity: function minWithdrawalDelayBlocks() view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) MinWithdrawalDelayBlocks(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "minWithdrawalDelayBlocks")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MinWithdrawalDelayBlocks is a free data retrieval call binding the contract method 0xc448feb8.
+//
+// Solidity: function minWithdrawalDelayBlocks() view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) MinWithdrawalDelayBlocks() (*big.Int, error) {
+	return _DelegationManager.Contract.MinWithdrawalDelayBlocks(&_DelegationManager.CallOpts)
+}
+
+// MinWithdrawalDelayBlocks is a free data retrieval call binding the contract method 0xc448feb8.
+//
+// Solidity: function minWithdrawalDelayBlocks() view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) MinWithdrawalDelayBlocks() (*big.Int, error) {
+	return _DelegationManager.Contract.MinWithdrawalDelayBlocks(&_DelegationManager.CallOpts)
+}
+
+// OperatorDetails is a free data retrieval call binding the contract method 0xc5e480db.
+//
+// Solidity: function operatorDetails(address operator) view returns((address,address,uint32))
+func (_DelegationManager *DelegationManagerCaller) OperatorDetails(opts *bind.CallOpts, operator common.Address) (IDelegationManagerOperatorDetails, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "operatorDetails", operator)
+
+	if err != nil {
+		return *new(IDelegationManagerOperatorDetails), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IDelegationManagerOperatorDetails)).(*IDelegationManagerOperatorDetails)
+
+	return out0, err
+
+}
+
+// OperatorDetails is a free data retrieval call binding the contract method 0xc5e480db.
+//
+// Solidity: function operatorDetails(address operator) view returns((address,address,uint32))
+func (_DelegationManager *DelegationManagerSession) OperatorDetails(operator common.Address) (IDelegationManagerOperatorDetails, error) {
+	return _DelegationManager.Contract.OperatorDetails(&_DelegationManager.CallOpts, operator)
+}
+
+// OperatorDetails is a free data retrieval call binding the contract method 0xc5e480db.
+//
+// Solidity: function operatorDetails(address operator) view returns((address,address,uint32))
+func (_DelegationManager *DelegationManagerCallerSession) OperatorDetails(operator common.Address) (IDelegationManagerOperatorDetails, error) {
+	return _DelegationManager.Contract.OperatorDetails(&_DelegationManager.CallOpts, operator)
+}
+
+// OperatorShares is a free data retrieval call binding the contract method 0x778e55f3.
+//
+// Solidity: function operatorShares(address , address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) OperatorShares(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "operatorShares", arg0, arg1)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// OperatorShares is a free data retrieval call binding the contract method 0x778e55f3.
+//
+// Solidity: function operatorShares(address , address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) OperatorShares(arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.OperatorShares(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// OperatorShares is a free data retrieval call binding the contract method 0x778e55f3.
+//
+// Solidity: function operatorShares(address , address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) OperatorShares(arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.OperatorShares(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_DelegationManager *DelegationManagerSession) Owner() (common.Address, error) {
+	return _DelegationManager.Contract.Owner(&_DelegationManager.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) Owner() (common.Address, error) {
+	return _DelegationManager.Contract.Owner(&_DelegationManager.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5ac86ab7.
+//
+// Solidity: function paused(uint8 index) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) Paused(opts *bind.CallOpts, index uint8) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "paused", index)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5ac86ab7.
+//
+// Solidity: function paused(uint8 index) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) Paused(index uint8) (bool, error) {
+	return _DelegationManager.Contract.Paused(&_DelegationManager.CallOpts, index)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5ac86ab7.
+//
+// Solidity: function paused(uint8 index) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) Paused(index uint8) (bool, error) {
+	return _DelegationManager.Contract.Paused(&_DelegationManager.CallOpts, index)
+}
+
+// Paused0 is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) Paused0(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "paused0")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Paused0 is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) Paused0() (*big.Int, error) {
+	return _DelegationManager.Contract.Paused0(&_DelegationManager.CallOpts)
+}
+
+// Paused0 is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) Paused0() (*big.Int, error) {
+	return _DelegationManager.Contract.Paused0(&_DelegationManager.CallOpts)
+}
+
+// PauserRegistry is a free data retrieval call binding the contract method 0x886f1195.
+//
+// Solidity: function pauserRegistry() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) PauserRegistry(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "pauserRegistry")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PauserRegistry is a free data retrieval call binding the contract method 0x886f1195.
+//
+// Solidity: function pauserRegistry() view returns(address)
+func (_DelegationManager *DelegationManagerSession) PauserRegistry() (common.Address, error) {
+	return _DelegationManager.Contract.PauserRegistry(&_DelegationManager.CallOpts)
+}
+
+// PauserRegistry is a free data retrieval call binding the contract method 0x886f1195.
+//
+// Solidity: function pauserRegistry() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) PauserRegistry() (common.Address, error) {
+	return _DelegationManager.Contract.PauserRegistry(&_DelegationManager.CallOpts)
+}
+
+// PendingWithdrawals is a free data retrieval call binding the contract method 0xb7f06ebe.
+//
+// Solidity: function pendingWithdrawals(bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) PendingWithdrawals(opts *bind.CallOpts, arg0 [32]byte) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "pendingWithdrawals", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// PendingWithdrawals is a free data retrieval call binding the contract method 0xb7f06ebe.
+//
+// Solidity: function pendingWithdrawals(bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) PendingWithdrawals(arg0 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.PendingWithdrawals(&_DelegationManager.CallOpts, arg0)
+}
+
+// PendingWithdrawals is a free data retrieval call binding the contract method 0xb7f06ebe.
+//
+// Solidity: function pendingWithdrawals(bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) PendingWithdrawals(arg0 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.PendingWithdrawals(&_DelegationManager.CallOpts, arg0)
+}
+
+// Slasher is a free data retrieval call binding the contract method 0xb1344271.
+//
+// Solidity: function slasher() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) Slasher(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "slasher")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Slasher is a free data retrieval call binding the contract method 0xb1344271.
+//
+// Solidity: function slasher() view returns(address)
+func (_DelegationManager *DelegationManagerSession) Slasher() (common.Address, error) {
+	return _DelegationManager.Contract.Slasher(&_DelegationManager.CallOpts)
+}
+
+// Slasher is a free data retrieval call binding the contract method 0xb1344271.
+//
+// Solidity: function slasher() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) Slasher() (common.Address, error) {
+	return _DelegationManager.Contract.Slasher(&_DelegationManager.CallOpts)
+}
+
+// StakerNonce is a free data retrieval call binding the contract method 0x29c77d4f.
+//
+// Solidity: function stakerNonce(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) StakerNonce(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "stakerNonce", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// StakerNonce is a free data retrieval call binding the contract method 0x29c77d4f.
+//
+// Solidity: function stakerNonce(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) StakerNonce(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StakerNonce(&_DelegationManager.CallOpts, arg0)
+}
+
+// StakerNonce is a free data retrieval call binding the contract method 0x29c77d4f.
+//
+// Solidity: function stakerNonce(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) StakerNonce(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StakerNonce(&_DelegationManager.CallOpts, arg0)
+}
+
+// StakerOptOutWindowBlocks is a free data retrieval call binding the contract method 0x16928365.
+//
+// Solidity: function stakerOptOutWindowBlocks(address operator) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) StakerOptOutWindowBlocks(opts *bind.CallOpts, operator common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "stakerOptOutWindowBlocks", operator)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// StakerOptOutWindowBlocks is a free data retrieval call binding the contract method 0x16928365.
+//
+// Solidity: function stakerOptOutWindowBlocks(address operator) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) StakerOptOutWindowBlocks(operator common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StakerOptOutWindowBlocks(&_DelegationManager.CallOpts, operator)
+}
+
+// StakerOptOutWindowBlocks is a free data retrieval call binding the contract method 0x16928365.
+//
+// Solidity: function stakerOptOutWindowBlocks(address operator) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) StakerOptOutWindowBlocks(operator common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StakerOptOutWindowBlocks(&_DelegationManager.CallOpts, operator)
+}
+
+// StrategyManager is a free data retrieval call binding the contract method 0x39b70e38.
+//
+// Solidity: function strategyManager() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) StrategyManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "strategyManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// StrategyManager is a free data retrieval call binding the contract method 0x39b70e38.
+//
+// Solidity: function strategyManager() view returns(address)
+func (_DelegationManager *DelegationManagerSession) StrategyManager() (common.Address, error) {
+	return _DelegationManager.Contract.StrategyManager(&_DelegationManager.CallOpts)
+}
+
+// StrategyManager is a free data retrieval call binding the contract method 0x39b70e38.
+//
+// Solidity: function strategyManager() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) StrategyManager() (common.Address, error) {
+	return _DelegationManager.Contract.StrategyManager(&_DelegationManager.CallOpts)
+}
+
+// StrategyWithdrawalDelayBlocks is a free data retrieval call binding the contract method 0xc488375a.
+//
+// Solidity: function strategyWithdrawalDelayBlocks(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) StrategyWithdrawalDelayBlocks(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "strategyWithdrawalDelayBlocks", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// StrategyWithdrawalDelayBlocks is a free data retrieval call binding the contract method 0xc488375a.
+//
+// Solidity: function strategyWithdrawalDelayBlocks(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) StrategyWithdrawalDelayBlocks(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StrategyWithdrawalDelayBlocks(&_DelegationManager.CallOpts, arg0)
+}
+
+// StrategyWithdrawalDelayBlocks is a free data retrieval call binding the contract method 0xc488375a.
+//
+// Solidity: function strategyWithdrawalDelayBlocks(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) StrategyWithdrawalDelayBlocks(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StrategyWithdrawalDelayBlocks(&_DelegationManager.CallOpts, arg0)
+}
+
+// CompleteQueuedWithdrawal is a paid mutator transaction binding the contract method 0x60d7faed.
+//
+// Solidity: function completeQueuedWithdrawal((address,address,address,uint256,uint32,address[],uint256[]) withdrawal, address[] tokens, uint256 middlewareTimesIndex, bool receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactor) CompleteQueuedWithdrawal(opts *bind.TransactOpts, withdrawal IDelegationManagerWithdrawal, tokens []common.Address, middlewareTimesIndex *big.Int, receiveAsTokens bool) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "completeQueuedWithdrawal", withdrawal, tokens, middlewareTimesIndex, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawal is a paid mutator transaction binding the contract method 0x60d7faed.
+//
+// Solidity: function completeQueuedWithdrawal((address,address,address,uint256,uint32,address[],uint256[]) withdrawal, address[] tokens, uint256 middlewareTimesIndex, bool receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerSession) CompleteQueuedWithdrawal(withdrawal IDelegationManagerWithdrawal, tokens []common.Address, middlewareTimesIndex *big.Int, receiveAsTokens bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawal(&_DelegationManager.TransactOpts, withdrawal, tokens, middlewareTimesIndex, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawal is a paid mutator transaction binding the contract method 0x60d7faed.
+//
+// Solidity: function completeQueuedWithdrawal((address,address,address,uint256,uint32,address[],uint256[]) withdrawal, address[] tokens, uint256 middlewareTimesIndex, bool receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) CompleteQueuedWithdrawal(withdrawal IDelegationManagerWithdrawal, tokens []common.Address, middlewareTimesIndex *big.Int, receiveAsTokens bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawal(&_DelegationManager.TransactOpts, withdrawal, tokens, middlewareTimesIndex, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawals is a paid mutator transaction binding the contract method 0x33404396.
+//
+// Solidity: function completeQueuedWithdrawals((address,address,address,uint256,uint32,address[],uint256[])[] withdrawals, address[][] tokens, uint256[] middlewareTimesIndexes, bool[] receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactor) CompleteQueuedWithdrawals(opts *bind.TransactOpts, withdrawals []IDelegationManagerWithdrawal, tokens [][]common.Address, middlewareTimesIndexes []*big.Int, receiveAsTokens []bool) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "completeQueuedWithdrawals", withdrawals, tokens, middlewareTimesIndexes, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawals is a paid mutator transaction binding the contract method 0x33404396.
+//
+// Solidity: function completeQueuedWithdrawals((address,address,address,uint256,uint32,address[],uint256[])[] withdrawals, address[][] tokens, uint256[] middlewareTimesIndexes, bool[] receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerSession) CompleteQueuedWithdrawals(withdrawals []IDelegationManagerWithdrawal, tokens [][]common.Address, middlewareTimesIndexes []*big.Int, receiveAsTokens []bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawals(&_DelegationManager.TransactOpts, withdrawals, tokens, middlewareTimesIndexes, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawals is a paid mutator transaction binding the contract method 0x33404396.
+//
+// Solidity: function completeQueuedWithdrawals((address,address,address,uint256,uint32,address[],uint256[])[] withdrawals, address[][] tokens, uint256[] middlewareTimesIndexes, bool[] receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) CompleteQueuedWithdrawals(withdrawals []IDelegationManagerWithdrawal, tokens [][]common.Address, middlewareTimesIndexes []*big.Int, receiveAsTokens []bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawals(&_DelegationManager.TransactOpts, withdrawals, tokens, middlewareTimesIndexes, receiveAsTokens)
+}
+
+// DecreaseDelegatedShares is a paid mutator transaction binding the contract method 0x132d4967.
+//
+// Solidity: function decreaseDelegatedShares(address staker, address strategy, uint256 shares) returns()
+func (_DelegationManager *DelegationManagerTransactor) DecreaseDelegatedShares(opts *bind.TransactOpts, staker common.Address, strategy common.Address, shares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "decreaseDelegatedShares", staker, strategy, shares)
+}
+
+// DecreaseDelegatedShares is a paid mutator transaction binding the contract method 0x132d4967.
+//
+// Solidity: function decreaseDelegatedShares(address staker, address strategy, uint256 shares) returns()
+func (_DelegationManager *DelegationManagerSession) DecreaseDelegatedShares(staker common.Address, strategy common.Address, shares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DecreaseDelegatedShares(&_DelegationManager.TransactOpts, staker, strategy, shares)
+}
+
+// DecreaseDelegatedShares is a paid mutator transaction binding the contract method 0x132d4967.
+//
+// Solidity: function decreaseDelegatedShares(address staker, address strategy, uint256 shares) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) DecreaseDelegatedShares(staker common.Address, strategy common.Address, shares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DecreaseDelegatedShares(&_DelegationManager.TransactOpts, staker, strategy, shares)
+}
+
+// DelegateTo is a paid mutator transaction binding the contract method 0xeea9064b.
+//
+// Solidity: function delegateTo(address operator, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactor) DelegateTo(opts *bind.TransactOpts, operator common.Address, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "delegateTo", operator, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateTo is a paid mutator transaction binding the contract method 0xeea9064b.
+//
+// Solidity: function delegateTo(address operator, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerSession) DelegateTo(operator common.Address, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateTo(&_DelegationManager.TransactOpts, operator, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateTo is a paid mutator transaction binding the contract method 0xeea9064b.
+//
+// Solidity: function delegateTo(address operator, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) DelegateTo(operator common.Address, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateTo(&_DelegationManager.TransactOpts, operator, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateToBySignature is a paid mutator transaction binding the contract method 0x7f548071.
+//
+// Solidity: function delegateToBySignature(address staker, address operator, (bytes,uint256) stakerSignatureAndExpiry, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactor) DelegateToBySignature(opts *bind.TransactOpts, staker common.Address, operator common.Address, stakerSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "delegateToBySignature", staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateToBySignature is a paid mutator transaction binding the contract method 0x7f548071.
+//
+// Solidity: function delegateToBySignature(address staker, address operator, (bytes,uint256) stakerSignatureAndExpiry, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerSession) DelegateToBySignature(staker common.Address, operator common.Address, stakerSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateToBySignature(&_DelegationManager.TransactOpts, staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateToBySignature is a paid mutator transaction binding the contract method 0x7f548071.
+//
+// Solidity: function delegateToBySignature(address staker, address operator, (bytes,uint256) stakerSignatureAndExpiry, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) DelegateToBySignature(staker common.Address, operator common.Address, stakerSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateToBySignature(&_DelegationManager.TransactOpts, staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, approverSalt)
+}
+
+// IncreaseDelegatedShares is a paid mutator transaction binding the contract method 0x28a573ae.
+//
+// Solidity: function increaseDelegatedShares(address staker, address strategy, uint256 shares) returns()
+func (_DelegationManager *DelegationManagerTransactor) IncreaseDelegatedShares(opts *bind.TransactOpts, staker common.Address, strategy common.Address, shares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "increaseDelegatedShares", staker, strategy, shares)
+}
+
+// IncreaseDelegatedShares is a paid mutator transaction binding the contract method 0x28a573ae.
+//
+// Solidity: function increaseDelegatedShares(address staker, address strategy, uint256 shares) returns()
+func (_DelegationManager *DelegationManagerSession) IncreaseDelegatedShares(staker common.Address, strategy common.Address, shares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.IncreaseDelegatedShares(&_DelegationManager.TransactOpts, staker, strategy, shares)
+}
+
+// IncreaseDelegatedShares is a paid mutator transaction binding the contract method 0x28a573ae.
+//
+// Solidity: function increaseDelegatedShares(address staker, address strategy, uint256 shares) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) IncreaseDelegatedShares(staker common.Address, strategy common.Address, shares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.IncreaseDelegatedShares(&_DelegationManager.TransactOpts, staker, strategy, shares)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x22bf40e4.
+//
+// Solidity: function initialize(address initialOwner, address _pauserRegistry, uint256 initialPausedStatus, uint256 _minWithdrawalDelayBlocks, address[] _strategies, uint256[] _withdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerTransactor) Initialize(opts *bind.TransactOpts, initialOwner common.Address, _pauserRegistry common.Address, initialPausedStatus *big.Int, _minWithdrawalDelayBlocks *big.Int, _strategies []common.Address, _withdrawalDelayBlocks []*big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "initialize", initialOwner, _pauserRegistry, initialPausedStatus, _minWithdrawalDelayBlocks, _strategies, _withdrawalDelayBlocks)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x22bf40e4.
+//
+// Solidity: function initialize(address initialOwner, address _pauserRegistry, uint256 initialPausedStatus, uint256 _minWithdrawalDelayBlocks, address[] _strategies, uint256[] _withdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerSession) Initialize(initialOwner common.Address, _pauserRegistry common.Address, initialPausedStatus *big.Int, _minWithdrawalDelayBlocks *big.Int, _strategies []common.Address, _withdrawalDelayBlocks []*big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Initialize(&_DelegationManager.TransactOpts, initialOwner, _pauserRegistry, initialPausedStatus, _minWithdrawalDelayBlocks, _strategies, _withdrawalDelayBlocks)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x22bf40e4.
+//
+// Solidity: function initialize(address initialOwner, address _pauserRegistry, uint256 initialPausedStatus, uint256 _minWithdrawalDelayBlocks, address[] _strategies, uint256[] _withdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) Initialize(initialOwner common.Address, _pauserRegistry common.Address, initialPausedStatus *big.Int, _minWithdrawalDelayBlocks *big.Int, _strategies []common.Address, _withdrawalDelayBlocks []*big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Initialize(&_DelegationManager.TransactOpts, initialOwner, _pauserRegistry, initialPausedStatus, _minWithdrawalDelayBlocks, _strategies, _withdrawalDelayBlocks)
+}
+
+// MigrateQueuedWithdrawals is a paid mutator transaction binding the contract method 0x5cfe8d2c.
+//
+// Solidity: function migrateQueuedWithdrawals((address[],uint256[],address,(address,uint96),uint32,address)[] withdrawalsToMigrate) returns()
+func (_DelegationManager *DelegationManagerTransactor) MigrateQueuedWithdrawals(opts *bind.TransactOpts, withdrawalsToMigrate []IStrategyManagerDeprecatedStructQueuedWithdrawal) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "migrateQueuedWithdrawals", withdrawalsToMigrate)
+}
+
+// MigrateQueuedWithdrawals is a paid mutator transaction binding the contract method 0x5cfe8d2c.
+//
+// Solidity: function migrateQueuedWithdrawals((address[],uint256[],address,(address,uint96),uint32,address)[] withdrawalsToMigrate) returns()
+func (_DelegationManager *DelegationManagerSession) MigrateQueuedWithdrawals(withdrawalsToMigrate []IStrategyManagerDeprecatedStructQueuedWithdrawal) (*types.Transaction, error) {
+	return _DelegationManager.Contract.MigrateQueuedWithdrawals(&_DelegationManager.TransactOpts, withdrawalsToMigrate)
+}
+
+// MigrateQueuedWithdrawals is a paid mutator transaction binding the contract method 0x5cfe8d2c.
+//
+// Solidity: function migrateQueuedWithdrawals((address[],uint256[],address,(address,uint96),uint32,address)[] withdrawalsToMigrate) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) MigrateQueuedWithdrawals(withdrawalsToMigrate []IStrategyManagerDeprecatedStructQueuedWithdrawal) (*types.Transaction, error) {
+	return _DelegationManager.Contract.MigrateQueuedWithdrawals(&_DelegationManager.TransactOpts, withdrawalsToMigrate)
+}
+
+// ModifyOperatorDetails is a paid mutator transaction binding the contract method 0xf16172b0.
+//
+// Solidity: function modifyOperatorDetails((address,address,uint32) newOperatorDetails) returns()
+func (_DelegationManager *DelegationManagerTransactor) ModifyOperatorDetails(opts *bind.TransactOpts, newOperatorDetails IDelegationManagerOperatorDetails) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "modifyOperatorDetails", newOperatorDetails)
+}
+
+// ModifyOperatorDetails is a paid mutator transaction binding the contract method 0xf16172b0.
+//
+// Solidity: function modifyOperatorDetails((address,address,uint32) newOperatorDetails) returns()
+func (_DelegationManager *DelegationManagerSession) ModifyOperatorDetails(newOperatorDetails IDelegationManagerOperatorDetails) (*types.Transaction, error) {
+	return _DelegationManager.Contract.ModifyOperatorDetails(&_DelegationManager.TransactOpts, newOperatorDetails)
+}
+
+// ModifyOperatorDetails is a paid mutator transaction binding the contract method 0xf16172b0.
+//
+// Solidity: function modifyOperatorDetails((address,address,uint32) newOperatorDetails) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) ModifyOperatorDetails(newOperatorDetails IDelegationManagerOperatorDetails) (*types.Transaction, error) {
+	return _DelegationManager.Contract.ModifyOperatorDetails(&_DelegationManager.TransactOpts, newOperatorDetails)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x136439dd.
+//
+// Solidity: function pause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactor) Pause(opts *bind.TransactOpts, newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "pause", newPausedStatus)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x136439dd.
+//
+// Solidity: function pause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerSession) Pause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Pause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x136439dd.
+//
+// Solidity: function pause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) Pause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Pause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// PauseAll is a paid mutator transaction binding the contract method 0x595c6a67.
+//
+// Solidity: function pauseAll() returns()
+func (_DelegationManager *DelegationManagerTransactor) PauseAll(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "pauseAll")
+}
+
+// PauseAll is a paid mutator transaction binding the contract method 0x595c6a67.
+//
+// Solidity: function pauseAll() returns()
+func (_DelegationManager *DelegationManagerSession) PauseAll() (*types.Transaction, error) {
+	return _DelegationManager.Contract.PauseAll(&_DelegationManager.TransactOpts)
+}
+
+// PauseAll is a paid mutator transaction binding the contract method 0x595c6a67.
+//
+// Solidity: function pauseAll() returns()
+func (_DelegationManager *DelegationManagerTransactorSession) PauseAll() (*types.Transaction, error) {
+	return _DelegationManager.Contract.PauseAll(&_DelegationManager.TransactOpts)
+}
+
+// QueueWithdrawals is a paid mutator transaction binding the contract method 0x0dd8dd02.
+//
+// Solidity: function queueWithdrawals((address[],uint256[],address)[] queuedWithdrawalParams) returns(bytes32[])
+func (_DelegationManager *DelegationManagerTransactor) QueueWithdrawals(opts *bind.TransactOpts, queuedWithdrawalParams []IDelegationManagerQueuedWithdrawalParams) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "queueWithdrawals", queuedWithdrawalParams)
+}
+
+// QueueWithdrawals is a paid mutator transaction binding the contract method 0x0dd8dd02.
+//
+// Solidity: function queueWithdrawals((address[],uint256[],address)[] queuedWithdrawalParams) returns(bytes32[])
+func (_DelegationManager *DelegationManagerSession) QueueWithdrawals(queuedWithdrawalParams []IDelegationManagerQueuedWithdrawalParams) (*types.Transaction, error) {
+	return _DelegationManager.Contract.QueueWithdrawals(&_DelegationManager.TransactOpts, queuedWithdrawalParams)
+}
+
+// QueueWithdrawals is a paid mutator transaction binding the contract method 0x0dd8dd02.
+//
+// Solidity: function queueWithdrawals((address[],uint256[],address)[] queuedWithdrawalParams) returns(bytes32[])
+func (_DelegationManager *DelegationManagerTransactorSession) QueueWithdrawals(queuedWithdrawalParams []IDelegationManagerQueuedWithdrawalParams) (*types.Transaction, error) {
+	return _DelegationManager.Contract.QueueWithdrawals(&_DelegationManager.TransactOpts, queuedWithdrawalParams)
+}
+
+// RegisterAsOperator is a paid mutator transaction binding the contract method 0x0f589e59.
+//
+// Solidity: function registerAsOperator((address,address,uint32) registeringOperatorDetails, string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactor) RegisterAsOperator(opts *bind.TransactOpts, registeringOperatorDetails IDelegationManagerOperatorDetails, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "registerAsOperator", registeringOperatorDetails, metadataURI)
+}
+
+// RegisterAsOperator is a paid mutator transaction binding the contract method 0x0f589e59.
+//
+// Solidity: function registerAsOperator((address,address,uint32) registeringOperatorDetails, string metadataURI) returns()
+func (_DelegationManager *DelegationManagerSession) RegisterAsOperator(registeringOperatorDetails IDelegationManagerOperatorDetails, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.RegisterAsOperator(&_DelegationManager.TransactOpts, registeringOperatorDetails, metadataURI)
+}
+
+// RegisterAsOperator is a paid mutator transaction binding the contract method 0x0f589e59.
+//
+// Solidity: function registerAsOperator((address,address,uint32) registeringOperatorDetails, string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) RegisterAsOperator(registeringOperatorDetails IDelegationManagerOperatorDetails, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.RegisterAsOperator(&_DelegationManager.TransactOpts, registeringOperatorDetails, metadataURI)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_DelegationManager *DelegationManagerTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_DelegationManager *DelegationManagerSession) RenounceOwnership() (*types.Transaction, error) {
+	return _DelegationManager.Contract.RenounceOwnership(&_DelegationManager.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_DelegationManager *DelegationManagerTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _DelegationManager.Contract.RenounceOwnership(&_DelegationManager.TransactOpts)
+}
+
+// SetMinWithdrawalDelayBlocks is a paid mutator transaction binding the contract method 0x635bbd10.
+//
+// Solidity: function setMinWithdrawalDelayBlocks(uint256 newMinWithdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerTransactor) SetMinWithdrawalDelayBlocks(opts *bind.TransactOpts, newMinWithdrawalDelayBlocks *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "setMinWithdrawalDelayBlocks", newMinWithdrawalDelayBlocks)
+}
+
+// SetMinWithdrawalDelayBlocks is a paid mutator transaction binding the contract method 0x635bbd10.
+//
+// Solidity: function setMinWithdrawalDelayBlocks(uint256 newMinWithdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerSession) SetMinWithdrawalDelayBlocks(newMinWithdrawalDelayBlocks *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetMinWithdrawalDelayBlocks(&_DelegationManager.TransactOpts, newMinWithdrawalDelayBlocks)
+}
+
+// SetMinWithdrawalDelayBlocks is a paid mutator transaction binding the contract method 0x635bbd10.
+//
+// Solidity: function setMinWithdrawalDelayBlocks(uint256 newMinWithdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) SetMinWithdrawalDelayBlocks(newMinWithdrawalDelayBlocks *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetMinWithdrawalDelayBlocks(&_DelegationManager.TransactOpts, newMinWithdrawalDelayBlocks)
+}
+
+// SetPauserRegistry is a paid mutator transaction binding the contract method 0x10d67a2f.
+//
+// Solidity: function setPauserRegistry(address newPauserRegistry) returns()
+func (_DelegationManager *DelegationManagerTransactor) SetPauserRegistry(opts *bind.TransactOpts, newPauserRegistry common.Address) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "setPauserRegistry", newPauserRegistry)
+}
+
+// SetPauserRegistry is a paid mutator transaction binding the contract method 0x10d67a2f.
+//
+// Solidity: function setPauserRegistry(address newPauserRegistry) returns()
+func (_DelegationManager *DelegationManagerSession) SetPauserRegistry(newPauserRegistry common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetPauserRegistry(&_DelegationManager.TransactOpts, newPauserRegistry)
+}
+
+// SetPauserRegistry is a paid mutator transaction binding the contract method 0x10d67a2f.
+//
+// Solidity: function setPauserRegistry(address newPauserRegistry) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) SetPauserRegistry(newPauserRegistry common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetPauserRegistry(&_DelegationManager.TransactOpts, newPauserRegistry)
+}
+
+// SetStrategyWithdrawalDelayBlocks is a paid mutator transaction binding the contract method 0x1522bf02.
+//
+// Solidity: function setStrategyWithdrawalDelayBlocks(address[] strategies, uint256[] withdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerTransactor) SetStrategyWithdrawalDelayBlocks(opts *bind.TransactOpts, strategies []common.Address, withdrawalDelayBlocks []*big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "setStrategyWithdrawalDelayBlocks", strategies, withdrawalDelayBlocks)
+}
+
+// SetStrategyWithdrawalDelayBlocks is a paid mutator transaction binding the contract method 0x1522bf02.
+//
+// Solidity: function setStrategyWithdrawalDelayBlocks(address[] strategies, uint256[] withdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerSession) SetStrategyWithdrawalDelayBlocks(strategies []common.Address, withdrawalDelayBlocks []*big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetStrategyWithdrawalDelayBlocks(&_DelegationManager.TransactOpts, strategies, withdrawalDelayBlocks)
+}
+
+// SetStrategyWithdrawalDelayBlocks is a paid mutator transaction binding the contract method 0x1522bf02.
+//
+// Solidity: function setStrategyWithdrawalDelayBlocks(address[] strategies, uint256[] withdrawalDelayBlocks) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) SetStrategyWithdrawalDelayBlocks(strategies []common.Address, withdrawalDelayBlocks []*big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetStrategyWithdrawalDelayBlocks(&_DelegationManager.TransactOpts, strategies, withdrawalDelayBlocks)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_DelegationManager *DelegationManagerTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_DelegationManager *DelegationManagerSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.TransferOwnership(&_DelegationManager.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.TransferOwnership(&_DelegationManager.TransactOpts, newOwner)
+}
+
+// Undelegate is a paid mutator transaction binding the contract method 0xda8be864.
+//
+// Solidity: function undelegate(address staker) returns(bytes32[] withdrawalRoots)
+func (_DelegationManager *DelegationManagerTransactor) Undelegate(opts *bind.TransactOpts, staker common.Address) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "undelegate", staker)
+}
+
+// Undelegate is a paid mutator transaction binding the contract method 0xda8be864.
+//
+// Solidity: function undelegate(address staker) returns(bytes32[] withdrawalRoots)
+func (_DelegationManager *DelegationManagerSession) Undelegate(staker common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Undelegate(&_DelegationManager.TransactOpts, staker)
+}
+
+// Undelegate is a paid mutator transaction binding the contract method 0xda8be864.
+//
+// Solidity: function undelegate(address staker) returns(bytes32[] withdrawalRoots)
+func (_DelegationManager *DelegationManagerTransactorSession) Undelegate(staker common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Undelegate(&_DelegationManager.TransactOpts, staker)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0xfabc1cbc.
+//
+// Solidity: function unpause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactor) Unpause(opts *bind.TransactOpts, newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "unpause", newPausedStatus)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0xfabc1cbc.
+//
+// Solidity: function unpause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerSession) Unpause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Unpause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0xfabc1cbc.
+//
+// Solidity: function unpause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) Unpause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Unpause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// UpdateOperatorMetadataURI is a paid mutator transaction binding the contract method 0x99be81c8.
+//
+// Solidity: function updateOperatorMetadataURI(string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactor) UpdateOperatorMetadataURI(opts *bind.TransactOpts, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "updateOperatorMetadataURI", metadataURI)
+}
+
+// UpdateOperatorMetadataURI is a paid mutator transaction binding the contract method 0x99be81c8.
+//
+// Solidity: function updateOperatorMetadataURI(string metadataURI) returns()
+func (_DelegationManager *DelegationManagerSession) UpdateOperatorMetadataURI(metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.UpdateOperatorMetadataURI(&_DelegationManager.TransactOpts, metadataURI)
+}
+
+// UpdateOperatorMetadataURI is a paid mutator transaction binding the contract method 0x99be81c8.
+//
+// Solidity: function updateOperatorMetadataURI(string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) UpdateOperatorMetadataURI(metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.UpdateOperatorMetadataURI(&_DelegationManager.TransactOpts, metadataURI)
+}
+
+// DelegationManagerInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the DelegationManager contract.
+type DelegationManagerInitializedIterator struct {
+	Event *DelegationManagerInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerInitialized represents a Initialized event raised by the DelegationManager contract.
+type DelegationManagerInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_DelegationManager *DelegationManagerFilterer) FilterInitialized(opts *bind.FilterOpts) (*DelegationManagerInitializedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerInitializedIterator{contract: _DelegationManager.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_DelegationManager *DelegationManagerFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *DelegationManagerInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerInitialized)
+				if err := _DelegationManager.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_DelegationManager *DelegationManagerFilterer) ParseInitialized(log types.Log) (*DelegationManagerInitialized, error) {
+	event := new(DelegationManagerInitialized)
+	if err := _DelegationManager.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerMinWithdrawalDelayBlocksSetIterator is returned from FilterMinWithdrawalDelayBlocksSet and is used to iterate over the raw logs and unpacked data for MinWithdrawalDelayBlocksSet events raised by the DelegationManager contract.
+type DelegationManagerMinWithdrawalDelayBlocksSetIterator struct {
+	Event *DelegationManagerMinWithdrawalDelayBlocksSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerMinWithdrawalDelayBlocksSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerMinWithdrawalDelayBlocksSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerMinWithdrawalDelayBlocksSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerMinWithdrawalDelayBlocksSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerMinWithdrawalDelayBlocksSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerMinWithdrawalDelayBlocksSet represents a MinWithdrawalDelayBlocksSet event raised by the DelegationManager contract.
+type DelegationManagerMinWithdrawalDelayBlocksSet struct {
+	PreviousValue *big.Int
+	NewValue      *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterMinWithdrawalDelayBlocksSet is a free log retrieval operation binding the contract event 0xafa003cd76f87ff9d62b35beea889920f33c0c42b8d45b74954d61d50f4b6b69.
+//
+// Solidity: event MinWithdrawalDelayBlocksSet(uint256 previousValue, uint256 newValue)
+func (_DelegationManager *DelegationManagerFilterer) FilterMinWithdrawalDelayBlocksSet(opts *bind.FilterOpts) (*DelegationManagerMinWithdrawalDelayBlocksSetIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "MinWithdrawalDelayBlocksSet")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerMinWithdrawalDelayBlocksSetIterator{contract: _DelegationManager.contract, event: "MinWithdrawalDelayBlocksSet", logs: logs, sub: sub}, nil
+}
+
+// WatchMinWithdrawalDelayBlocksSet is a free log subscription operation binding the contract event 0xafa003cd76f87ff9d62b35beea889920f33c0c42b8d45b74954d61d50f4b6b69.
+//
+// Solidity: event MinWithdrawalDelayBlocksSet(uint256 previousValue, uint256 newValue)
+func (_DelegationManager *DelegationManagerFilterer) WatchMinWithdrawalDelayBlocksSet(opts *bind.WatchOpts, sink chan<- *DelegationManagerMinWithdrawalDelayBlocksSet) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "MinWithdrawalDelayBlocksSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerMinWithdrawalDelayBlocksSet)
+				if err := _DelegationManager.contract.UnpackLog(event, "MinWithdrawalDelayBlocksSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMinWithdrawalDelayBlocksSet is a log parse operation binding the contract event 0xafa003cd76f87ff9d62b35beea889920f33c0c42b8d45b74954d61d50f4b6b69.
+//
+// Solidity: event MinWithdrawalDelayBlocksSet(uint256 previousValue, uint256 newValue)
+func (_DelegationManager *DelegationManagerFilterer) ParseMinWithdrawalDelayBlocksSet(log types.Log) (*DelegationManagerMinWithdrawalDelayBlocksSet, error) {
+	event := new(DelegationManagerMinWithdrawalDelayBlocksSet)
+	if err := _DelegationManager.contract.UnpackLog(event, "MinWithdrawalDelayBlocksSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorDetailsModifiedIterator is returned from FilterOperatorDetailsModified and is used to iterate over the raw logs and unpacked data for OperatorDetailsModified events raised by the DelegationManager contract.
+type DelegationManagerOperatorDetailsModifiedIterator struct {
+	Event *DelegationManagerOperatorDetailsModified // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorDetailsModifiedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorDetailsModified)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorDetailsModified)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorDetailsModifiedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorDetailsModifiedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorDetailsModified represents a OperatorDetailsModified event raised by the DelegationManager contract.
+type DelegationManagerOperatorDetailsModified struct {
+	Operator           common.Address
+	NewOperatorDetails IDelegationManagerOperatorDetails
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorDetailsModified is a free log retrieval operation binding the contract event 0xfebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac.
+//
+// Solidity: event OperatorDetailsModified(address indexed operator, (address,address,uint32) newOperatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorDetailsModified(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorDetailsModifiedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorDetailsModified", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorDetailsModifiedIterator{contract: _DelegationManager.contract, event: "OperatorDetailsModified", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorDetailsModified is a free log subscription operation binding the contract event 0xfebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac.
+//
+// Solidity: event OperatorDetailsModified(address indexed operator, (address,address,uint32) newOperatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorDetailsModified(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorDetailsModified, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorDetailsModified", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorDetailsModified)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorDetailsModified", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorDetailsModified is a log parse operation binding the contract event 0xfebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac.
+//
+// Solidity: event OperatorDetailsModified(address indexed operator, (address,address,uint32) newOperatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorDetailsModified(log types.Log) (*DelegationManagerOperatorDetailsModified, error) {
+	event := new(DelegationManagerOperatorDetailsModified)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorDetailsModified", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorMetadataURIUpdatedIterator is returned from FilterOperatorMetadataURIUpdated and is used to iterate over the raw logs and unpacked data for OperatorMetadataURIUpdated events raised by the DelegationManager contract.
+type DelegationManagerOperatorMetadataURIUpdatedIterator struct {
+	Event *DelegationManagerOperatorMetadataURIUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorMetadataURIUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorMetadataURIUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorMetadataURIUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorMetadataURIUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorMetadataURIUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorMetadataURIUpdated represents a OperatorMetadataURIUpdated event raised by the DelegationManager contract.
+type DelegationManagerOperatorMetadataURIUpdated struct {
+	Operator    common.Address
+	MetadataURI string
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorMetadataURIUpdated is a free log retrieval operation binding the contract event 0x02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b6708090.
+//
+// Solidity: event OperatorMetadataURIUpdated(address indexed operator, string metadataURI)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorMetadataURIUpdated(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorMetadataURIUpdatedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorMetadataURIUpdated", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorMetadataURIUpdatedIterator{contract: _DelegationManager.contract, event: "OperatorMetadataURIUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorMetadataURIUpdated is a free log subscription operation binding the contract event 0x02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b6708090.
+//
+// Solidity: event OperatorMetadataURIUpdated(address indexed operator, string metadataURI)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorMetadataURIUpdated(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorMetadataURIUpdated, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorMetadataURIUpdated", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorMetadataURIUpdated)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorMetadataURIUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorMetadataURIUpdated is a log parse operation binding the contract event 0x02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b6708090.
+//
+// Solidity: event OperatorMetadataURIUpdated(address indexed operator, string metadataURI)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorMetadataURIUpdated(log types.Log) (*DelegationManagerOperatorMetadataURIUpdated, error) {
+	event := new(DelegationManagerOperatorMetadataURIUpdated)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorMetadataURIUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorRegisteredIterator is returned from FilterOperatorRegistered and is used to iterate over the raw logs and unpacked data for OperatorRegistered events raised by the DelegationManager contract.
+type DelegationManagerOperatorRegisteredIterator struct {
+	Event *DelegationManagerOperatorRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorRegistered represents a OperatorRegistered event raised by the DelegationManager contract.
+type DelegationManagerOperatorRegistered struct {
+	Operator        common.Address
+	OperatorDetails IDelegationManagerOperatorDetails
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorRegistered is a free log retrieval operation binding the contract event 0x8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e2.
+//
+// Solidity: event OperatorRegistered(address indexed operator, (address,address,uint32) operatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorRegistered(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorRegisteredIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorRegistered", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorRegisteredIterator{contract: _DelegationManager.contract, event: "OperatorRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorRegistered is a free log subscription operation binding the contract event 0x8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e2.
+//
+// Solidity: event OperatorRegistered(address indexed operator, (address,address,uint32) operatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorRegistered(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorRegistered, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorRegistered", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorRegistered)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorRegistered is a log parse operation binding the contract event 0x8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e2.
+//
+// Solidity: event OperatorRegistered(address indexed operator, (address,address,uint32) operatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorRegistered(log types.Log) (*DelegationManagerOperatorRegistered, error) {
+	event := new(DelegationManagerOperatorRegistered)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorSharesDecreasedIterator is returned from FilterOperatorSharesDecreased and is used to iterate over the raw logs and unpacked data for OperatorSharesDecreased events raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesDecreasedIterator struct {
+	Event *DelegationManagerOperatorSharesDecreased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorSharesDecreasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorSharesDecreased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorSharesDecreased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorSharesDecreasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorSharesDecreasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorSharesDecreased represents a OperatorSharesDecreased event raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesDecreased struct {
+	Operator common.Address
+	Staker   common.Address
+	Strategy common.Address
+	Shares   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorSharesDecreased is a free log retrieval operation binding the contract event 0x6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd.
+//
+// Solidity: event OperatorSharesDecreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorSharesDecreased(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorSharesDecreasedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorSharesDecreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorSharesDecreasedIterator{contract: _DelegationManager.contract, event: "OperatorSharesDecreased", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorSharesDecreased is a free log subscription operation binding the contract event 0x6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd.
+//
+// Solidity: event OperatorSharesDecreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorSharesDecreased(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorSharesDecreased, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorSharesDecreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorSharesDecreased)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesDecreased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorSharesDecreased is a log parse operation binding the contract event 0x6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd.
+//
+// Solidity: event OperatorSharesDecreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorSharesDecreased(log types.Log) (*DelegationManagerOperatorSharesDecreased, error) {
+	event := new(DelegationManagerOperatorSharesDecreased)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesDecreased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorSharesIncreasedIterator is returned from FilterOperatorSharesIncreased and is used to iterate over the raw logs and unpacked data for OperatorSharesIncreased events raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesIncreasedIterator struct {
+	Event *DelegationManagerOperatorSharesIncreased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorSharesIncreasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorSharesIncreased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorSharesIncreased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorSharesIncreasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorSharesIncreasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorSharesIncreased represents a OperatorSharesIncreased event raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesIncreased struct {
+	Operator common.Address
+	Staker   common.Address
+	Strategy common.Address
+	Shares   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorSharesIncreased is a free log retrieval operation binding the contract event 0x1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c.
+//
+// Solidity: event OperatorSharesIncreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorSharesIncreased(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorSharesIncreasedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorSharesIncreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorSharesIncreasedIterator{contract: _DelegationManager.contract, event: "OperatorSharesIncreased", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorSharesIncreased is a free log subscription operation binding the contract event 0x1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c.
+//
+// Solidity: event OperatorSharesIncreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorSharesIncreased(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorSharesIncreased, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorSharesIncreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorSharesIncreased)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesIncreased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorSharesIncreased is a log parse operation binding the contract event 0x1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c.
+//
+// Solidity: event OperatorSharesIncreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorSharesIncreased(log types.Log) (*DelegationManagerOperatorSharesIncreased, error) {
+	event := new(DelegationManagerOperatorSharesIncreased)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesIncreased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the DelegationManager contract.
+type DelegationManagerOwnershipTransferredIterator struct {
+	Event *DelegationManagerOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOwnershipTransferred represents a OwnershipTransferred event raised by the DelegationManager contract.
+type DelegationManagerOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_DelegationManager *DelegationManagerFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*DelegationManagerOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOwnershipTransferredIterator{contract: _DelegationManager.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_DelegationManager *DelegationManagerFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *DelegationManagerOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOwnershipTransferred)
+				if err := _DelegationManager.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_DelegationManager *DelegationManagerFilterer) ParseOwnershipTransferred(log types.Log) (*DelegationManagerOwnershipTransferred, error) {
+	event := new(DelegationManagerOwnershipTransferred)
+	if err := _DelegationManager.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the DelegationManager contract.
+type DelegationManagerPausedIterator struct {
+	Event *DelegationManagerPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerPaused represents a Paused event raised by the DelegationManager contract.
+type DelegationManagerPaused struct {
+	Account         common.Address
+	NewPausedStatus *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0xab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d.
+//
+// Solidity: event Paused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) FilterPaused(opts *bind.FilterOpts, account []common.Address) (*DelegationManagerPausedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "Paused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerPausedIterator{contract: _DelegationManager.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0xab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d.
+//
+// Solidity: event Paused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *DelegationManagerPaused, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "Paused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerPaused)
+				if err := _DelegationManager.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0xab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d.
+//
+// Solidity: event Paused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) ParsePaused(log types.Log) (*DelegationManagerPaused, error) {
+	event := new(DelegationManagerPaused)
+	if err := _DelegationManager.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerPauserRegistrySetIterator is returned from FilterPauserRegistrySet and is used to iterate over the raw logs and unpacked data for PauserRegistrySet events raised by the DelegationManager contract.
+type DelegationManagerPauserRegistrySetIterator struct {
+	Event *DelegationManagerPauserRegistrySet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerPauserRegistrySetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerPauserRegistrySet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerPauserRegistrySet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerPauserRegistrySetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerPauserRegistrySetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerPauserRegistrySet represents a PauserRegistrySet event raised by the DelegationManager contract.
+type DelegationManagerPauserRegistrySet struct {
+	PauserRegistry    common.Address
+	NewPauserRegistry common.Address
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterPauserRegistrySet is a free log retrieval operation binding the contract event 0x6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6.
+//
+// Solidity: event PauserRegistrySet(address pauserRegistry, address newPauserRegistry)
+func (_DelegationManager *DelegationManagerFilterer) FilterPauserRegistrySet(opts *bind.FilterOpts) (*DelegationManagerPauserRegistrySetIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "PauserRegistrySet")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerPauserRegistrySetIterator{contract: _DelegationManager.contract, event: "PauserRegistrySet", logs: logs, sub: sub}, nil
+}
+
+// WatchPauserRegistrySet is a free log subscription operation binding the contract event 0x6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6.
+//
+// Solidity: event PauserRegistrySet(address pauserRegistry, address newPauserRegistry)
+func (_DelegationManager *DelegationManagerFilterer) WatchPauserRegistrySet(opts *bind.WatchOpts, sink chan<- *DelegationManagerPauserRegistrySet) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "PauserRegistrySet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerPauserRegistrySet)
+				if err := _DelegationManager.contract.UnpackLog(event, "PauserRegistrySet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePauserRegistrySet is a log parse operation binding the contract event 0x6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6.
+//
+// Solidity: event PauserRegistrySet(address pauserRegistry, address newPauserRegistry)
+func (_DelegationManager *DelegationManagerFilterer) ParsePauserRegistrySet(log types.Log) (*DelegationManagerPauserRegistrySet, error) {
+	event := new(DelegationManagerPauserRegistrySet)
+	if err := _DelegationManager.contract.UnpackLog(event, "PauserRegistrySet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerStakerDelegatedIterator is returned from FilterStakerDelegated and is used to iterate over the raw logs and unpacked data for StakerDelegated events raised by the DelegationManager contract.
+type DelegationManagerStakerDelegatedIterator struct {
+	Event *DelegationManagerStakerDelegated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerStakerDelegatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerStakerDelegated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerStakerDelegated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerStakerDelegatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerStakerDelegatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerStakerDelegated represents a StakerDelegated event raised by the DelegationManager contract.
+type DelegationManagerStakerDelegated struct {
+	Staker   common.Address
+	Operator common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakerDelegated is a free log retrieval operation binding the contract event 0xc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d8743304.
+//
+// Solidity: event StakerDelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) FilterStakerDelegated(opts *bind.FilterOpts, staker []common.Address, operator []common.Address) (*DelegationManagerStakerDelegatedIterator, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "StakerDelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerStakerDelegatedIterator{contract: _DelegationManager.contract, event: "StakerDelegated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakerDelegated is a free log subscription operation binding the contract event 0xc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d8743304.
+//
+// Solidity: event StakerDelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) WatchStakerDelegated(opts *bind.WatchOpts, sink chan<- *DelegationManagerStakerDelegated, staker []common.Address, operator []common.Address) (event.Subscription, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "StakerDelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerStakerDelegated)
+				if err := _DelegationManager.contract.UnpackLog(event, "StakerDelegated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakerDelegated is a log parse operation binding the contract event 0xc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d8743304.
+//
+// Solidity: event StakerDelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) ParseStakerDelegated(log types.Log) (*DelegationManagerStakerDelegated, error) {
+	event := new(DelegationManagerStakerDelegated)
+	if err := _DelegationManager.contract.UnpackLog(event, "StakerDelegated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerStakerForceUndelegatedIterator is returned from FilterStakerForceUndelegated and is used to iterate over the raw logs and unpacked data for StakerForceUndelegated events raised by the DelegationManager contract.
+type DelegationManagerStakerForceUndelegatedIterator struct {
+	Event *DelegationManagerStakerForceUndelegated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerStakerForceUndelegatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerStakerForceUndelegated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerStakerForceUndelegated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerStakerForceUndelegatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerStakerForceUndelegatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerStakerForceUndelegated represents a StakerForceUndelegated event raised by the DelegationManager contract.
+type DelegationManagerStakerForceUndelegated struct {
+	Staker   common.Address
+	Operator common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakerForceUndelegated is a free log retrieval operation binding the contract event 0xf0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a.
+//
+// Solidity: event StakerForceUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) FilterStakerForceUndelegated(opts *bind.FilterOpts, staker []common.Address, operator []common.Address) (*DelegationManagerStakerForceUndelegatedIterator, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "StakerForceUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerStakerForceUndelegatedIterator{contract: _DelegationManager.contract, event: "StakerForceUndelegated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakerForceUndelegated is a free log subscription operation binding the contract event 0xf0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a.
+//
+// Solidity: event StakerForceUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) WatchStakerForceUndelegated(opts *bind.WatchOpts, sink chan<- *DelegationManagerStakerForceUndelegated, staker []common.Address, operator []common.Address) (event.Subscription, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "StakerForceUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerStakerForceUndelegated)
+				if err := _DelegationManager.contract.UnpackLog(event, "StakerForceUndelegated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakerForceUndelegated is a log parse operation binding the contract event 0xf0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a.
+//
+// Solidity: event StakerForceUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) ParseStakerForceUndelegated(log types.Log) (*DelegationManagerStakerForceUndelegated, error) {
+	event := new(DelegationManagerStakerForceUndelegated)
+	if err := _DelegationManager.contract.UnpackLog(event, "StakerForceUndelegated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerStakerUndelegatedIterator is returned from FilterStakerUndelegated and is used to iterate over the raw logs and unpacked data for StakerUndelegated events raised by the DelegationManager contract.
+type DelegationManagerStakerUndelegatedIterator struct {
+	Event *DelegationManagerStakerUndelegated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerStakerUndelegatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerStakerUndelegated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerStakerUndelegated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerStakerUndelegatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerStakerUndelegatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerStakerUndelegated represents a StakerUndelegated event raised by the DelegationManager contract.
+type DelegationManagerStakerUndelegated struct {
+	Staker   common.Address
+	Operator common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakerUndelegated is a free log retrieval operation binding the contract event 0xfee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af44676.
+//
+// Solidity: event StakerUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) FilterStakerUndelegated(opts *bind.FilterOpts, staker []common.Address, operator []common.Address) (*DelegationManagerStakerUndelegatedIterator, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "StakerUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerStakerUndelegatedIterator{contract: _DelegationManager.contract, event: "StakerUndelegated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakerUndelegated is a free log subscription operation binding the contract event 0xfee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af44676.
+//
+// Solidity: event StakerUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) WatchStakerUndelegated(opts *bind.WatchOpts, sink chan<- *DelegationManagerStakerUndelegated, staker []common.Address, operator []common.Address) (event.Subscription, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "StakerUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerStakerUndelegated)
+				if err := _DelegationManager.contract.UnpackLog(event, "StakerUndelegated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakerUndelegated is a log parse operation binding the contract event 0xfee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af44676.
+//
+// Solidity: event StakerUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) ParseStakerUndelegated(log types.Log) (*DelegationManagerStakerUndelegated, error) {
+	event := new(DelegationManagerStakerUndelegated)
+	if err := _DelegationManager.contract.UnpackLog(event, "StakerUndelegated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerStrategyWithdrawalDelayBlocksSetIterator is returned from FilterStrategyWithdrawalDelayBlocksSet and is used to iterate over the raw logs and unpacked data for StrategyWithdrawalDelayBlocksSet events raised by the DelegationManager contract.
+type DelegationManagerStrategyWithdrawalDelayBlocksSetIterator struct {
+	Event *DelegationManagerStrategyWithdrawalDelayBlocksSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerStrategyWithdrawalDelayBlocksSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerStrategyWithdrawalDelayBlocksSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerStrategyWithdrawalDelayBlocksSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerStrategyWithdrawalDelayBlocksSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerStrategyWithdrawalDelayBlocksSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerStrategyWithdrawalDelayBlocksSet represents a StrategyWithdrawalDelayBlocksSet event raised by the DelegationManager contract.
+type DelegationManagerStrategyWithdrawalDelayBlocksSet struct {
+	Strategy      common.Address
+	PreviousValue *big.Int
+	NewValue      *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterStrategyWithdrawalDelayBlocksSet is a free log retrieval operation binding the contract event 0x0e7efa738e8b0ce6376a0c1af471655540d2e9a81647d7b09ed823018426576d.
+//
+// Solidity: event StrategyWithdrawalDelayBlocksSet(address strategy, uint256 previousValue, uint256 newValue)
+func (_DelegationManager *DelegationManagerFilterer) FilterStrategyWithdrawalDelayBlocksSet(opts *bind.FilterOpts) (*DelegationManagerStrategyWithdrawalDelayBlocksSetIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "StrategyWithdrawalDelayBlocksSet")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerStrategyWithdrawalDelayBlocksSetIterator{contract: _DelegationManager.contract, event: "StrategyWithdrawalDelayBlocksSet", logs: logs, sub: sub}, nil
+}
+
+// WatchStrategyWithdrawalDelayBlocksSet is a free log subscription operation binding the contract event 0x0e7efa738e8b0ce6376a0c1af471655540d2e9a81647d7b09ed823018426576d.
+//
+// Solidity: event StrategyWithdrawalDelayBlocksSet(address strategy, uint256 previousValue, uint256 newValue)
+func (_DelegationManager *DelegationManagerFilterer) WatchStrategyWithdrawalDelayBlocksSet(opts *bind.WatchOpts, sink chan<- *DelegationManagerStrategyWithdrawalDelayBlocksSet) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "StrategyWithdrawalDelayBlocksSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerStrategyWithdrawalDelayBlocksSet)
+				if err := _DelegationManager.contract.UnpackLog(event, "StrategyWithdrawalDelayBlocksSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStrategyWithdrawalDelayBlocksSet is a log parse operation binding the contract event 0x0e7efa738e8b0ce6376a0c1af471655540d2e9a81647d7b09ed823018426576d.
+//
+// Solidity: event StrategyWithdrawalDelayBlocksSet(address strategy, uint256 previousValue, uint256 newValue)
+func (_DelegationManager *DelegationManagerFilterer) ParseStrategyWithdrawalDelayBlocksSet(log types.Log) (*DelegationManagerStrategyWithdrawalDelayBlocksSet, error) {
+	event := new(DelegationManagerStrategyWithdrawalDelayBlocksSet)
+	if err := _DelegationManager.contract.UnpackLog(event, "StrategyWithdrawalDelayBlocksSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the DelegationManager contract.
+type DelegationManagerUnpausedIterator struct {
+	Event *DelegationManagerUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerUnpaused represents a Unpaused event raised by the DelegationManager contract.
+type DelegationManagerUnpaused struct {
+	Account         common.Address
+	NewPausedStatus *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c.
+//
+// Solidity: event Unpaused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) FilterUnpaused(opts *bind.FilterOpts, account []common.Address) (*DelegationManagerUnpausedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "Unpaused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerUnpausedIterator{contract: _DelegationManager.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c.
+//
+// Solidity: event Unpaused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *DelegationManagerUnpaused, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "Unpaused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerUnpaused)
+				if err := _DelegationManager.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c.
+//
+// Solidity: event Unpaused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) ParseUnpaused(log types.Log) (*DelegationManagerUnpaused, error) {
+	event := new(DelegationManagerUnpaused)
+	if err := _DelegationManager.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerWithdrawalCompletedIterator is returned from FilterWithdrawalCompleted and is used to iterate over the raw logs and unpacked data for WithdrawalCompleted events raised by the DelegationManager contract.
+type DelegationManagerWithdrawalCompletedIterator struct {
+	Event *DelegationManagerWithdrawalCompleted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerWithdrawalCompletedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerWithdrawalCompleted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerWithdrawalCompleted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerWithdrawalCompletedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerWithdrawalCompletedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerWithdrawalCompleted represents a WithdrawalCompleted event raised by the DelegationManager contract.
+type DelegationManagerWithdrawalCompleted struct {
+	WithdrawalRoot [32]byte
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrawalCompleted is a free log retrieval operation binding the contract event 0xc97098c2f658800b4df29001527f7324bcdffcf6e8751a699ab920a1eced5b1d.
+//
+// Solidity: event WithdrawalCompleted(bytes32 withdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) FilterWithdrawalCompleted(opts *bind.FilterOpts) (*DelegationManagerWithdrawalCompletedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "WithdrawalCompleted")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerWithdrawalCompletedIterator{contract: _DelegationManager.contract, event: "WithdrawalCompleted", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrawalCompleted is a free log subscription operation binding the contract event 0xc97098c2f658800b4df29001527f7324bcdffcf6e8751a699ab920a1eced5b1d.
+//
+// Solidity: event WithdrawalCompleted(bytes32 withdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) WatchWithdrawalCompleted(opts *bind.WatchOpts, sink chan<- *DelegationManagerWithdrawalCompleted) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "WithdrawalCompleted")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerWithdrawalCompleted)
+				if err := _DelegationManager.contract.UnpackLog(event, "WithdrawalCompleted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseWithdrawalCompleted is a log parse operation binding the contract event 0xc97098c2f658800b4df29001527f7324bcdffcf6e8751a699ab920a1eced5b1d.
+//
+// Solidity: event WithdrawalCompleted(bytes32 withdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) ParseWithdrawalCompleted(log types.Log) (*DelegationManagerWithdrawalCompleted, error) {
+	event := new(DelegationManagerWithdrawalCompleted)
+	if err := _DelegationManager.contract.UnpackLog(event, "WithdrawalCompleted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerWithdrawalMigratedIterator is returned from FilterWithdrawalMigrated and is used to iterate over the raw logs and unpacked data for WithdrawalMigrated events raised by the DelegationManager contract.
+type DelegationManagerWithdrawalMigratedIterator struct {
+	Event *DelegationManagerWithdrawalMigrated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerWithdrawalMigratedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerWithdrawalMigrated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerWithdrawalMigrated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerWithdrawalMigratedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerWithdrawalMigratedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerWithdrawalMigrated represents a WithdrawalMigrated event raised by the DelegationManager contract.
+type DelegationManagerWithdrawalMigrated struct {
+	OldWithdrawalRoot [32]byte
+	NewWithdrawalRoot [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrawalMigrated is a free log retrieval operation binding the contract event 0xdc00758b65eef71dc3780c04ebe36cab6bdb266c3a698187e29e0f0dca012630.
+//
+// Solidity: event WithdrawalMigrated(bytes32 oldWithdrawalRoot, bytes32 newWithdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) FilterWithdrawalMigrated(opts *bind.FilterOpts) (*DelegationManagerWithdrawalMigratedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "WithdrawalMigrated")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerWithdrawalMigratedIterator{contract: _DelegationManager.contract, event: "WithdrawalMigrated", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrawalMigrated is a free log subscription operation binding the contract event 0xdc00758b65eef71dc3780c04ebe36cab6bdb266c3a698187e29e0f0dca012630.
+//
+// Solidity: event WithdrawalMigrated(bytes32 oldWithdrawalRoot, bytes32 newWithdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) WatchWithdrawalMigrated(opts *bind.WatchOpts, sink chan<- *DelegationManagerWithdrawalMigrated) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "WithdrawalMigrated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerWithdrawalMigrated)
+				if err := _DelegationManager.contract.UnpackLog(event, "WithdrawalMigrated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseWithdrawalMigrated is a log parse operation binding the contract event 0xdc00758b65eef71dc3780c04ebe36cab6bdb266c3a698187e29e0f0dca012630.
+//
+// Solidity: event WithdrawalMigrated(bytes32 oldWithdrawalRoot, bytes32 newWithdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) ParseWithdrawalMigrated(log types.Log) (*DelegationManagerWithdrawalMigrated, error) {
+	event := new(DelegationManagerWithdrawalMigrated)
+	if err := _DelegationManager.contract.UnpackLog(event, "WithdrawalMigrated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerWithdrawalQueuedIterator is returned from FilterWithdrawalQueued and is used to iterate over the raw logs and unpacked data for WithdrawalQueued events raised by the DelegationManager contract.
+type DelegationManagerWithdrawalQueuedIterator struct {
+	Event *DelegationManagerWithdrawalQueued // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerWithdrawalQueuedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerWithdrawalQueued)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerWithdrawalQueued)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerWithdrawalQueuedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerWithdrawalQueuedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerWithdrawalQueued represents a WithdrawalQueued event raised by the DelegationManager contract.
+type DelegationManagerWithdrawalQueued struct {
+	WithdrawalRoot [32]byte
+	Withdrawal     IDelegationManagerWithdrawal
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrawalQueued is a free log retrieval operation binding the contract event 0x9009ab153e8014fbfb02f2217f5cde7aa7f9ad734ae85ca3ee3f4ca2fdd499f9.
+//
+// Solidity: event WithdrawalQueued(bytes32 withdrawalRoot, (address,address,address,uint256,uint32,address[],uint256[]) withdrawal)
+func (_DelegationManager *DelegationManagerFilterer) FilterWithdrawalQueued(opts *bind.FilterOpts) (*DelegationManagerWithdrawalQueuedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "WithdrawalQueued")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerWithdrawalQueuedIterator{contract: _DelegationManager.contract, event: "WithdrawalQueued", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrawalQueued is a free log subscription operation binding the contract event 0x9009ab153e8014fbfb02f2217f5cde7aa7f9ad734ae85ca3ee3f4ca2fdd499f9.
+//
+// Solidity: event WithdrawalQueued(bytes32 withdrawalRoot, (address,address,address,uint256,uint32,address[],uint256[]) withdrawal)
+func (_DelegationManager *DelegationManagerFilterer) WatchWithdrawalQueued(opts *bind.WatchOpts, sink chan<- *DelegationManagerWithdrawalQueued) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "WithdrawalQueued")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerWithdrawalQueued)
+				if err := _DelegationManager.contract.UnpackLog(event, "WithdrawalQueued", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseWithdrawalQueued is a log parse operation binding the contract event 0x9009ab153e8014fbfb02f2217f5cde7aa7f9ad734ae85ca3ee3f4ca2fdd499f9.
+//
+// Solidity: event WithdrawalQueued(bytes32 withdrawalRoot, (address,address,address,uint256,uint32,address[],uint256[]) withdrawal)
+func (_DelegationManager *DelegationManagerFilterer) ParseWithdrawalQueued(log types.Log) (*DelegationManagerWithdrawalQueued, error) {
+	event := new(DelegationManagerWithdrawalQueued)
+	if err := _DelegationManager.contract.UnpackLog(event, "WithdrawalQueued", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/eigenState/bindings/DelegationManagerSlashing/binding.go
+++ b/internal/eigenState/bindings/DelegationManagerSlashing/binding.go
@@ -1,0 +1,4179 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package DelegationManager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IDelegationManagerTypesOperatorDetails is an auto generated low-level Go binding around an user-defined struct.
+type IDelegationManagerTypesOperatorDetails struct {
+	DeprecatedEarningsReceiver         common.Address
+	DelegationApprover                 common.Address
+	DeprecatedStakerOptOutWindowBlocks uint32
+}
+
+// IDelegationManagerTypesQueuedWithdrawalParams is an auto generated low-level Go binding around an user-defined struct.
+type IDelegationManagerTypesQueuedWithdrawalParams struct {
+	Strategies []common.Address
+	Shares     []*big.Int
+	Withdrawer common.Address
+}
+
+// IDelegationManagerTypesWithdrawal is an auto generated low-level Go binding around an user-defined struct.
+type IDelegationManagerTypesWithdrawal struct {
+	Staker                 common.Address
+	DelegatedTo            common.Address
+	Withdrawer             common.Address
+	Nonce                  *big.Int
+	StartTimestamp         uint32
+	Strategies             []common.Address
+	ScaledSharesToWithdraw []*big.Int
+}
+
+// ISignatureUtilsSignatureWithExpiry is an auto generated low-level Go binding around an user-defined struct.
+type ISignatureUtilsSignatureWithExpiry struct {
+	Signature []byte
+	Expiry    *big.Int
+}
+
+// DelegationManagerMetaData contains all meta data concerning the DelegationManager contract.
+var DelegationManagerMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_avsDirectory\",\"type\":\"address\",\"internalType\":\"contractIAVSDirectory\"},{\"name\":\"_strategyManager\",\"type\":\"address\",\"internalType\":\"contractIStrategyManager\"},{\"name\":\"_eigenPodManager\",\"type\":\"address\",\"internalType\":\"contractIEigenPodManager\"},{\"name\":\"_allocationManager\",\"type\":\"address\",\"internalType\":\"contractIAllocationManager\"},{\"name\":\"_MIN_WITHDRAWAL_DELAY\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DELEGATION_APPROVAL_TYPEHASH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"LEGACY_WITHDRAWAL_CHECK_VALUE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MIN_WITHDRAWAL_DELAY\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"STAKER_DELEGATION_TYPEHASH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"allocationManager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIAllocationManager\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"avsDirectory\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIAVSDirectory\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"beaconChainETHStrategy\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateCurrentStakerDelegationDigestHash\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateDelegationApprovalDigestHash\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"approver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"approverSalt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateStakerDelegationDigestHash\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateWithdrawalRoot\",\"inputs\":[{\"name\":\"withdrawal\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManagerTypes.Withdrawal\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startTimestamp\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"scaledSharesToWithdraw\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"completeQueuedWithdrawal\",\"inputs\":[{\"name\":\"withdrawal\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManagerTypes.Withdrawal\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startTimestamp\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"scaledSharesToWithdraw\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]},{\"name\":\"tokens\",\"type\":\"address[]\",\"internalType\":\"contractIERC20[]\"},{\"name\":\"receiveAsTokens\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"completeQueuedWithdrawals\",\"inputs\":[{\"name\":\"withdrawals\",\"type\":\"tuple[]\",\"internalType\":\"structIDelegationManagerTypes.Withdrawal[]\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startTimestamp\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"scaledSharesToWithdraw\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]},{\"name\":\"tokens\",\"type\":\"address[][]\",\"internalType\":\"contractIERC20[][]\"},{\"name\":\"receiveAsTokens\",\"type\":\"bool[]\",\"internalType\":\"bool[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"cumulativeWithdrawalsQueued\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decreaseBeaconChainScalingFactor\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"existingDepositShares\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"proportionOfOldBalance\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"decreaseOperatorShares\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"},{\"name\":\"previousTotalMagnitude\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"newTotalMagnitude\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegateTo\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"approverSignatureAndExpiry\",\"type\":\"tuple\",\"internalType\":\"structISignatureUtils.SignatureWithExpiry\",\"components\":[{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"approverSalt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegateToBySignature\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stakerSignatureAndExpiry\",\"type\":\"tuple\",\"internalType\":\"structISignatureUtils.SignatureWithExpiry\",\"components\":[{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"approverSignatureAndExpiry\",\"type\":\"tuple\",\"internalType\":\"structISignatureUtils.SignatureWithExpiry\",\"components\":[{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"expiry\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"approverSalt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegatedTo\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"delegationApprover\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"delegationApproverSaltIsSpent\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"domainSeparator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenPodManager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenPodManager\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCompletableTimestamp\",\"inputs\":[{\"name\":\"startTimestamp\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"outputs\":[{\"name\":\"completableTimestamp\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getDepositedShares\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getOperatorShares\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getOperatorsShares\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256[][]\",\"internalType\":\"uint256[][]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getWithdrawableShares\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"}],\"outputs\":[{\"name\":\"withdrawableShares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"increaseDelegatedShares\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"},{\"name\":\"existingDepositShares\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"addedShares\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"initialOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_pauserRegistry\",\"type\":\"address\",\"internalType\":\"contractIPauserRegistry\"},{\"name\":\"initialPausedStatus\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isDelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isOperator\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"modifyOperatorDetails\",\"inputs\":[{\"name\":\"newOperatorDetails\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManagerTypes.OperatorDetails\",\"components\":[{\"name\":\"__deprecated_earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"__deprecated_stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"operatorDetails\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManagerTypes.OperatorDetails\",\"components\":[{\"name\":\"__deprecated_earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"__deprecated_stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorShares\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"pauseAll\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pauserRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIPauserRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingWithdrawals\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"queueWithdrawals\",\"inputs\":[{\"name\":\"params\",\"type\":\"tuple[]\",\"internalType\":\"structIDelegationManagerTypes.QueuedWithdrawalParams[]\",\"components\":[{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"shares\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerAsOperator\",\"inputs\":[{\"name\":\"registeringOperatorDetails\",\"type\":\"tuple\",\"internalType\":\"structIDelegationManagerTypes.OperatorDetails\",\"components\":[{\"name\":\"__deprecated_earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"__deprecated_stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]},{\"name\":\"allocationDelay\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setPauserRegistry\",\"inputs\":[{\"name\":\"newPauserRegistry\",\"type\":\"address\",\"internalType\":\"contractIPauserRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"stakerNonce\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"stakerScalingFactor\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategy\"}],\"outputs\":[{\"name\":\"depositScalingFactor\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"isBeaconChainScalingFactorSet\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"beaconChainScalingFactor\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"strategyManager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIStrategyManager\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"undelegate\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"withdrawalRoots\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateOperatorMetadataURI\",\"inputs\":[{\"name\":\"metadataURI\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"BeaconChainScalingFactorDecreased\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newBeaconChainScalingFactor\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DepositScalingFactorUpdated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIStrategy\"},{\"name\":\"newDepositScalingFactor\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorDetailsModified\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOperatorDetails\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIDelegationManagerTypes.OperatorDetails\",\"components\":[{\"name\":\"__deprecated_earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"__deprecated_stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorMetadataURIUpdated\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operatorDetails\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIDelegationManagerTypes.OperatorDetails\",\"components\":[{\"name\":\"__deprecated_earningsReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegationApprover\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"__deprecated_stakerOptOutWindowBlocks\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorSharesDecreased\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"staker\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIStrategy\"},{\"name\":\"shares\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorSharesIncreased\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"staker\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"strategy\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIStrategy\"},{\"name\":\"shares\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PauserRegistrySet\",\"inputs\":[{\"name\":\"pauserRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIPauserRegistry\"},{\"name\":\"newPauserRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"contractIPauserRegistry\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashingWithdrawalCompleted\",\"inputs\":[{\"name\":\"withdrawalRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashingWithdrawalQueued\",\"inputs\":[{\"name\":\"withdrawalRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"withdrawal\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIDelegationManagerTypes.Withdrawal\",\"components\":[{\"name\":\"staker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatedTo\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"withdrawer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"startTimestamp\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"strategies\",\"type\":\"address[]\",\"internalType\":\"contractIStrategy[]\"},{\"name\":\"scaledSharesToWithdraw\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}]},{\"name\":\"sharesToWithdraw\",\"type\":\"uint256[]\",\"indexed\":false,\"internalType\":\"uint256[]\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakerDelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakerForceUndelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakerUndelegated\",\"inputs\":[{\"name\":\"staker\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newPausedStatus\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ActivelyDelegated\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AllocationDelaySet\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CallerCannotUndelegate\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CurrentlyPaused\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InputAddressZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InputArrayLengthMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InputArrayLengthZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidNewPausedStatus\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidSignature\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotActivelyDelegated\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyAllocationManager\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyEigenPodManager\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyPauser\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyStrategyManagerOrEigenPodManager\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyUnpauser\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OperatorNotRegistered\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OperatorsCannotUndelegate\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SaltSpent\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SignatureExpired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnauthorizedCaller\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalDelayExceedsMax\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalDelayExeedsMax\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalDelayNotElapsed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalDoesNotExist\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalExceedsMax\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalNotQueued\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawerNotCaller\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawerNotStaker\",\"inputs\":[]}]",
+	Bin: "0x61016060405234801561001157600080fd5b50604051615a47380380615a4783398101604081905261003091610200565b6001600160a01b0380861660805280851660a05280841660c052821660e05263ffffffff811661010052466101205261006761007d565b61014052610073610129565b505050505061027e565b60006101205146146101215750604080518082018252600a81526922b4b3b2b72630bcb2b960b11b60209182015281517f8cad95687ba82c2ce50e74f7b754645e5117c3a5bec8151c0726d5857980a866818301527f71b625cfad44bac63b13dba07f2e1d6084ee04b6f8752101ece6126d584ee6ea81840152466060820152306080808301919091528351808303909101815260a0909101909252815191012090565b506101405190565b600054610100900460ff16156101955760405162461bcd60e51b815260206004820152602760248201527f496e697469616c697a61626c653a20636f6e747261637420697320696e697469604482015266616c697a696e6760c81b606482015260840160405180910390fd5b60005460ff908116146101e6576000805460ff191660ff9081179091556040519081527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b565b6001600160a01b03811681146101fd57600080fd5b50565b600080600080600060a0868803121561021857600080fd5b8551610223816101e8565b6020870151909550610234816101e8565b6040870151909450610245816101e8565b6060870151909350610256816101e8565b608087015190925063ffffffff8116811461027057600080fd5b809150509295509295909350565b60805160a05160c05160e0516101005161012051610140516156f16103566000396000613e9801526000613dd80152600081816105bd01528181610f680152610fb70152600081816108dc01528181610bb10152818161123c015281816113530152818161163d01528181611f25015281816120470152818161251d015281816134f701526138fe0152600081816105830152818161117501528181611571015281816119a40152613daf01526000818161044f01528181611143015281816118f30152613d890152600061068701526156f16000f3fe608060405234801561001057600080fd5b50600436106103425760003560e01c8063715018a6116101b8578063c5e480db11610104578063e4cc3f90116100a2578063f16172b01161007c578063f16172b01461096b578063f2fde38b1461097e578063f698da2514610991578063fabc1cbc1461099957600080fd5b8063e4cc3f9014610925578063eea9064b14610938578063f0e0e6761461094b57600080fd5b8063ca8aa7c7116100de578063ca8aa7c7146108d7578063cb00387b146108fe578063cebc04ef14610907578063da8be8641461091257600080fd5b8063c5e480db1461080b578063c94b5111146108b1578063c978f7ac146108c457600080fd5b80639104c31911610171578063a17884841161014b578063a178848414610787578063a57ab10b146107a7578063b7f06ebe146107ba578063bb45fef2146107dd57600080fd5b80639104c319146107465780639435bb431461076157806399be81c81461077457600080fd5b8063715018a6146106bc578063778e55f3146106c45780637f548071146106ef578063886f1195146107025780638da5cb5b14610715578063900413471461072657600080fd5b806343377382116102925780635ac86ab71161023057806365da12641161020a57806365da12641461063857806366d5ba93146106615780636b3aa72e146106825780636d70f7ae146106a957600080fd5b80635ac86ab7146105fa5780635c975abb1461061d5780635d9aed231461062557600080fd5b8063497300601161026c57806349730060146105a55780634a5f2b5d146105b8578063595c6a67146105df578063597b36da146105e757600080fd5b806343377382146104ee578063457c6070146105155780634665bcda1461057e57600080fd5b80631794bb3c116102ff57806339b70e38116102d957806339b70e381461044a5780633c651cf2146104895780633cdeb5e01461049c5780633e28391d146104cb57600080fd5b80631794bb3c146104045780631bbce0911461041757806329c77d4f1461042a57600080fd5b806304a4f979146103475780630b9f487a146103815780630dd8dd021461039457806310d67a2f146103b4578063136439dd146103c957806315c4a288146103dc575b600080fd5b61036e7f14bde674c9f64b2ad00eaaee4a8bed1fabef35c7507e3c5b9cfc9436909a2dad81565b6040519081526020015b60405180910390f35b61036e61038f366004614447565b6109ac565b6103a76103a23660046144e6565b610a36565b6040516103789190614527565b6103c76103c236600461455f565b610d75565b005b6103c76103d736600461457c565b610e29565b6103ef6103ea3660046145b2565b610f14565b60405163ffffffff9091168152602001610378565b6103c76104123660046145cf565b610fe4565b61036e6104253660046145cf565b611108565b61036e61043836600461455f565b609b6020526000908152604090205481565b6104717f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610378565b6103c7610497366004614610565b611138565b6104716104aa36600461455f565b6001600160a01b039081166000908152609960205260409020600101541690565b6104de6104d936600461455f565b6112eb565b6040519015158152602001610378565b61036e7f39111bc4a4d688e1f685123d7497d4615370152a8ee4a0593e647bd06ad8bb0b81565b61055a610523366004614656565b60a26020908152600092835260408084209091529082529020805460019091015460ff81169061010090046001600160401b031683565b6040805193845291151560208401526001600160401b031690820152606001610378565b6104717f000000000000000000000000000000000000000000000000000000000000000081565b6103c76105b33660046146e2565b61130b565b6103ef7f000000000000000000000000000000000000000000000000000000000000000081565b6103c761146e565b61036e6105f536600461498c565b611536565b6104de6106083660046149c8565b606654600160ff9092169190911b9081161490565b60665461036e565b6103c7610633366004614a00565b611566565b61047161064636600461455f565b609a602052600090815260409020546001600160a01b031681565b61067461066f36600461455f565b6118ca565b604051610378929190614ab9565b6104717f000000000000000000000000000000000000000000000000000000000000000081565b6104de6106b736600461455f565b611bd7565b6103c7611c0e565b61036e6106d2366004614656565b609860209081526000928352604080842090915290825290205481565b6103c76106fd366004614b89565b611c22565b606554610471906001600160a01b031681565b6033546001600160a01b0316610471565b610739610734366004614c1d565b611d0b565b6040516103789190614c6c565b61047173beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac081565b6103c761076f366004614c7f565b611de7565b6103c7610782366004614d22565b611ead565b61036e61079536600461455f565b609f6020526000908152604090205481565b6103c76107b5366004614d57565b611f1a565b6104de6107c836600461457c565b609e6020526000908152604090205460ff1681565b6104de6107eb366004614db3565b609c60209081526000928352604080842090915290825290205460ff1681565b61087b61081936600461455f565b6040805160608082018352600080835260208084018290529284018190526001600160a01b03948516815260998352839020835191820184528054851682526001015493841691810191909152600160a01b90920463ffffffff169082015290565b6040805182516001600160a01b039081168252602080850151909116908201529181015163ffffffff1690820152606001610378565b61036e6108bf366004614ddf565b611fac565b6107396108d2366004614c1d565b612016565b6104717f000000000000000000000000000000000000000000000000000000000000000081565b61036e61c4e081565b6103ef633b9aca0081565b6103a761092036600461455f565b6122f7565b6103c7610933366004614e35565b6128e6565b6103c7610946366004614eae565b61292d565b61095e610959366004614f07565b61298b565b6040516103789190614fba565b6103c761097936600461501f565b612a32565b6103c761098c36600461455f565b612a62565b61036e612ad8565b6103c76109a736600461457c565b612ae7565b604080517f14bde674c9f64b2ad00eaaee4a8bed1fabef35c7507e3c5b9cfc9436909a2dad60208201526001600160a01b03808616928201929092528187166060820152908516608082015260a0810183905260c08101829052600090610a2c9060e0015b60405160208183030381529060405280519060200120612bef565b9695505050505050565b606654606090600190600290811603610a625760405163840a48d560e01b815260040160405180910390fd5b6000836001600160401b03811115610a7c57610a7c614745565b604051908082528060200260200182016040528015610aa5578160200160208202803683370190505b50336000908152609a60205260408120549192506001600160a01b03909116905b85811015610d6a57868682818110610ae057610ae061503b565b9050602002810190610af29190615051565b610b00906020810190615071565b9050878783818110610b1457610b1461503b565b9050602002810190610b269190615051565b610b309080615071565b905014610b50576040516343714afd60e01b815260040160405180910390fd5b33878783818110610b6357610b6361503b565b9050602002810190610b759190615051565b610b8690606081019060400161455f565b6001600160a01b031614610bad576040516330c4716960e21b815260040160405180910390fd5b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663547afb87848a8a86818110610bf157610bf161503b565b9050602002810190610c039190615051565b610c0d9080615071565b6040518463ffffffff1660e01b8152600401610c2b939291906150fa565b600060405180830381865afa158015610c48573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f19168201604052610c70919081019061511f565b9050610d4433848a8a86818110610c8957610c8961503b565b9050602002810190610c9b9190615051565b610ca59080615071565b808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508e92508d9150889050818110610ceb57610ceb61503b565b9050602002810190610cfd9190615051565b610d0b906020810190615071565b80806020026020016040519081016040528093929190818152602001838360200280828437600092019190915250889250612c1e915050565b848381518110610d5657610d5661503b565b602090810291909101015250600101610ac6565b509095945050505050565b606560009054906101000a90046001600160a01b03166001600160a01b031663eab66d7a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610dc8573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610dec91906151b3565b6001600160a01b0316336001600160a01b031614610e1d5760405163794821ff60e01b815260040160405180910390fd5b610e26816130b1565b50565b60655460405163237dfb4760e11b81523360048201526001600160a01b03909116906346fbf68e90602401602060405180830381865afa158015610e71573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610e9591906151d0565b610eb257604051631d77d47760e21b815260040160405180910390fd5b60665481811614610ed65760405163c61dca5d60e01b815260040160405180910390fd5b606681905560405181815233907fab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d906020015b60405180910390a250565b6000633b9aca0063ffffffff83161015610f625743610f3b61c4e063ffffffff8516615203565b1115610f5a576040516378f67ae160e11b815260040160405180910390fd5b506000919050565b42610f8d7f000000000000000000000000000000000000000000000000000000000000000084615216565b63ffffffff161115610fb2576040516378f67ae160e11b815260040160405180910390fd5b610fdc7f000000000000000000000000000000000000000000000000000000000000000083615216565b90505b919050565b600054610100900460ff16158080156110045750600054600160ff909116105b8061101e5750303b15801561101e575060005460ff166001145b6110865760405162461bcd60e51b815260206004820152602e60248201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160448201526d191e481a5b9a5d1a585b1a5e995960921b60648201526084015b60405180910390fd5b6000805460ff1916600117905580156110a9576000805461ff0019166101001790555b6110b38383613141565b6110bc846131c6565b8015611102576000805461ff0019169055604051600181527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b50505050565b6001600160a01b0383166000908152609b602052604081205461112e9085908585611fac565b90505b9392505050565b336001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001614806111975750336001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016145b6111b45760405163045206a560e21b815260040160405180910390fd5b6111bd846112eb565b15611102576001600160a01b038481166000908152609a602052604080822054815160018082528184019093529316929081602001602082028036833701905050905084816000815181106112145761121461503b565b6001600160a01b03928316602091820292909201015260405163547afb8760e01b81526000917f0000000000000000000000000000000000000000000000000000000000000000169063547afb87906112739086908690600401615232565b600060405180830381865afa158015611290573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526112b8919081019061511f565b90506112e28388888888866000815181106112d5576112d561503b565b6020026020010151613218565b50505050505050565b6001600160a01b039081166000908152609a602052604090205416151590565b611314336112eb565b1561133257604051633bf2b50360e11b815260040160405180910390fd5b604051632b6241f360e11b815233600482015263ffffffff841660248201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316906356c483e690604401600060405180830381600087803b15801561139f57600080fd5b505af11580156113b3573d6000803e3d6000fd5b505050506113c13385613311565b6040805180820190915260608152600060208201526113e33380836000613369565b336001600160a01b03167f8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e28660405161141c9190615256565b60405180910390a2336001600160a01b03167f02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b6708090848460405161145f9291906152ad565b60405180910390a25050505050565b60655460405163237dfb4760e11b81523360048201526001600160a01b03909116906346fbf68e90602401602060405180830381865afa1580156114b6573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906114da91906151d0565b6114f757604051631d77d47760e21b815260040160405180910390fd5b600019606681905560405190815233907fab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d9060200160405180910390a2565b600081604051602001611549919061535b565b604051602081830303815290604052805190602001209050919050565b336001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016146115af57604051633213a66160e21b815260040160405180910390fd5b6001600160a01b038381166000908152609a602052604080822054815160018082528184019093529316929081602001602082028036833701905050905073beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0816000815181106116155761161561503b565b6001600160a01b03928316602091820292909201015260405163547afb8760e01b81526000917f0000000000000000000000000000000000000000000000000000000000000000169063547afb87906116749086908690600401615232565b600060405180830381865afa158015611691573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526116b9919081019061511f565b6001600160a01b038716600090815260a26020908152604080832073beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac08452825280832081516060810183528154815260019091015460ff81161515938201939093526101009092046001600160401b0316908201528251929350909161175691908490849061173e5761173e61503b565b6020026020010151886135f79092919063ffffffff16565b6001600160a01b038816600090815260a26020908152604080832073beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac08452909152902090915061179a8187613634565b6001810154604080516001600160a01b038b1681526101009092046001600160401b031660208301527fddf935ec8825c7afee6a15d4731e28963ee96dfcb85d0a1e794b43318bbca4fd910160405180910390a16001600160a01b038816600090815260a26020908152604080832073beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac08452825280832081516060810183528154815260019091015460ff81161515938201939093526101009092046001600160401b031690820152845161188691908690849061186e5761186e61503b565b60200260200101518a6135f79092919063ffffffff16565b9050611891896112eb565b156118bf576118bf868a73beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac06118ba858861536e565b6136bf565b505050505050505050565b6040516394f649dd60e01b81526001600160a01b038281166004830152606091829160009182917f000000000000000000000000000000000000000000000000000000000000000016906394f649dd90602401600060405180830381865afa15801561193a573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f1916820160405261196291908101906153df565b60405163fe243a1760e01b81526001600160a01b03888116600483015273beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac060248301529294509092506000917f0000000000000000000000000000000000000000000000000000000000000000169063fe243a1790604401602060405180830381865afa1580156119eb573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611a0f91906154a0565b905080600003611a2457509094909350915050565b600083516001611a349190615203565b6001600160401b03811115611a4b57611a4b614745565b604051908082528060200260200182016040528015611a74578160200160208202803683370190505b509050600084516001611a879190615203565b6001600160401b03811115611a9e57611a9e614745565b604051908082528060200260200182016040528015611ac7578160200160208202803683370190505b50905073beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac082865181518110611af257611af261503b565b60200260200101906001600160a01b031690816001600160a01b0316815250508281865181518110611b2657611b2661503b565b60200260200101818152505060005b8551811015611bc957858181518110611b5057611b5061503b565b6020026020010151838281518110611b6a57611b6a61503b565b60200260200101906001600160a01b031690816001600160a01b031681525050848181518110611b9c57611b9c61503b565b6020026020010151828281518110611bb657611bb661503b565b6020908102919091010152600101611b35565b509097909650945050505050565b60006001600160a01b03821615801590610fdc5750506001600160a01b039081166000818152609a60205260409020549091161490565b611c16613748565b611c2060006131c6565b565b4283602001511015611c4757604051630819bdcd60e01b815260040160405180910390fd5b611c50856112eb565b15611c6e57604051633bf2b50360e11b815260040160405180910390fd5b611c7784611bd7565b611c94576040516325ec6c1f60e01b815260040160405180910390fd5b6000609b6000876001600160a01b03166001600160a01b03168152602001908152602001600020549050611cd986611cd28884898960200151611fac565b86516137a2565b6001600160a01b0386166000908152609b60205260409020600182019055611d0386868585613369565b505050505050565b6060600082516001600160401b03811115611d2857611d28614745565b604051908082528060200260200182016040528015611d51578160200160208202803683370190505b50905060005b8351811015611ddd576001600160a01b03851660009081526098602052604081208551909190869084908110611d8f57611d8f61503b565b60200260200101516001600160a01b03166001600160a01b0316815260200190815260200160002054828281518110611dca57611dca61503b565b6020908102919091010152600101611d57565b5090505b92915050565b606654600290600490811603611e105760405163840a48d560e01b815260040160405180910390fd5b611e186137d3565b60005b86811015611ea257611e9a888883818110611e3857611e3861503b565b9050602002810190611e4a91906154b9565b878784818110611e5c57611e5c61503b565b9050602002810190611e6e9190615071565b878786818110611e8057611e8061503b565b9050602002016020810190611e9591906154cf565b61382c565b600101611e1b565b506112e2600160c955565b611eb633611bd7565b611ed3576040516325ec6c1f60e01b815260040160405180910390fd5b336001600160a01b03167f02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b67080908383604051611f0e9291906152ad565b60405180910390a25050565b336001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001614611f63576040516323d871a560e01b815260040160405180910390fd5b6001600160a01b038085166000908152609860209081526040808320938716835292905290812054611f96908484613d2c565b9050611fa585600086846136bf565b5050505050565b604080517f39111bc4a4d688e1f685123d7497d4615370152a8ee4a0593e647bd06ad8bb0b60208201526001600160a01b038087169282019290925290831660608201526080810184905260a0810182905260009061200d9060c001610a11565b95945050505050565b6001600160a01b038083166000908152609a602052604080822054905163547afb8760e01b815260609391821692917f0000000000000000000000000000000000000000000000000000000000000000169063547afb879061207e9085908890600401615232565b600060405180830381865afa15801561209b573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526120c3919081019061511f565b905083516001600160401b038111156120de576120de614745565b604051908082528060200260200182016040528015612107578160200160208202803683370190505b50925060005b84518110156122ee57600061213a86838151811061212d5761212d61503b565b6020026020010151613d61565b90506000816001600160a01b031663fe243a17898986815181106121605761216061503b565b60200260200101516040518363ffffffff1660e01b815260040161219a9291906001600160a01b0392831681529116602082015260400190565b602060405180830381865afa1580156121b7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906121db91906154a0565b90506001600160a01b038516156122c4576001600160a01b038816600090815260a26020526040812088516122a192908a908790811061221d5761221d61503b565b6020908102919091018101516001600160a01b0316825281810192909252604090810160002081516060810183528154815260019091015460ff81161515938201939093526101009092046001600160401b03169082015285518690869081106122895761228961503b565b6020026020010151836135f79092919063ffffffff16565b8684815181106122b3576122b361503b565b6020026020010181815250506122e4565b808684815181106122d7576122d761503b565b6020026020010181815250505b505060010161210d565b50505092915050565b6066546060906001906002908116036123235760405163840a48d560e01b815260040160405180910390fd5b61232c836112eb565b6123495760405163a5c7c44560e01b815260040160405180910390fd5b61235283611bd7565b15612370576040516311ca333560e31b815260040160405180910390fd5b6001600160a01b038316612397576040516339b190bb60e11b815260040160405180910390fd5b6001600160a01b038084166000818152609a6020526040902054909116903314806123ca5750336001600160a01b038216145b806123f157506001600160a01b038181166000908152609960205260409020600101541633145b61240e57604051631e499a2360e11b815260040160405180910390fd5b60008061241a866118ca565b6001600160a01b038089166000818152609a602052604080822080546001600160a01b0319169055519496509294509086169290917ffee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af4467691a3336001600160a01b038716146124c357826001600160a01b0316866001600160a01b03167ff0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a60405160405180910390a35b81516000036124d4575050506128e0565b81516001600160401b038111156124ed576124ed614745565b604051908082528060200260200182016040528015612516578160200160208202803683370190505b50945060007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663547afb8785856040518363ffffffff1660e01b8152600401612569929190615232565b600060405180830381865afa158015612586573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526125ae919081019061511f565b905060005b83518110156128da5760408051600180825281830190925260009160208083019080368337505060408051600180825281830190925292935060009291506020808301908036833750506040805160018082528183019092529293506000929150602080830190803683370190505090508684815181106126365761263661503b565b6020026020010151836000815181106126515761265161503b565b60200260200101906001600160a01b031690816001600160a01b03168152505061274a60a260008d6001600160a01b03166001600160a01b0316815260200190815260200160002060008987815181106126ad576126ad61503b565b6020908102919091018101516001600160a01b0316825281810192909252604090810160002081516060810183528154815260019091015460ff81161515938201939093526101009092046001600160401b03169082015286518790879081106127195761271961503b565b60200260200101518887815181106127335761273361503b565b60200260200101516135f79092919063ffffffff16565b8260008151811061275d5761275d61503b565b60200260200101818152505084848151811061277b5761277b61503b565b6020026020010151816000815181106127965761279661503b565b60200260200101906001600160401b031690816001600160401b0316815250506127c38b89858585612c1e565b8a85815181106127d5576127d561503b565b602002602001018181525050670de0b6b3a76400006001600160401b031660a260008d6001600160a01b03166001600160a01b03168152602001908152602001600020600089878151811061282c5761282c61503b565b60200260200101516001600160a01b03166001600160a01b03168152602001908152602001600020600001819055507f8be932bac54561f27260f95463d9b8ab37e06b2842e5ee2404157cc13df6eb8f8b88868151811061288f5761288f61503b565b602090810291909101810151604080516001600160a01b0394851681529390911691830191909152670de0b6b3a76400009082015260600160405180910390a15050506001016125b3565b50505050505b50919050565b60665460029060049081160361290f5760405163840a48d560e01b815260040160405180910390fd5b6129176137d3565b6129238585858561382c565b611fa5600160c955565b612936336112eb565b1561295457604051633bf2b50360e11b815260040160405180910390fd5b61295d83611bd7565b61297a576040516325ec6c1f60e01b815260040160405180910390fd5b61298633848484613369565b505050565b6060600083516001600160401b038111156129a8576129a8614745565b6040519080825280602002602001820160405280156129db57816020015b60608152602001906001900390816129c65790505b50905060005b8451811015611ddd57612a0d8582815181106129ff576129ff61503b565b602002602001015185611d0b565b828281518110612a1f57612a1f61503b565b60209081029190910101526001016129e1565b612a3b33611bd7565b612a58576040516325ec6c1f60e01b815260040160405180910390fd5b610e263382613311565b612a6a613748565b6001600160a01b038116612acf5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b606482015260840161107d565b610e26816131c6565b6000612ae2613dd4565b905090565b606560009054906101000a90046001600160a01b03166001600160a01b031663eab66d7a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612b3a573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612b5e91906151b3565b6001600160a01b0316336001600160a01b031614612b8f5760405163794821ff60e01b815260040160405180910390fd5b606654198119606654191614612bb85760405163c61dca5d60e01b815260040160405180910390fd5b606681905560405181815233907f3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c90602001610f09565b6000612bf9613dd4565b60405161190160f01b6020820152602281019190915260428101839052606201611549565b60006001600160a01b038616612c47576040516339b190bb60e11b815260040160405180910390fd5b8351600003612c695760405163796cc52560e01b815260040160405180910390fd5b600084516001600160401b03811115612c8457612c84614745565b604051908082528060200260200182016040528015612cad578160200160208202803683370190505b50905060005b8551811015612fbc576000612cd387838151811061212d5761212d61503b565b9050600060a260008b6001600160a01b03166001600160a01b031681526020019081526020016000206000898581518110612d1057612d1061503b565b6020908102919091018101516001600160a01b03168252818101929092526040908101600090812082516060810184528154815260019091015460ff81161515948201949094526101009093046001600160401b031691830191909152875191925090612dbc908390899087908110612d8b57612d8b61503b565b60200260200101518a8781518110612da557612da561503b565b6020026020010151613eba9092919063ffffffff16565b90506000836001600160a01b031663fe243a178d8c8881518110612de257612de261503b565b60200260200101516040518363ffffffff1660e01b8152600401612e1c9291906001600160a01b0392831681529116602082015260400190565b602060405180830381865afa158015612e39573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612e5d91906154a0565b905080821115612e805760405163f020e5b960e01b815260040160405180910390fd5b6001600160a01b038b1615612ecd57612ecd8b8d8c8881518110612ea657612ea661503b565b60200260200101518c8981518110612ec057612ec061503b565b60200260200101516136bf565b612f1483898781518110612ee357612ee361503b565b60200260200101518b8881518110612efd57612efd61503b565b6020026020010151613ef79092919063ffffffff16565b868681518110612f2657612f2661503b565b602002602001018181525050836001600160a01b031663724af4238d8c8881518110612f5457612f5461503b565b6020026020010151856040518463ffffffff1660e01b8152600401612f7b939291906154ec565b600060405180830381600087803b158015612f9557600080fd5b505af1158015612fa9573d6000803e3d6000fd5b5050505050505050806001019050612cb3565b506001600160a01b0387166000908152609f60205260408120805491829190612fe483615510565b919050555060006040518060e001604052808a6001600160a01b03168152602001896001600160a01b031681526020018a6001600160a01b031681526020018381526020014263ffffffff168152602001888152602001848152509050600061304c82611536565b6000818152609e602052604090819020805460ff19166001179055519091507f26b2aae26516e8719ef50ea2f6831a2efbd4e37dccdf0f6936b27bc08e793e309061309c90839085908b90615529565b60405180910390a19998505050505050505050565b6001600160a01b0381166130d8576040516339b190bb60e11b815260040160405180910390fd5b606554604080516001600160a01b03928316815291831660208301527f6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6910160405180910390a1606580546001600160a01b0319166001600160a01b0392909216919091179055565b6065546001600160a01b031615801561316257506001600160a01b03821615155b61317f576040516339b190bb60e11b815260040160405180910390fd5b606681905560405181815233907fab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d9060200160405180910390a26131c2826130b1565b5050565b603380546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b6001600160a01b0380871660009081526098602090815260408083209388168352929052908120805484929061324f908490615203565b92505081905550856001600160a01b03167f1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c868685604051613293939291906154ec565b60405180910390a26001600160a01b03808616600090815260a2602090815260408083209388168352929052206132cc81858585613f22565b80546040517f8be932bac54561f27260f95463d9b8ab37e06b2842e5ee2404157cc13df6eb8f9161330091899189916154ec565b60405180910390a150505050505050565b6001600160a01b038216600090815260996020526040902081906133358282615574565b505060405133907ffebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac90611f0e908490615256565b6066546000906001908116036133925760405163840a48d560e01b815260040160405180910390fd5b6001600160a01b038085166000908152609960205260409020600101541680158015906133c85750336001600160a01b03821614155b80156133dd5750336001600160a01b03861614155b1561349057428460200151101561340757604051630819bdcd60e01b815260040160405180910390fd5b6001600160a01b0381166000908152609c6020908152604080832086845290915290205460ff161561344c57604051630d4c4c9160e21b815260040160405180910390fd5b61346181611cd2888885888a602001516109ac565b6001600160a01b0381166000908152609c602090815260408083208684529091529020805460ff191660011790555b6001600160a01b038681166000818152609a602052604080822080546001600160a01b031916948a169485179055517fc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d87433049190a36000806134ef886118ca565b9150915060007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663547afb8789856040518363ffffffff1660e01b8152600401613543929190615232565b600060405180830381865afa158015613560573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f19168201604052613588919081019061511f565b905060005b83518110156135eb576135e3898b8684815181106135ad576135ad61503b565b602002602001015160008786815181106135c9576135c961503b565b60200260200101518787815181106112d5576112d561503b565b60010161358d565b50505050505050505050565b600061112e826001600160401b031661362e6136128661405f565b6001600160401b031661362e61362788614080565b89906140a0565b906140a0565b6040805160608101825283548152600184015460ff81161515602083015261010090046001600160401b0390811692820192909252613688918316906136799061405f565b6001600160401b0316906140a0565b6001928301805468ffffffffffffffffff19166101006001600160401b03939093169290920260ff19169190911790921790915550565b6001600160a01b038085166000908152609860209081526040808320938616835292905290812080548392906136f690849061536e565b92505081905550836001600160a01b03167f6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd84848460405161373a939291906154ec565b60405180910390a250505050565b6033546001600160a01b03163314611c205760405162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604482015260640161107d565b6137b66001600160a01b03841683836140b5565b61298657604051638baa579f60e01b815260040160405180910390fd5b600260c954036138255760405162461bcd60e51b815260206004820152601f60248201527f5265656e7472616e637947756172643a207265656e7472616e742063616c6c00604482015260640161107d565b600260c955565b61383960a0850185615071565b8314905061385a576040516343714afd60e01b815260040160405180910390fd5b61386a606085016040860161455f565b6001600160a01b0316336001600160a01b03161461389b576040516316110d3560e21b815260040160405180910390fd5b60006138a96105f5866155d7565b6000818152609e602052604090205490915060ff166138db576040516387c9d21960e01b815260040160405180910390fd5b60006138f06103ea60a08801608089016145b2565b905060006001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001663843b349f61393360408a0160208b0161455f565b61394060a08b018b615071565b866040518563ffffffff1660e01b815260040161396094939291906155e3565b600060405180830381865afa15801561397d573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526139a5919081019061511f565b905060005b6139b760a0890189615071565b9050811015613ce35760006139fc6139d260a08b018b615071565b848181106139e2576139e261503b565b90506020020160208101906139f7919061455f565b613d61565b90506000613b0160a282613a1360208e018e61455f565b6001600160a01b031681526020810191909152604001600090812090613a3c60a08e018e615071565b87818110613a4c57613a4c61503b565b9050602002016020810190613a61919061455f565b6001600160a01b03168152602080820192909252604090810160002081516060810183528154815260019091015460ff81161515938201939093526101009092046001600160401b0316908201528551869086908110613ac357613ac361503b565b60200260200101518c8060c00190613adb9190615071565b87818110613aeb57613aeb61503b565b9050602002013561410c9092919063ffffffff16565b90508615613bf3576001600160a01b038216632eae418c613b2560208d018d61455f565b613b3260a08e018e615071565b87818110613b4257613b4261503b565b9050602002016020810190613b57919061455f565b8c8c88818110613b6957613b6961503b565b9050602002016020810190613b7e919061455f565b60405160e085901b6001600160e01b03191681526001600160a01b0393841660048201529183166024830152909116604482015260648101849052608401600060405180830381600087803b158015613bd657600080fd5b505af1158015613bea573d6000803e3d6000fd5b50505050613cd9565b6001600160a01b03821663c4623ea1613c0f60208d018d61455f565b613c1c60a08e018e615071565b87818110613c2c57613c2c61503b565b9050602002016020810190613c41919061455f565b8c8c88818110613c5357613c5361503b565b9050602002016020810190613c68919061455f565b60405160e085901b6001600160e01b03191681526001600160a01b0393841660048201529183166024830152909116604482015260648101849052608401600060405180830381600087803b158015613cc057600080fd5b505af1158015613cd4573d6000803e3d6000fd5b505050505b50506001016139aa565b506000838152609e602052604090819020805460ff19169055517f1f40400889274ed07b24845e5054a87a0cab969eb1277aafe61ae352e7c32a00906133009085815260200190565b6000613d57826001600160401b031661362e856001600160401b03168761413790919063ffffffff16565b61112e908561536e565b60006001600160a01b03821673beac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac014613dad577f0000000000000000000000000000000000000000000000000000000000000000610fdc565b7f000000000000000000000000000000000000000000000000000000000000000092915050565b60007f00000000000000000000000000000000000000000000000000000000000000004614613e955750604080518082018252600a81526922b4b3b2b72630bcb2b960b11b60209182015281517f8cad95687ba82c2ce50e74f7b754645e5117c3a5bec8151c0726d5857980a866818301527f71b625cfad44bac63b13dba07f2e1d6084ee04b6f8752101ece6126d584ee6ea81840152466060820152306080808301919091528351808303909101815260a0909101909252815191012090565b507f000000000000000000000000000000000000000000000000000000000000000090565b600061112e826001600160401b0316613ef1613ed58661405f565b6001600160401b0316613ef1613eea88614080565b8990614137565b90614137565b600061112e826001600160401b0316613ef1613f128661405f565b87906001600160401b0316614137565b82600003613f92576040805160608101825285548152600186015460ff81161515602083015261010090046001600160401b0390811692820192909252613f8b91831690613ef190613f739061405f565b670de0b6b3a7640000906001600160401b0316614137565b8455611102565b6040805160608101825285548152600186015460ff81161515602083015261010090046001600160401b031691810191909152600090613fd4908590846135f7565b90506000613fe28483615203565b6040805160608101825288548152600189015460ff81161515602083015261010090046001600160401b031691810191909152909150600090614054906140289061405f565b6001600160401b0316613ef1866001600160401b0316613ef1898b61404d9190615203565b8790614137565b875550505050505050565b6000816020015161407857670de0b6b3a7640000610fdc565b506040015190565b805160009015614091578151610fdc565b670de0b6b3a764000092915050565b60006111318383670de0b6b3a7640000614148565b60008060006140c48585614232565b909250905060008160048111156140dd576140dd61561f565b1480156140fb5750856001600160a01b0316826001600160a01b0316145b80610a2c5750610a2c868686614277565b600061112e826001600160401b031661362e6141278661405f565b87906001600160401b03166140a0565b600061113183670de0b6b3a7640000845b60008080600019858709858702925082811083820303915050806000036141825783828161417857614178615635565b0492505050611131565b8084116141c95760405162461bcd60e51b81526020600482015260156024820152744d6174683a206d756c446976206f766572666c6f7760581b604482015260640161107d565b60008486880960026001871981018816978890046003810283188082028403028082028403028082028403028082028403028082028403029081029092039091026000889003889004909101858311909403939093029303949094049190911702949350505050565b60008082516041036142685760208301516040840151606085015160001a61425c87828585614363565b94509450505050614270565b506000905060025b9250929050565b6000806000856001600160a01b0316631626ba7e60e01b86866040516024016142a192919061566f565b60408051601f198184030181529181526020820180516001600160e01b03166001600160e01b03199094169390931790925290516142df91906156a9565b600060405180830381855afa9150503d806000811461431a576040519150601f19603f3d011682016040523d82523d6000602084013e61431f565b606091505b509150915081801561433357506020815110155b8015610a2c57508051630b135d3f60e11b9061435890830160209081019084016154a0565b149695505050505050565b6000807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a083111561439a575060009050600361441e565b6040805160008082526020820180845289905260ff881692820192909252606081018690526080810185905260019060a0016020604051602081039080840390855afa1580156143ee573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b0381166144175760006001925092505061441e565b9150600090505b94509492505050565b6001600160a01b0381168114610e2657600080fd5b8035610fdf81614427565b600080600080600060a0868803121561445f57600080fd5b853561446a81614427565b9450602086013561447a81614427565b9350604086013561448a81614427565b94979396509394606081013594506080013592915050565b60008083601f8401126144b457600080fd5b5081356001600160401b038111156144cb57600080fd5b6020830191508360208260051b850101111561427057600080fd5b600080602083850312156144f957600080fd5b82356001600160401b0381111561450f57600080fd5b61451b858286016144a2565b90969095509350505050565b602080825282518282018190526000918401906040840190835b81811015610d6a578351835260209384019390920191600101614541565b60006020828403121561457157600080fd5b813561113181614427565b60006020828403121561458e57600080fd5b5035919050565b63ffffffff81168114610e2657600080fd5b8035610fdf81614595565b6000602082840312156145c457600080fd5b813561113181614595565b6000806000606084860312156145e457600080fd5b83356145ef81614427565b925060208401356145ff81614427565b929592945050506040919091013590565b6000806000806080858703121561462657600080fd5b843561463181614427565b9350602085013561464181614427565b93969395505050506040820135916060013590565b6000806040838503121561466957600080fd5b823561467481614427565b9150602083013561468481614427565b809150509250929050565b6000606082840312156128e057600080fd5b60008083601f8401126146b357600080fd5b5081356001600160401b038111156146ca57600080fd5b60208301915083602082850101111561427057600080fd5b60008060008060a085870312156146f857600080fd5b614702868661468f565b9350606085013561471281614595565b925060808501356001600160401b0381111561472d57600080fd5b614739878288016146a1565b95989497509550505050565b634e487b7160e01b600052604160045260246000fd5b60405160e081016001600160401b038111828210171561477d5761477d614745565b60405290565b604080519081016001600160401b038111828210171561477d5761477d614745565b604051601f8201601f191681016001600160401b03811182821017156147cd576147cd614745565b604052919050565b60006001600160401b038211156147ee576147ee614745565b5060051b60200190565b600082601f83011261480957600080fd5b813561481c614817826147d5565b6147a5565b8082825260208201915060208360051b86010192508583111561483e57600080fd5b602085015b8381101561486457803561485681614427565b835260209283019201614843565b5095945050505050565b600082601f83011261487f57600080fd5b813561488d614817826147d5565b8082825260208201915060208360051b8601019250858311156148af57600080fd5b602085015b838110156148645780358352602092830192016148b4565b600060e082840312156148de57600080fd5b6148e661475b565b90506148f18261443c565b81526148ff6020830161443c565b60208201526149106040830161443c565b60408201526060828101359082015261492b608083016145a7565b608082015260a08201356001600160401b0381111561494957600080fd5b614955848285016147f8565b60a08301525060c08201356001600160401b0381111561497457600080fd5b6149808482850161486e565b60c08301525092915050565b60006020828403121561499e57600080fd5b81356001600160401b038111156149b457600080fd5b6149c0848285016148cc565b949350505050565b6000602082840312156149da57600080fd5b813560ff8116811461113157600080fd5b6001600160401b0381168114610e2657600080fd5b600080600060608486031215614a1557600080fd5b8335614a2081614427565b9250602084013591506040840135614a37816149eb565b809150509250925092565b600081518084526020840193506020830160005b82811015614a7d5781516001600160a01b0316865260209586019590910190600101614a56565b5093949350505050565b600081518084526020840193506020830160005b82811015614a7d578151865260209586019590910190600101614a9b565b604081526000614acc6040830185614a42565b828103602084015261200d8185614a87565b600060408284031215614af057600080fd5b614af8614783565b905081356001600160401b03811115614b1057600080fd5b8201601f81018413614b2157600080fd5b80356001600160401b03811115614b3a57614b3a614745565b614b4d601f8201601f19166020016147a5565b818152856020838501011115614b6257600080fd5b81602084016020830137600060209282018301528352928301359282019290925292915050565b600080600080600060a08688031215614ba157600080fd5b8535614bac81614427565b94506020860135614bbc81614427565b935060408601356001600160401b03811115614bd757600080fd5b614be388828901614ade565b93505060608601356001600160401b03811115614bff57600080fd5b614c0b88828901614ade565b95989497509295608001359392505050565b60008060408385031215614c3057600080fd5b8235614c3b81614427565b915060208301356001600160401b03811115614c5657600080fd5b614c62858286016147f8565b9150509250929050565b6020815260006111316020830184614a87565b60008060008060008060608789031215614c9857600080fd5b86356001600160401b03811115614cae57600080fd5b614cba89828a016144a2565b90975095505060208701356001600160401b03811115614cd957600080fd5b614ce589828a016144a2565b90955093505060408701356001600160401b03811115614d0457600080fd5b614d1089828a016144a2565b979a9699509497509295939492505050565b60008060208385031215614d3557600080fd5b82356001600160401b03811115614d4b57600080fd5b61451b858286016146a1565b60008060008060808587031215614d6d57600080fd5b8435614d7881614427565b93506020850135614d8881614427565b92506040850135614d98816149eb565b91506060850135614da8816149eb565b939692955090935050565b60008060408385031215614dc657600080fd5b8235614dd181614427565b946020939093013593505050565b60008060008060808587031215614df557600080fd5b8435614e0081614427565b9350602085013592506040850135614e1781614427565b9396929550929360600135925050565b8015158114610e2657600080fd5b60008060008060608587031215614e4b57600080fd5b84356001600160401b03811115614e6157600080fd5b850160e08188031215614e7357600080fd5b935060208501356001600160401b03811115614e8e57600080fd5b614e9a878288016144a2565b9094509250506040850135614da881614e27565b600080600060608486031215614ec357600080fd5b8335614ece81614427565b925060208401356001600160401b03811115614ee957600080fd5b614ef586828701614ade565b93969395505050506040919091013590565b60008060408385031215614f1a57600080fd5b82356001600160401b03811115614f3057600080fd5b8301601f81018513614f4157600080fd5b8035614f4f614817826147d5565b8082825260208201915060208360051b850101925087831115614f7157600080fd5b6020840193505b82841015614f9c578335614f8b81614427565b825260209384019390910190614f78565b945050505060208301356001600160401b03811115614c5657600080fd5b6000602082016020835280845180835260408501915060408160051b86010192506020860160005b8281101561501357603f19878603018452614ffe858351614a87565b94506020938401939190910190600101614fe2565b50929695505050505050565b60006060828403121561503157600080fd5b611131838361468f565b634e487b7160e01b600052603260045260246000fd5b60008235605e1983360301811261506757600080fd5b9190910192915050565b6000808335601e1984360301811261508857600080fd5b8301803591506001600160401b038211156150a257600080fd5b6020019150600581901b360382131561427057600080fd5b81835260208301925060008160005b84811015614a7d5781356150dc81614427565b6001600160a01b0316865260209586019591909101906001016150c9565b6001600160a01b038416815260406020820181905260009061200d90830184866150ba565b60006020828403121561513157600080fd5b81516001600160401b0381111561514757600080fd5b8201601f8101841361515857600080fd5b8051615166614817826147d5565b8082825260208201915060208360051b85010192508683111561518857600080fd5b6020840193505b82841015610a2c5783516151a2816149eb565b82526020938401939091019061518f565b6000602082840312156151c557600080fd5b815161113181614427565b6000602082840312156151e257600080fd5b815161113181614e27565b634e487b7160e01b600052601160045260246000fd5b80820180821115611de157611de16151ed565b63ffffffff8181168382160190811115611de157611de16151ed565b6001600160a01b038316815260406020820181905260009061112e90830184614a42565b60608101823561526581614427565b6001600160a01b03168252602083013561527e81614427565b6001600160a01b03166020830152604083013561529a81614595565b63ffffffff811660408401525092915050565b60208152816020820152818360408301376000818301604090810191909152601f909201601f19160101919050565b80516001600160a01b03908116835260208083015182169084015260408083015190911690830152606080820151908301526080808201516000916153289085018263ffffffff169052565b5060a082015160e060a085015261534260e0850182614a42565b905060c083015184820360c086015261200d8282614a87565b60208152600061113160208301846152dc565b81810381811115611de157611de16151ed565b600082601f83011261539257600080fd5b81516153a0614817826147d5565b8082825260208201915060208360051b8601019250858311156153c257600080fd5b602085015b838110156148645780518352602092830192016153c7565b600080604083850312156153f257600080fd5b82516001600160401b0381111561540857600080fd5b8301601f8101851361541957600080fd5b8051615427614817826147d5565b8082825260208201915060208360051b85010192508783111561544957600080fd5b6020840193505b8284101561547457835161546381614427565b825260209384019390910190615450565b8095505050505060208301516001600160401b0381111561549457600080fd5b614c6285828601615381565b6000602082840312156154b257600080fd5b5051919050565b6000823560de1983360301811261506757600080fd5b6000602082840312156154e157600080fd5b813561113181614e27565b6001600160a01b039384168152919092166020820152604081019190915260600190565b600060018201615522576155226151ed565b5060010190565b83815260606020820152600061554260608301856152dc565b8281036040840152610a2c8185614a87565b80546001600160a01b0319166001600160a01b0392909216919091179055565b813561557f81614427565b6155898183615554565b5060018101602083013561559c81614427565b6155a68183615554565b5060408301356155b581614595565b815463ffffffff60a01b191660a09190911b63ffffffff60a01b161790555050565b6000610fdc36836148cc565b6001600160a01b038516815260606020820181905260009061560890830185876150ba565b905063ffffffff8316604083015295945050505050565b634e487b7160e01b600052602160045260246000fd5b634e487b7160e01b600052601260045260246000fd5b60005b8381101561566657818101518382015260200161564e565b50506000910152565b828152604060208201526000825180604084015261569481606085016020870161564b565b601f01601f1916919091016060019392505050565b6000825161506781846020870161564b56fea2646970667358221220cdd00abdad34c2769457664847fa94862eed70849deb551a9cb08636607be58164736f6c634300081b0033",
+}
+
+// DelegationManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use DelegationManagerMetaData.ABI instead.
+var DelegationManagerABI = DelegationManagerMetaData.ABI
+
+// DelegationManagerBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use DelegationManagerMetaData.Bin instead.
+var DelegationManagerBin = DelegationManagerMetaData.Bin
+
+// DeployDelegationManager deploys a new Ethereum contract, binding an instance of DelegationManager to it.
+func DeployDelegationManager(auth *bind.TransactOpts, backend bind.ContractBackend, _avsDirectory common.Address, _strategyManager common.Address, _eigenPodManager common.Address, _allocationManager common.Address, _MIN_WITHDRAWAL_DELAY uint32) (common.Address, *types.Transaction, *DelegationManager, error) {
+	parsed, err := DelegationManagerMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(DelegationManagerBin), backend, _avsDirectory, _strategyManager, _eigenPodManager, _allocationManager, _MIN_WITHDRAWAL_DELAY)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &DelegationManager{DelegationManagerCaller: DelegationManagerCaller{contract: contract}, DelegationManagerTransactor: DelegationManagerTransactor{contract: contract}, DelegationManagerFilterer: DelegationManagerFilterer{contract: contract}}, nil
+}
+
+// DelegationManager is an auto generated Go binding around an Ethereum contract.
+type DelegationManager struct {
+	DelegationManagerCaller     // Read-only binding to the contract
+	DelegationManagerTransactor // Write-only binding to the contract
+	DelegationManagerFilterer   // Log filterer for contract events
+}
+
+// DelegationManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type DelegationManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type DelegationManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type DelegationManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type DelegationManagerSession struct {
+	Contract     *DelegationManager // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// DelegationManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type DelegationManagerCallerSession struct {
+	Contract *DelegationManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// DelegationManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type DelegationManagerTransactorSession struct {
+	Contract     *DelegationManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// DelegationManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type DelegationManagerRaw struct {
+	Contract *DelegationManager // Generic contract binding to access the raw methods on
+}
+
+// DelegationManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type DelegationManagerCallerRaw struct {
+	Contract *DelegationManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// DelegationManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type DelegationManagerTransactorRaw struct {
+	Contract *DelegationManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewDelegationManager creates a new instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManager(address common.Address, backend bind.ContractBackend) (*DelegationManager, error) {
+	contract, err := bindDelegationManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManager{DelegationManagerCaller: DelegationManagerCaller{contract: contract}, DelegationManagerTransactor: DelegationManagerTransactor{contract: contract}, DelegationManagerFilterer: DelegationManagerFilterer{contract: contract}}, nil
+}
+
+// NewDelegationManagerCaller creates a new read-only instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManagerCaller(address common.Address, caller bind.ContractCaller) (*DelegationManagerCaller, error) {
+	contract, err := bindDelegationManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerCaller{contract: contract}, nil
+}
+
+// NewDelegationManagerTransactor creates a new write-only instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*DelegationManagerTransactor, error) {
+	contract, err := bindDelegationManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerTransactor{contract: contract}, nil
+}
+
+// NewDelegationManagerFilterer creates a new log filterer instance of DelegationManager, bound to a specific deployed contract.
+func NewDelegationManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*DelegationManagerFilterer, error) {
+	contract, err := bindDelegationManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerFilterer{contract: contract}, nil
+}
+
+// bindDelegationManager binds a generic wrapper to an already deployed contract.
+func bindDelegationManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := DelegationManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_DelegationManager *DelegationManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _DelegationManager.Contract.DelegationManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_DelegationManager *DelegationManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegationManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_DelegationManager *DelegationManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegationManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_DelegationManager *DelegationManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _DelegationManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_DelegationManager *DelegationManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_DelegationManager *DelegationManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _DelegationManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// DELEGATIONAPPROVALTYPEHASH is a free data retrieval call binding the contract method 0x04a4f979.
+//
+// Solidity: function DELEGATION_APPROVAL_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) DELEGATIONAPPROVALTYPEHASH(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "DELEGATION_APPROVAL_TYPEHASH")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DELEGATIONAPPROVALTYPEHASH is a free data retrieval call binding the contract method 0x04a4f979.
+//
+// Solidity: function DELEGATION_APPROVAL_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) DELEGATIONAPPROVALTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.DELEGATIONAPPROVALTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// DELEGATIONAPPROVALTYPEHASH is a free data retrieval call binding the contract method 0x04a4f979.
+//
+// Solidity: function DELEGATION_APPROVAL_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) DELEGATIONAPPROVALTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.DELEGATIONAPPROVALTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// LEGACYMINWITHDRAWALDELAYBLOCKS is a free data retrieval call binding the contract method 0xcb00387b.
+//
+// Solidity: function LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) LEGACYMINWITHDRAWALDELAYBLOCKS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LEGACYMINWITHDRAWALDELAYBLOCKS is a free data retrieval call binding the contract method 0xcb00387b.
+//
+// Solidity: function LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) LEGACYMINWITHDRAWALDELAYBLOCKS() (*big.Int, error) {
+	return _DelegationManager.Contract.LEGACYMINWITHDRAWALDELAYBLOCKS(&_DelegationManager.CallOpts)
+}
+
+// LEGACYMINWITHDRAWALDELAYBLOCKS is a free data retrieval call binding the contract method 0xcb00387b.
+//
+// Solidity: function LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS() view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) LEGACYMINWITHDRAWALDELAYBLOCKS() (*big.Int, error) {
+	return _DelegationManager.Contract.LEGACYMINWITHDRAWALDELAYBLOCKS(&_DelegationManager.CallOpts)
+}
+
+// LEGACYWITHDRAWALCHECKVALUE is a free data retrieval call binding the contract method 0xcebc04ef.
+//
+// Solidity: function LEGACY_WITHDRAWAL_CHECK_VALUE() view returns(uint32)
+func (_DelegationManager *DelegationManagerCaller) LEGACYWITHDRAWALCHECKVALUE(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "LEGACY_WITHDRAWAL_CHECK_VALUE")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// LEGACYWITHDRAWALCHECKVALUE is a free data retrieval call binding the contract method 0xcebc04ef.
+//
+// Solidity: function LEGACY_WITHDRAWAL_CHECK_VALUE() view returns(uint32)
+func (_DelegationManager *DelegationManagerSession) LEGACYWITHDRAWALCHECKVALUE() (uint32, error) {
+	return _DelegationManager.Contract.LEGACYWITHDRAWALCHECKVALUE(&_DelegationManager.CallOpts)
+}
+
+// LEGACYWITHDRAWALCHECKVALUE is a free data retrieval call binding the contract method 0xcebc04ef.
+//
+// Solidity: function LEGACY_WITHDRAWAL_CHECK_VALUE() view returns(uint32)
+func (_DelegationManager *DelegationManagerCallerSession) LEGACYWITHDRAWALCHECKVALUE() (uint32, error) {
+	return _DelegationManager.Contract.LEGACYWITHDRAWALCHECKVALUE(&_DelegationManager.CallOpts)
+}
+
+// MINWITHDRAWALDELAY is a free data retrieval call binding the contract method 0x4a5f2b5d.
+//
+// Solidity: function MIN_WITHDRAWAL_DELAY() view returns(uint32)
+func (_DelegationManager *DelegationManagerCaller) MINWITHDRAWALDELAY(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "MIN_WITHDRAWAL_DELAY")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// MINWITHDRAWALDELAY is a free data retrieval call binding the contract method 0x4a5f2b5d.
+//
+// Solidity: function MIN_WITHDRAWAL_DELAY() view returns(uint32)
+func (_DelegationManager *DelegationManagerSession) MINWITHDRAWALDELAY() (uint32, error) {
+	return _DelegationManager.Contract.MINWITHDRAWALDELAY(&_DelegationManager.CallOpts)
+}
+
+// MINWITHDRAWALDELAY is a free data retrieval call binding the contract method 0x4a5f2b5d.
+//
+// Solidity: function MIN_WITHDRAWAL_DELAY() view returns(uint32)
+func (_DelegationManager *DelegationManagerCallerSession) MINWITHDRAWALDELAY() (uint32, error) {
+	return _DelegationManager.Contract.MINWITHDRAWALDELAY(&_DelegationManager.CallOpts)
+}
+
+// STAKERDELEGATIONTYPEHASH is a free data retrieval call binding the contract method 0x43377382.
+//
+// Solidity: function STAKER_DELEGATION_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) STAKERDELEGATIONTYPEHASH(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "STAKER_DELEGATION_TYPEHASH")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// STAKERDELEGATIONTYPEHASH is a free data retrieval call binding the contract method 0x43377382.
+//
+// Solidity: function STAKER_DELEGATION_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) STAKERDELEGATIONTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.STAKERDELEGATIONTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// STAKERDELEGATIONTYPEHASH is a free data retrieval call binding the contract method 0x43377382.
+//
+// Solidity: function STAKER_DELEGATION_TYPEHASH() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) STAKERDELEGATIONTYPEHASH() ([32]byte, error) {
+	return _DelegationManager.Contract.STAKERDELEGATIONTYPEHASH(&_DelegationManager.CallOpts)
+}
+
+// AllocationManager is a free data retrieval call binding the contract method 0xca8aa7c7.
+//
+// Solidity: function allocationManager() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) AllocationManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "allocationManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AllocationManager is a free data retrieval call binding the contract method 0xca8aa7c7.
+//
+// Solidity: function allocationManager() view returns(address)
+func (_DelegationManager *DelegationManagerSession) AllocationManager() (common.Address, error) {
+	return _DelegationManager.Contract.AllocationManager(&_DelegationManager.CallOpts)
+}
+
+// AllocationManager is a free data retrieval call binding the contract method 0xca8aa7c7.
+//
+// Solidity: function allocationManager() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) AllocationManager() (common.Address, error) {
+	return _DelegationManager.Contract.AllocationManager(&_DelegationManager.CallOpts)
+}
+
+// AvsDirectory is a free data retrieval call binding the contract method 0x6b3aa72e.
+//
+// Solidity: function avsDirectory() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) AvsDirectory(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "avsDirectory")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AvsDirectory is a free data retrieval call binding the contract method 0x6b3aa72e.
+//
+// Solidity: function avsDirectory() view returns(address)
+func (_DelegationManager *DelegationManagerSession) AvsDirectory() (common.Address, error) {
+	return _DelegationManager.Contract.AvsDirectory(&_DelegationManager.CallOpts)
+}
+
+// AvsDirectory is a free data retrieval call binding the contract method 0x6b3aa72e.
+//
+// Solidity: function avsDirectory() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) AvsDirectory() (common.Address, error) {
+	return _DelegationManager.Contract.AvsDirectory(&_DelegationManager.CallOpts)
+}
+
+// BeaconChainETHStrategy is a free data retrieval call binding the contract method 0x9104c319.
+//
+// Solidity: function beaconChainETHStrategy() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) BeaconChainETHStrategy(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "beaconChainETHStrategy")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// BeaconChainETHStrategy is a free data retrieval call binding the contract method 0x9104c319.
+//
+// Solidity: function beaconChainETHStrategy() view returns(address)
+func (_DelegationManager *DelegationManagerSession) BeaconChainETHStrategy() (common.Address, error) {
+	return _DelegationManager.Contract.BeaconChainETHStrategy(&_DelegationManager.CallOpts)
+}
+
+// BeaconChainETHStrategy is a free data retrieval call binding the contract method 0x9104c319.
+//
+// Solidity: function beaconChainETHStrategy() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) BeaconChainETHStrategy() (common.Address, error) {
+	return _DelegationManager.Contract.BeaconChainETHStrategy(&_DelegationManager.CallOpts)
+}
+
+// CalculateCurrentStakerDelegationDigestHash is a free data retrieval call binding the contract method 0x1bbce091.
+//
+// Solidity: function calculateCurrentStakerDelegationDigestHash(address staker, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateCurrentStakerDelegationDigestHash(opts *bind.CallOpts, staker common.Address, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateCurrentStakerDelegationDigestHash", staker, operator, expiry)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateCurrentStakerDelegationDigestHash is a free data retrieval call binding the contract method 0x1bbce091.
+//
+// Solidity: function calculateCurrentStakerDelegationDigestHash(address staker, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateCurrentStakerDelegationDigestHash(staker common.Address, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateCurrentStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, operator, expiry)
+}
+
+// CalculateCurrentStakerDelegationDigestHash is a free data retrieval call binding the contract method 0x1bbce091.
+//
+// Solidity: function calculateCurrentStakerDelegationDigestHash(address staker, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateCurrentStakerDelegationDigestHash(staker common.Address, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateCurrentStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, operator, expiry)
+}
+
+// CalculateDelegationApprovalDigestHash is a free data retrieval call binding the contract method 0x0b9f487a.
+//
+// Solidity: function calculateDelegationApprovalDigestHash(address staker, address operator, address approver, bytes32 approverSalt, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateDelegationApprovalDigestHash(opts *bind.CallOpts, staker common.Address, operator common.Address, approver common.Address, approverSalt [32]byte, expiry *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateDelegationApprovalDigestHash", staker, operator, approver, approverSalt, expiry)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateDelegationApprovalDigestHash is a free data retrieval call binding the contract method 0x0b9f487a.
+//
+// Solidity: function calculateDelegationApprovalDigestHash(address staker, address operator, address approver, bytes32 approverSalt, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateDelegationApprovalDigestHash(staker common.Address, operator common.Address, approver common.Address, approverSalt [32]byte, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateDelegationApprovalDigestHash(&_DelegationManager.CallOpts, staker, operator, approver, approverSalt, expiry)
+}
+
+// CalculateDelegationApprovalDigestHash is a free data retrieval call binding the contract method 0x0b9f487a.
+//
+// Solidity: function calculateDelegationApprovalDigestHash(address staker, address operator, address approver, bytes32 approverSalt, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateDelegationApprovalDigestHash(staker common.Address, operator common.Address, approver common.Address, approverSalt [32]byte, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateDelegationApprovalDigestHash(&_DelegationManager.CallOpts, staker, operator, approver, approverSalt, expiry)
+}
+
+// CalculateStakerDelegationDigestHash is a free data retrieval call binding the contract method 0xc94b5111.
+//
+// Solidity: function calculateStakerDelegationDigestHash(address staker, uint256 nonce, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateStakerDelegationDigestHash(opts *bind.CallOpts, staker common.Address, nonce *big.Int, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateStakerDelegationDigestHash", staker, nonce, operator, expiry)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateStakerDelegationDigestHash is a free data retrieval call binding the contract method 0xc94b5111.
+//
+// Solidity: function calculateStakerDelegationDigestHash(address staker, uint256 nonce, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateStakerDelegationDigestHash(staker common.Address, nonce *big.Int, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, nonce, operator, expiry)
+}
+
+// CalculateStakerDelegationDigestHash is a free data retrieval call binding the contract method 0xc94b5111.
+//
+// Solidity: function calculateStakerDelegationDigestHash(address staker, uint256 nonce, address operator, uint256 expiry) view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateStakerDelegationDigestHash(staker common.Address, nonce *big.Int, operator common.Address, expiry *big.Int) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateStakerDelegationDigestHash(&_DelegationManager.CallOpts, staker, nonce, operator, expiry)
+}
+
+// CalculateWithdrawalRoot is a free data retrieval call binding the contract method 0x597b36da.
+//
+// Solidity: function calculateWithdrawalRoot((address,address,address,uint256,uint32,address[],uint256[]) withdrawal) pure returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) CalculateWithdrawalRoot(opts *bind.CallOpts, withdrawal IDelegationManagerTypesWithdrawal) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "calculateWithdrawalRoot", withdrawal)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CalculateWithdrawalRoot is a free data retrieval call binding the contract method 0x597b36da.
+//
+// Solidity: function calculateWithdrawalRoot((address,address,address,uint256,uint32,address[],uint256[]) withdrawal) pure returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) CalculateWithdrawalRoot(withdrawal IDelegationManagerTypesWithdrawal) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateWithdrawalRoot(&_DelegationManager.CallOpts, withdrawal)
+}
+
+// CalculateWithdrawalRoot is a free data retrieval call binding the contract method 0x597b36da.
+//
+// Solidity: function calculateWithdrawalRoot((address,address,address,uint256,uint32,address[],uint256[]) withdrawal) pure returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) CalculateWithdrawalRoot(withdrawal IDelegationManagerTypesWithdrawal) ([32]byte, error) {
+	return _DelegationManager.Contract.CalculateWithdrawalRoot(&_DelegationManager.CallOpts, withdrawal)
+}
+
+// CumulativeWithdrawalsQueued is a free data retrieval call binding the contract method 0xa1788484.
+//
+// Solidity: function cumulativeWithdrawalsQueued(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) CumulativeWithdrawalsQueued(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "cumulativeWithdrawalsQueued", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CumulativeWithdrawalsQueued is a free data retrieval call binding the contract method 0xa1788484.
+//
+// Solidity: function cumulativeWithdrawalsQueued(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) CumulativeWithdrawalsQueued(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.CumulativeWithdrawalsQueued(&_DelegationManager.CallOpts, arg0)
+}
+
+// CumulativeWithdrawalsQueued is a free data retrieval call binding the contract method 0xa1788484.
+//
+// Solidity: function cumulativeWithdrawalsQueued(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) CumulativeWithdrawalsQueued(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.CumulativeWithdrawalsQueued(&_DelegationManager.CallOpts, arg0)
+}
+
+// DelegatedTo is a free data retrieval call binding the contract method 0x65da1264.
+//
+// Solidity: function delegatedTo(address ) view returns(address)
+func (_DelegationManager *DelegationManagerCaller) DelegatedTo(opts *bind.CallOpts, arg0 common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "delegatedTo", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// DelegatedTo is a free data retrieval call binding the contract method 0x65da1264.
+//
+// Solidity: function delegatedTo(address ) view returns(address)
+func (_DelegationManager *DelegationManagerSession) DelegatedTo(arg0 common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegatedTo(&_DelegationManager.CallOpts, arg0)
+}
+
+// DelegatedTo is a free data retrieval call binding the contract method 0x65da1264.
+//
+// Solidity: function delegatedTo(address ) view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) DelegatedTo(arg0 common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegatedTo(&_DelegationManager.CallOpts, arg0)
+}
+
+// DelegationApprover is a free data retrieval call binding the contract method 0x3cdeb5e0.
+//
+// Solidity: function delegationApprover(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerCaller) DelegationApprover(opts *bind.CallOpts, operator common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "delegationApprover", operator)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// DelegationApprover is a free data retrieval call binding the contract method 0x3cdeb5e0.
+//
+// Solidity: function delegationApprover(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerSession) DelegationApprover(operator common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegationApprover(&_DelegationManager.CallOpts, operator)
+}
+
+// DelegationApprover is a free data retrieval call binding the contract method 0x3cdeb5e0.
+//
+// Solidity: function delegationApprover(address operator) view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) DelegationApprover(operator common.Address) (common.Address, error) {
+	return _DelegationManager.Contract.DelegationApprover(&_DelegationManager.CallOpts, operator)
+}
+
+// DelegationApproverSaltIsSpent is a free data retrieval call binding the contract method 0xbb45fef2.
+//
+// Solidity: function delegationApproverSaltIsSpent(address , bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) DelegationApproverSaltIsSpent(opts *bind.CallOpts, arg0 common.Address, arg1 [32]byte) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "delegationApproverSaltIsSpent", arg0, arg1)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// DelegationApproverSaltIsSpent is a free data retrieval call binding the contract method 0xbb45fef2.
+//
+// Solidity: function delegationApproverSaltIsSpent(address , bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) DelegationApproverSaltIsSpent(arg0 common.Address, arg1 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.DelegationApproverSaltIsSpent(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// DelegationApproverSaltIsSpent is a free data retrieval call binding the contract method 0xbb45fef2.
+//
+// Solidity: function delegationApproverSaltIsSpent(address , bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) DelegationApproverSaltIsSpent(arg0 common.Address, arg1 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.DelegationApproverSaltIsSpent(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCaller) DomainSeparator(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "domainSeparator")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_DelegationManager *DelegationManagerSession) DomainSeparator() ([32]byte, error) {
+	return _DelegationManager.Contract.DomainSeparator(&_DelegationManager.CallOpts)
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_DelegationManager *DelegationManagerCallerSession) DomainSeparator() ([32]byte, error) {
+	return _DelegationManager.Contract.DomainSeparator(&_DelegationManager.CallOpts)
+}
+
+// EigenPodManager is a free data retrieval call binding the contract method 0x4665bcda.
+//
+// Solidity: function eigenPodManager() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) EigenPodManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "eigenPodManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// EigenPodManager is a free data retrieval call binding the contract method 0x4665bcda.
+//
+// Solidity: function eigenPodManager() view returns(address)
+func (_DelegationManager *DelegationManagerSession) EigenPodManager() (common.Address, error) {
+	return _DelegationManager.Contract.EigenPodManager(&_DelegationManager.CallOpts)
+}
+
+// EigenPodManager is a free data retrieval call binding the contract method 0x4665bcda.
+//
+// Solidity: function eigenPodManager() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) EigenPodManager() (common.Address, error) {
+	return _DelegationManager.Contract.EigenPodManager(&_DelegationManager.CallOpts)
+}
+
+// GetCompletableTimestamp is a free data retrieval call binding the contract method 0x15c4a288.
+//
+// Solidity: function getCompletableTimestamp(uint32 startTimestamp) view returns(uint32 completableTimestamp)
+func (_DelegationManager *DelegationManagerCaller) GetCompletableTimestamp(opts *bind.CallOpts, startTimestamp uint32) (uint32, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getCompletableTimestamp", startTimestamp)
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// GetCompletableTimestamp is a free data retrieval call binding the contract method 0x15c4a288.
+//
+// Solidity: function getCompletableTimestamp(uint32 startTimestamp) view returns(uint32 completableTimestamp)
+func (_DelegationManager *DelegationManagerSession) GetCompletableTimestamp(startTimestamp uint32) (uint32, error) {
+	return _DelegationManager.Contract.GetCompletableTimestamp(&_DelegationManager.CallOpts, startTimestamp)
+}
+
+// GetCompletableTimestamp is a free data retrieval call binding the contract method 0x15c4a288.
+//
+// Solidity: function getCompletableTimestamp(uint32 startTimestamp) view returns(uint32 completableTimestamp)
+func (_DelegationManager *DelegationManagerCallerSession) GetCompletableTimestamp(startTimestamp uint32) (uint32, error) {
+	return _DelegationManager.Contract.GetCompletableTimestamp(&_DelegationManager.CallOpts, startTimestamp)
+}
+
+// GetDepositedShares is a free data retrieval call binding the contract method 0x66d5ba93.
+//
+// Solidity: function getDepositedShares(address staker) view returns(address[], uint256[])
+func (_DelegationManager *DelegationManagerCaller) GetDepositedShares(opts *bind.CallOpts, staker common.Address) ([]common.Address, []*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getDepositedShares", staker)
+
+	if err != nil {
+		return *new([]common.Address), *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+	out1 := *abi.ConvertType(out[1], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, out1, err
+
+}
+
+// GetDepositedShares is a free data retrieval call binding the contract method 0x66d5ba93.
+//
+// Solidity: function getDepositedShares(address staker) view returns(address[], uint256[])
+func (_DelegationManager *DelegationManagerSession) GetDepositedShares(staker common.Address) ([]common.Address, []*big.Int, error) {
+	return _DelegationManager.Contract.GetDepositedShares(&_DelegationManager.CallOpts, staker)
+}
+
+// GetDepositedShares is a free data retrieval call binding the contract method 0x66d5ba93.
+//
+// Solidity: function getDepositedShares(address staker) view returns(address[], uint256[])
+func (_DelegationManager *DelegationManagerCallerSession) GetDepositedShares(staker common.Address) ([]common.Address, []*big.Int, error) {
+	return _DelegationManager.Contract.GetDepositedShares(&_DelegationManager.CallOpts, staker)
+}
+
+// GetOperatorShares is a free data retrieval call binding the contract method 0x90041347.
+//
+// Solidity: function getOperatorShares(address operator, address[] strategies) view returns(uint256[])
+func (_DelegationManager *DelegationManagerCaller) GetOperatorShares(opts *bind.CallOpts, operator common.Address, strategies []common.Address) ([]*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getOperatorShares", operator, strategies)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// GetOperatorShares is a free data retrieval call binding the contract method 0x90041347.
+//
+// Solidity: function getOperatorShares(address operator, address[] strategies) view returns(uint256[])
+func (_DelegationManager *DelegationManagerSession) GetOperatorShares(operator common.Address, strategies []common.Address) ([]*big.Int, error) {
+	return _DelegationManager.Contract.GetOperatorShares(&_DelegationManager.CallOpts, operator, strategies)
+}
+
+// GetOperatorShares is a free data retrieval call binding the contract method 0x90041347.
+//
+// Solidity: function getOperatorShares(address operator, address[] strategies) view returns(uint256[])
+func (_DelegationManager *DelegationManagerCallerSession) GetOperatorShares(operator common.Address, strategies []common.Address) ([]*big.Int, error) {
+	return _DelegationManager.Contract.GetOperatorShares(&_DelegationManager.CallOpts, operator, strategies)
+}
+
+// GetOperatorsShares is a free data retrieval call binding the contract method 0xf0e0e676.
+//
+// Solidity: function getOperatorsShares(address[] operators, address[] strategies) view returns(uint256[][])
+func (_DelegationManager *DelegationManagerCaller) GetOperatorsShares(opts *bind.CallOpts, operators []common.Address, strategies []common.Address) ([][]*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getOperatorsShares", operators, strategies)
+
+	if err != nil {
+		return *new([][]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([][]*big.Int)).(*[][]*big.Int)
+
+	return out0, err
+
+}
+
+// GetOperatorsShares is a free data retrieval call binding the contract method 0xf0e0e676.
+//
+// Solidity: function getOperatorsShares(address[] operators, address[] strategies) view returns(uint256[][])
+func (_DelegationManager *DelegationManagerSession) GetOperatorsShares(operators []common.Address, strategies []common.Address) ([][]*big.Int, error) {
+	return _DelegationManager.Contract.GetOperatorsShares(&_DelegationManager.CallOpts, operators, strategies)
+}
+
+// GetOperatorsShares is a free data retrieval call binding the contract method 0xf0e0e676.
+//
+// Solidity: function getOperatorsShares(address[] operators, address[] strategies) view returns(uint256[][])
+func (_DelegationManager *DelegationManagerCallerSession) GetOperatorsShares(operators []common.Address, strategies []common.Address) ([][]*big.Int, error) {
+	return _DelegationManager.Contract.GetOperatorsShares(&_DelegationManager.CallOpts, operators, strategies)
+}
+
+// GetWithdrawableShares is a free data retrieval call binding the contract method 0xc978f7ac.
+//
+// Solidity: function getWithdrawableShares(address staker, address[] strategies) view returns(uint256[] withdrawableShares)
+func (_DelegationManager *DelegationManagerCaller) GetWithdrawableShares(opts *bind.CallOpts, staker common.Address, strategies []common.Address) ([]*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "getWithdrawableShares", staker, strategies)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// GetWithdrawableShares is a free data retrieval call binding the contract method 0xc978f7ac.
+//
+// Solidity: function getWithdrawableShares(address staker, address[] strategies) view returns(uint256[] withdrawableShares)
+func (_DelegationManager *DelegationManagerSession) GetWithdrawableShares(staker common.Address, strategies []common.Address) ([]*big.Int, error) {
+	return _DelegationManager.Contract.GetWithdrawableShares(&_DelegationManager.CallOpts, staker, strategies)
+}
+
+// GetWithdrawableShares is a free data retrieval call binding the contract method 0xc978f7ac.
+//
+// Solidity: function getWithdrawableShares(address staker, address[] strategies) view returns(uint256[] withdrawableShares)
+func (_DelegationManager *DelegationManagerCallerSession) GetWithdrawableShares(staker common.Address, strategies []common.Address) ([]*big.Int, error) {
+	return _DelegationManager.Contract.GetWithdrawableShares(&_DelegationManager.CallOpts, staker, strategies)
+}
+
+// IsDelegated is a free data retrieval call binding the contract method 0x3e28391d.
+//
+// Solidity: function isDelegated(address staker) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) IsDelegated(opts *bind.CallOpts, staker common.Address) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "isDelegated", staker)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsDelegated is a free data retrieval call binding the contract method 0x3e28391d.
+//
+// Solidity: function isDelegated(address staker) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) IsDelegated(staker common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsDelegated(&_DelegationManager.CallOpts, staker)
+}
+
+// IsDelegated is a free data retrieval call binding the contract method 0x3e28391d.
+//
+// Solidity: function isDelegated(address staker) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) IsDelegated(staker common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsDelegated(&_DelegationManager.CallOpts, staker)
+}
+
+// IsOperator is a free data retrieval call binding the contract method 0x6d70f7ae.
+//
+// Solidity: function isOperator(address operator) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) IsOperator(opts *bind.CallOpts, operator common.Address) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "isOperator", operator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsOperator is a free data retrieval call binding the contract method 0x6d70f7ae.
+//
+// Solidity: function isOperator(address operator) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) IsOperator(operator common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsOperator(&_DelegationManager.CallOpts, operator)
+}
+
+// IsOperator is a free data retrieval call binding the contract method 0x6d70f7ae.
+//
+// Solidity: function isOperator(address operator) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) IsOperator(operator common.Address) (bool, error) {
+	return _DelegationManager.Contract.IsOperator(&_DelegationManager.CallOpts, operator)
+}
+
+// OperatorDetails is a free data retrieval call binding the contract method 0xc5e480db.
+//
+// Solidity: function operatorDetails(address operator) view returns((address,address,uint32))
+func (_DelegationManager *DelegationManagerCaller) OperatorDetails(opts *bind.CallOpts, operator common.Address) (IDelegationManagerTypesOperatorDetails, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "operatorDetails", operator)
+
+	if err != nil {
+		return *new(IDelegationManagerTypesOperatorDetails), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IDelegationManagerTypesOperatorDetails)).(*IDelegationManagerTypesOperatorDetails)
+
+	return out0, err
+
+}
+
+// OperatorDetails is a free data retrieval call binding the contract method 0xc5e480db.
+//
+// Solidity: function operatorDetails(address operator) view returns((address,address,uint32))
+func (_DelegationManager *DelegationManagerSession) OperatorDetails(operator common.Address) (IDelegationManagerTypesOperatorDetails, error) {
+	return _DelegationManager.Contract.OperatorDetails(&_DelegationManager.CallOpts, operator)
+}
+
+// OperatorDetails is a free data retrieval call binding the contract method 0xc5e480db.
+//
+// Solidity: function operatorDetails(address operator) view returns((address,address,uint32))
+func (_DelegationManager *DelegationManagerCallerSession) OperatorDetails(operator common.Address) (IDelegationManagerTypesOperatorDetails, error) {
+	return _DelegationManager.Contract.OperatorDetails(&_DelegationManager.CallOpts, operator)
+}
+
+// OperatorShares is a free data retrieval call binding the contract method 0x778e55f3.
+//
+// Solidity: function operatorShares(address , address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) OperatorShares(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "operatorShares", arg0, arg1)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// OperatorShares is a free data retrieval call binding the contract method 0x778e55f3.
+//
+// Solidity: function operatorShares(address , address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) OperatorShares(arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.OperatorShares(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// OperatorShares is a free data retrieval call binding the contract method 0x778e55f3.
+//
+// Solidity: function operatorShares(address , address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) OperatorShares(arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.OperatorShares(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_DelegationManager *DelegationManagerSession) Owner() (common.Address, error) {
+	return _DelegationManager.Contract.Owner(&_DelegationManager.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) Owner() (common.Address, error) {
+	return _DelegationManager.Contract.Owner(&_DelegationManager.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5ac86ab7.
+//
+// Solidity: function paused(uint8 index) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) Paused(opts *bind.CallOpts, index uint8) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "paused", index)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5ac86ab7.
+//
+// Solidity: function paused(uint8 index) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) Paused(index uint8) (bool, error) {
+	return _DelegationManager.Contract.Paused(&_DelegationManager.CallOpts, index)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5ac86ab7.
+//
+// Solidity: function paused(uint8 index) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) Paused(index uint8) (bool, error) {
+	return _DelegationManager.Contract.Paused(&_DelegationManager.CallOpts, index)
+}
+
+// Paused0 is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) Paused0(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "paused0")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Paused0 is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) Paused0() (*big.Int, error) {
+	return _DelegationManager.Contract.Paused0(&_DelegationManager.CallOpts)
+}
+
+// Paused0 is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) Paused0() (*big.Int, error) {
+	return _DelegationManager.Contract.Paused0(&_DelegationManager.CallOpts)
+}
+
+// PauserRegistry is a free data retrieval call binding the contract method 0x886f1195.
+//
+// Solidity: function pauserRegistry() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) PauserRegistry(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "pauserRegistry")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PauserRegistry is a free data retrieval call binding the contract method 0x886f1195.
+//
+// Solidity: function pauserRegistry() view returns(address)
+func (_DelegationManager *DelegationManagerSession) PauserRegistry() (common.Address, error) {
+	return _DelegationManager.Contract.PauserRegistry(&_DelegationManager.CallOpts)
+}
+
+// PauserRegistry is a free data retrieval call binding the contract method 0x886f1195.
+//
+// Solidity: function pauserRegistry() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) PauserRegistry() (common.Address, error) {
+	return _DelegationManager.Contract.PauserRegistry(&_DelegationManager.CallOpts)
+}
+
+// PendingWithdrawals is a free data retrieval call binding the contract method 0xb7f06ebe.
+//
+// Solidity: function pendingWithdrawals(bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCaller) PendingWithdrawals(opts *bind.CallOpts, arg0 [32]byte) (bool, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "pendingWithdrawals", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// PendingWithdrawals is a free data retrieval call binding the contract method 0xb7f06ebe.
+//
+// Solidity: function pendingWithdrawals(bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerSession) PendingWithdrawals(arg0 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.PendingWithdrawals(&_DelegationManager.CallOpts, arg0)
+}
+
+// PendingWithdrawals is a free data retrieval call binding the contract method 0xb7f06ebe.
+//
+// Solidity: function pendingWithdrawals(bytes32 ) view returns(bool)
+func (_DelegationManager *DelegationManagerCallerSession) PendingWithdrawals(arg0 [32]byte) (bool, error) {
+	return _DelegationManager.Contract.PendingWithdrawals(&_DelegationManager.CallOpts, arg0)
+}
+
+// StakerNonce is a free data retrieval call binding the contract method 0x29c77d4f.
+//
+// Solidity: function stakerNonce(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCaller) StakerNonce(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "stakerNonce", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// StakerNonce is a free data retrieval call binding the contract method 0x29c77d4f.
+//
+// Solidity: function stakerNonce(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerSession) StakerNonce(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StakerNonce(&_DelegationManager.CallOpts, arg0)
+}
+
+// StakerNonce is a free data retrieval call binding the contract method 0x29c77d4f.
+//
+// Solidity: function stakerNonce(address ) view returns(uint256)
+func (_DelegationManager *DelegationManagerCallerSession) StakerNonce(arg0 common.Address) (*big.Int, error) {
+	return _DelegationManager.Contract.StakerNonce(&_DelegationManager.CallOpts, arg0)
+}
+
+// StakerScalingFactor is a free data retrieval call binding the contract method 0x457c6070.
+//
+// Solidity: function stakerScalingFactor(address , address ) view returns(uint256 depositScalingFactor, bool isBeaconChainScalingFactorSet, uint64 beaconChainScalingFactor)
+func (_DelegationManager *DelegationManagerCaller) StakerScalingFactor(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address) (struct {
+	DepositScalingFactor          *big.Int
+	IsBeaconChainScalingFactorSet bool
+	BeaconChainScalingFactor      uint64
+}, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "stakerScalingFactor", arg0, arg1)
+
+	outstruct := new(struct {
+		DepositScalingFactor          *big.Int
+		IsBeaconChainScalingFactorSet bool
+		BeaconChainScalingFactor      uint64
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.DepositScalingFactor = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.IsBeaconChainScalingFactorSet = *abi.ConvertType(out[1], new(bool)).(*bool)
+	outstruct.BeaconChainScalingFactor = *abi.ConvertType(out[2], new(uint64)).(*uint64)
+
+	return *outstruct, err
+
+}
+
+// StakerScalingFactor is a free data retrieval call binding the contract method 0x457c6070.
+//
+// Solidity: function stakerScalingFactor(address , address ) view returns(uint256 depositScalingFactor, bool isBeaconChainScalingFactorSet, uint64 beaconChainScalingFactor)
+func (_DelegationManager *DelegationManagerSession) StakerScalingFactor(arg0 common.Address, arg1 common.Address) (struct {
+	DepositScalingFactor          *big.Int
+	IsBeaconChainScalingFactorSet bool
+	BeaconChainScalingFactor      uint64
+}, error) {
+	return _DelegationManager.Contract.StakerScalingFactor(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// StakerScalingFactor is a free data retrieval call binding the contract method 0x457c6070.
+//
+// Solidity: function stakerScalingFactor(address , address ) view returns(uint256 depositScalingFactor, bool isBeaconChainScalingFactorSet, uint64 beaconChainScalingFactor)
+func (_DelegationManager *DelegationManagerCallerSession) StakerScalingFactor(arg0 common.Address, arg1 common.Address) (struct {
+	DepositScalingFactor          *big.Int
+	IsBeaconChainScalingFactorSet bool
+	BeaconChainScalingFactor      uint64
+}, error) {
+	return _DelegationManager.Contract.StakerScalingFactor(&_DelegationManager.CallOpts, arg0, arg1)
+}
+
+// StrategyManager is a free data retrieval call binding the contract method 0x39b70e38.
+//
+// Solidity: function strategyManager() view returns(address)
+func (_DelegationManager *DelegationManagerCaller) StrategyManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _DelegationManager.contract.Call(opts, &out, "strategyManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// StrategyManager is a free data retrieval call binding the contract method 0x39b70e38.
+//
+// Solidity: function strategyManager() view returns(address)
+func (_DelegationManager *DelegationManagerSession) StrategyManager() (common.Address, error) {
+	return _DelegationManager.Contract.StrategyManager(&_DelegationManager.CallOpts)
+}
+
+// StrategyManager is a free data retrieval call binding the contract method 0x39b70e38.
+//
+// Solidity: function strategyManager() view returns(address)
+func (_DelegationManager *DelegationManagerCallerSession) StrategyManager() (common.Address, error) {
+	return _DelegationManager.Contract.StrategyManager(&_DelegationManager.CallOpts)
+}
+
+// CompleteQueuedWithdrawal is a paid mutator transaction binding the contract method 0xe4cc3f90.
+//
+// Solidity: function completeQueuedWithdrawal((address,address,address,uint256,uint32,address[],uint256[]) withdrawal, address[] tokens, bool receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactor) CompleteQueuedWithdrawal(opts *bind.TransactOpts, withdrawal IDelegationManagerTypesWithdrawal, tokens []common.Address, receiveAsTokens bool) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "completeQueuedWithdrawal", withdrawal, tokens, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawal is a paid mutator transaction binding the contract method 0xe4cc3f90.
+//
+// Solidity: function completeQueuedWithdrawal((address,address,address,uint256,uint32,address[],uint256[]) withdrawal, address[] tokens, bool receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerSession) CompleteQueuedWithdrawal(withdrawal IDelegationManagerTypesWithdrawal, tokens []common.Address, receiveAsTokens bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawal(&_DelegationManager.TransactOpts, withdrawal, tokens, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawal is a paid mutator transaction binding the contract method 0xe4cc3f90.
+//
+// Solidity: function completeQueuedWithdrawal((address,address,address,uint256,uint32,address[],uint256[]) withdrawal, address[] tokens, bool receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) CompleteQueuedWithdrawal(withdrawal IDelegationManagerTypesWithdrawal, tokens []common.Address, receiveAsTokens bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawal(&_DelegationManager.TransactOpts, withdrawal, tokens, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawals is a paid mutator transaction binding the contract method 0x9435bb43.
+//
+// Solidity: function completeQueuedWithdrawals((address,address,address,uint256,uint32,address[],uint256[])[] withdrawals, address[][] tokens, bool[] receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactor) CompleteQueuedWithdrawals(opts *bind.TransactOpts, withdrawals []IDelegationManagerTypesWithdrawal, tokens [][]common.Address, receiveAsTokens []bool) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "completeQueuedWithdrawals", withdrawals, tokens, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawals is a paid mutator transaction binding the contract method 0x9435bb43.
+//
+// Solidity: function completeQueuedWithdrawals((address,address,address,uint256,uint32,address[],uint256[])[] withdrawals, address[][] tokens, bool[] receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerSession) CompleteQueuedWithdrawals(withdrawals []IDelegationManagerTypesWithdrawal, tokens [][]common.Address, receiveAsTokens []bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawals(&_DelegationManager.TransactOpts, withdrawals, tokens, receiveAsTokens)
+}
+
+// CompleteQueuedWithdrawals is a paid mutator transaction binding the contract method 0x9435bb43.
+//
+// Solidity: function completeQueuedWithdrawals((address,address,address,uint256,uint32,address[],uint256[])[] withdrawals, address[][] tokens, bool[] receiveAsTokens) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) CompleteQueuedWithdrawals(withdrawals []IDelegationManagerTypesWithdrawal, tokens [][]common.Address, receiveAsTokens []bool) (*types.Transaction, error) {
+	return _DelegationManager.Contract.CompleteQueuedWithdrawals(&_DelegationManager.TransactOpts, withdrawals, tokens, receiveAsTokens)
+}
+
+// DecreaseBeaconChainScalingFactor is a paid mutator transaction binding the contract method 0x5d9aed23.
+//
+// Solidity: function decreaseBeaconChainScalingFactor(address staker, uint256 existingDepositShares, uint64 proportionOfOldBalance) returns()
+func (_DelegationManager *DelegationManagerTransactor) DecreaseBeaconChainScalingFactor(opts *bind.TransactOpts, staker common.Address, existingDepositShares *big.Int, proportionOfOldBalance uint64) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "decreaseBeaconChainScalingFactor", staker, existingDepositShares, proportionOfOldBalance)
+}
+
+// DecreaseBeaconChainScalingFactor is a paid mutator transaction binding the contract method 0x5d9aed23.
+//
+// Solidity: function decreaseBeaconChainScalingFactor(address staker, uint256 existingDepositShares, uint64 proportionOfOldBalance) returns()
+func (_DelegationManager *DelegationManagerSession) DecreaseBeaconChainScalingFactor(staker common.Address, existingDepositShares *big.Int, proportionOfOldBalance uint64) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DecreaseBeaconChainScalingFactor(&_DelegationManager.TransactOpts, staker, existingDepositShares, proportionOfOldBalance)
+}
+
+// DecreaseBeaconChainScalingFactor is a paid mutator transaction binding the contract method 0x5d9aed23.
+//
+// Solidity: function decreaseBeaconChainScalingFactor(address staker, uint256 existingDepositShares, uint64 proportionOfOldBalance) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) DecreaseBeaconChainScalingFactor(staker common.Address, existingDepositShares *big.Int, proportionOfOldBalance uint64) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DecreaseBeaconChainScalingFactor(&_DelegationManager.TransactOpts, staker, existingDepositShares, proportionOfOldBalance)
+}
+
+// DecreaseOperatorShares is a paid mutator transaction binding the contract method 0xa57ab10b.
+//
+// Solidity: function decreaseOperatorShares(address operator, address strategy, uint64 previousTotalMagnitude, uint64 newTotalMagnitude) returns()
+func (_DelegationManager *DelegationManagerTransactor) DecreaseOperatorShares(opts *bind.TransactOpts, operator common.Address, strategy common.Address, previousTotalMagnitude uint64, newTotalMagnitude uint64) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "decreaseOperatorShares", operator, strategy, previousTotalMagnitude, newTotalMagnitude)
+}
+
+// DecreaseOperatorShares is a paid mutator transaction binding the contract method 0xa57ab10b.
+//
+// Solidity: function decreaseOperatorShares(address operator, address strategy, uint64 previousTotalMagnitude, uint64 newTotalMagnitude) returns()
+func (_DelegationManager *DelegationManagerSession) DecreaseOperatorShares(operator common.Address, strategy common.Address, previousTotalMagnitude uint64, newTotalMagnitude uint64) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DecreaseOperatorShares(&_DelegationManager.TransactOpts, operator, strategy, previousTotalMagnitude, newTotalMagnitude)
+}
+
+// DecreaseOperatorShares is a paid mutator transaction binding the contract method 0xa57ab10b.
+//
+// Solidity: function decreaseOperatorShares(address operator, address strategy, uint64 previousTotalMagnitude, uint64 newTotalMagnitude) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) DecreaseOperatorShares(operator common.Address, strategy common.Address, previousTotalMagnitude uint64, newTotalMagnitude uint64) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DecreaseOperatorShares(&_DelegationManager.TransactOpts, operator, strategy, previousTotalMagnitude, newTotalMagnitude)
+}
+
+// DelegateTo is a paid mutator transaction binding the contract method 0xeea9064b.
+//
+// Solidity: function delegateTo(address operator, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactor) DelegateTo(opts *bind.TransactOpts, operator common.Address, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "delegateTo", operator, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateTo is a paid mutator transaction binding the contract method 0xeea9064b.
+//
+// Solidity: function delegateTo(address operator, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerSession) DelegateTo(operator common.Address, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateTo(&_DelegationManager.TransactOpts, operator, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateTo is a paid mutator transaction binding the contract method 0xeea9064b.
+//
+// Solidity: function delegateTo(address operator, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) DelegateTo(operator common.Address, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateTo(&_DelegationManager.TransactOpts, operator, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateToBySignature is a paid mutator transaction binding the contract method 0x7f548071.
+//
+// Solidity: function delegateToBySignature(address staker, address operator, (bytes,uint256) stakerSignatureAndExpiry, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactor) DelegateToBySignature(opts *bind.TransactOpts, staker common.Address, operator common.Address, stakerSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "delegateToBySignature", staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateToBySignature is a paid mutator transaction binding the contract method 0x7f548071.
+//
+// Solidity: function delegateToBySignature(address staker, address operator, (bytes,uint256) stakerSignatureAndExpiry, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerSession) DelegateToBySignature(staker common.Address, operator common.Address, stakerSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateToBySignature(&_DelegationManager.TransactOpts, staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, approverSalt)
+}
+
+// DelegateToBySignature is a paid mutator transaction binding the contract method 0x7f548071.
+//
+// Solidity: function delegateToBySignature(address staker, address operator, (bytes,uint256) stakerSignatureAndExpiry, (bytes,uint256) approverSignatureAndExpiry, bytes32 approverSalt) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) DelegateToBySignature(staker common.Address, operator common.Address, stakerSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSignatureAndExpiry ISignatureUtilsSignatureWithExpiry, approverSalt [32]byte) (*types.Transaction, error) {
+	return _DelegationManager.Contract.DelegateToBySignature(&_DelegationManager.TransactOpts, staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, approverSalt)
+}
+
+// IncreaseDelegatedShares is a paid mutator transaction binding the contract method 0x3c651cf2.
+//
+// Solidity: function increaseDelegatedShares(address staker, address strategy, uint256 existingDepositShares, uint256 addedShares) returns()
+func (_DelegationManager *DelegationManagerTransactor) IncreaseDelegatedShares(opts *bind.TransactOpts, staker common.Address, strategy common.Address, existingDepositShares *big.Int, addedShares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "increaseDelegatedShares", staker, strategy, existingDepositShares, addedShares)
+}
+
+// IncreaseDelegatedShares is a paid mutator transaction binding the contract method 0x3c651cf2.
+//
+// Solidity: function increaseDelegatedShares(address staker, address strategy, uint256 existingDepositShares, uint256 addedShares) returns()
+func (_DelegationManager *DelegationManagerSession) IncreaseDelegatedShares(staker common.Address, strategy common.Address, existingDepositShares *big.Int, addedShares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.IncreaseDelegatedShares(&_DelegationManager.TransactOpts, staker, strategy, existingDepositShares, addedShares)
+}
+
+// IncreaseDelegatedShares is a paid mutator transaction binding the contract method 0x3c651cf2.
+//
+// Solidity: function increaseDelegatedShares(address staker, address strategy, uint256 existingDepositShares, uint256 addedShares) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) IncreaseDelegatedShares(staker common.Address, strategy common.Address, existingDepositShares *big.Int, addedShares *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.IncreaseDelegatedShares(&_DelegationManager.TransactOpts, staker, strategy, existingDepositShares, addedShares)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x1794bb3c.
+//
+// Solidity: function initialize(address initialOwner, address _pauserRegistry, uint256 initialPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactor) Initialize(opts *bind.TransactOpts, initialOwner common.Address, _pauserRegistry common.Address, initialPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "initialize", initialOwner, _pauserRegistry, initialPausedStatus)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x1794bb3c.
+//
+// Solidity: function initialize(address initialOwner, address _pauserRegistry, uint256 initialPausedStatus) returns()
+func (_DelegationManager *DelegationManagerSession) Initialize(initialOwner common.Address, _pauserRegistry common.Address, initialPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Initialize(&_DelegationManager.TransactOpts, initialOwner, _pauserRegistry, initialPausedStatus)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x1794bb3c.
+//
+// Solidity: function initialize(address initialOwner, address _pauserRegistry, uint256 initialPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) Initialize(initialOwner common.Address, _pauserRegistry common.Address, initialPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Initialize(&_DelegationManager.TransactOpts, initialOwner, _pauserRegistry, initialPausedStatus)
+}
+
+// ModifyOperatorDetails is a paid mutator transaction binding the contract method 0xf16172b0.
+//
+// Solidity: function modifyOperatorDetails((address,address,uint32) newOperatorDetails) returns()
+func (_DelegationManager *DelegationManagerTransactor) ModifyOperatorDetails(opts *bind.TransactOpts, newOperatorDetails IDelegationManagerTypesOperatorDetails) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "modifyOperatorDetails", newOperatorDetails)
+}
+
+// ModifyOperatorDetails is a paid mutator transaction binding the contract method 0xf16172b0.
+//
+// Solidity: function modifyOperatorDetails((address,address,uint32) newOperatorDetails) returns()
+func (_DelegationManager *DelegationManagerSession) ModifyOperatorDetails(newOperatorDetails IDelegationManagerTypesOperatorDetails) (*types.Transaction, error) {
+	return _DelegationManager.Contract.ModifyOperatorDetails(&_DelegationManager.TransactOpts, newOperatorDetails)
+}
+
+// ModifyOperatorDetails is a paid mutator transaction binding the contract method 0xf16172b0.
+//
+// Solidity: function modifyOperatorDetails((address,address,uint32) newOperatorDetails) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) ModifyOperatorDetails(newOperatorDetails IDelegationManagerTypesOperatorDetails) (*types.Transaction, error) {
+	return _DelegationManager.Contract.ModifyOperatorDetails(&_DelegationManager.TransactOpts, newOperatorDetails)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x136439dd.
+//
+// Solidity: function pause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactor) Pause(opts *bind.TransactOpts, newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "pause", newPausedStatus)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x136439dd.
+//
+// Solidity: function pause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerSession) Pause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Pause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x136439dd.
+//
+// Solidity: function pause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) Pause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Pause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// PauseAll is a paid mutator transaction binding the contract method 0x595c6a67.
+//
+// Solidity: function pauseAll() returns()
+func (_DelegationManager *DelegationManagerTransactor) PauseAll(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "pauseAll")
+}
+
+// PauseAll is a paid mutator transaction binding the contract method 0x595c6a67.
+//
+// Solidity: function pauseAll() returns()
+func (_DelegationManager *DelegationManagerSession) PauseAll() (*types.Transaction, error) {
+	return _DelegationManager.Contract.PauseAll(&_DelegationManager.TransactOpts)
+}
+
+// PauseAll is a paid mutator transaction binding the contract method 0x595c6a67.
+//
+// Solidity: function pauseAll() returns()
+func (_DelegationManager *DelegationManagerTransactorSession) PauseAll() (*types.Transaction, error) {
+	return _DelegationManager.Contract.PauseAll(&_DelegationManager.TransactOpts)
+}
+
+// QueueWithdrawals is a paid mutator transaction binding the contract method 0x0dd8dd02.
+//
+// Solidity: function queueWithdrawals((address[],uint256[],address)[] params) returns(bytes32[])
+func (_DelegationManager *DelegationManagerTransactor) QueueWithdrawals(opts *bind.TransactOpts, params []IDelegationManagerTypesQueuedWithdrawalParams) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "queueWithdrawals", params)
+}
+
+// QueueWithdrawals is a paid mutator transaction binding the contract method 0x0dd8dd02.
+//
+// Solidity: function queueWithdrawals((address[],uint256[],address)[] params) returns(bytes32[])
+func (_DelegationManager *DelegationManagerSession) QueueWithdrawals(params []IDelegationManagerTypesQueuedWithdrawalParams) (*types.Transaction, error) {
+	return _DelegationManager.Contract.QueueWithdrawals(&_DelegationManager.TransactOpts, params)
+}
+
+// QueueWithdrawals is a paid mutator transaction binding the contract method 0x0dd8dd02.
+//
+// Solidity: function queueWithdrawals((address[],uint256[],address)[] params) returns(bytes32[])
+func (_DelegationManager *DelegationManagerTransactorSession) QueueWithdrawals(params []IDelegationManagerTypesQueuedWithdrawalParams) (*types.Transaction, error) {
+	return _DelegationManager.Contract.QueueWithdrawals(&_DelegationManager.TransactOpts, params)
+}
+
+// RegisterAsOperator is a paid mutator transaction binding the contract method 0x49730060.
+//
+// Solidity: function registerAsOperator((address,address,uint32) registeringOperatorDetails, uint32 allocationDelay, string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactor) RegisterAsOperator(opts *bind.TransactOpts, registeringOperatorDetails IDelegationManagerTypesOperatorDetails, allocationDelay uint32, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "registerAsOperator", registeringOperatorDetails, allocationDelay, metadataURI)
+}
+
+// RegisterAsOperator is a paid mutator transaction binding the contract method 0x49730060.
+//
+// Solidity: function registerAsOperator((address,address,uint32) registeringOperatorDetails, uint32 allocationDelay, string metadataURI) returns()
+func (_DelegationManager *DelegationManagerSession) RegisterAsOperator(registeringOperatorDetails IDelegationManagerTypesOperatorDetails, allocationDelay uint32, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.RegisterAsOperator(&_DelegationManager.TransactOpts, registeringOperatorDetails, allocationDelay, metadataURI)
+}
+
+// RegisterAsOperator is a paid mutator transaction binding the contract method 0x49730060.
+//
+// Solidity: function registerAsOperator((address,address,uint32) registeringOperatorDetails, uint32 allocationDelay, string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) RegisterAsOperator(registeringOperatorDetails IDelegationManagerTypesOperatorDetails, allocationDelay uint32, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.RegisterAsOperator(&_DelegationManager.TransactOpts, registeringOperatorDetails, allocationDelay, metadataURI)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_DelegationManager *DelegationManagerTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_DelegationManager *DelegationManagerSession) RenounceOwnership() (*types.Transaction, error) {
+	return _DelegationManager.Contract.RenounceOwnership(&_DelegationManager.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_DelegationManager *DelegationManagerTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _DelegationManager.Contract.RenounceOwnership(&_DelegationManager.TransactOpts)
+}
+
+// SetPauserRegistry is a paid mutator transaction binding the contract method 0x10d67a2f.
+//
+// Solidity: function setPauserRegistry(address newPauserRegistry) returns()
+func (_DelegationManager *DelegationManagerTransactor) SetPauserRegistry(opts *bind.TransactOpts, newPauserRegistry common.Address) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "setPauserRegistry", newPauserRegistry)
+}
+
+// SetPauserRegistry is a paid mutator transaction binding the contract method 0x10d67a2f.
+//
+// Solidity: function setPauserRegistry(address newPauserRegistry) returns()
+func (_DelegationManager *DelegationManagerSession) SetPauserRegistry(newPauserRegistry common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetPauserRegistry(&_DelegationManager.TransactOpts, newPauserRegistry)
+}
+
+// SetPauserRegistry is a paid mutator transaction binding the contract method 0x10d67a2f.
+//
+// Solidity: function setPauserRegistry(address newPauserRegistry) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) SetPauserRegistry(newPauserRegistry common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.SetPauserRegistry(&_DelegationManager.TransactOpts, newPauserRegistry)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_DelegationManager *DelegationManagerTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_DelegationManager *DelegationManagerSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.TransferOwnership(&_DelegationManager.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.TransferOwnership(&_DelegationManager.TransactOpts, newOwner)
+}
+
+// Undelegate is a paid mutator transaction binding the contract method 0xda8be864.
+//
+// Solidity: function undelegate(address staker) returns(bytes32[] withdrawalRoots)
+func (_DelegationManager *DelegationManagerTransactor) Undelegate(opts *bind.TransactOpts, staker common.Address) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "undelegate", staker)
+}
+
+// Undelegate is a paid mutator transaction binding the contract method 0xda8be864.
+//
+// Solidity: function undelegate(address staker) returns(bytes32[] withdrawalRoots)
+func (_DelegationManager *DelegationManagerSession) Undelegate(staker common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Undelegate(&_DelegationManager.TransactOpts, staker)
+}
+
+// Undelegate is a paid mutator transaction binding the contract method 0xda8be864.
+//
+// Solidity: function undelegate(address staker) returns(bytes32[] withdrawalRoots)
+func (_DelegationManager *DelegationManagerTransactorSession) Undelegate(staker common.Address) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Undelegate(&_DelegationManager.TransactOpts, staker)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0xfabc1cbc.
+//
+// Solidity: function unpause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactor) Unpause(opts *bind.TransactOpts, newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "unpause", newPausedStatus)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0xfabc1cbc.
+//
+// Solidity: function unpause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerSession) Unpause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Unpause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0xfabc1cbc.
+//
+// Solidity: function unpause(uint256 newPausedStatus) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) Unpause(newPausedStatus *big.Int) (*types.Transaction, error) {
+	return _DelegationManager.Contract.Unpause(&_DelegationManager.TransactOpts, newPausedStatus)
+}
+
+// UpdateOperatorMetadataURI is a paid mutator transaction binding the contract method 0x99be81c8.
+//
+// Solidity: function updateOperatorMetadataURI(string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactor) UpdateOperatorMetadataURI(opts *bind.TransactOpts, metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.contract.Transact(opts, "updateOperatorMetadataURI", metadataURI)
+}
+
+// UpdateOperatorMetadataURI is a paid mutator transaction binding the contract method 0x99be81c8.
+//
+// Solidity: function updateOperatorMetadataURI(string metadataURI) returns()
+func (_DelegationManager *DelegationManagerSession) UpdateOperatorMetadataURI(metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.UpdateOperatorMetadataURI(&_DelegationManager.TransactOpts, metadataURI)
+}
+
+// UpdateOperatorMetadataURI is a paid mutator transaction binding the contract method 0x99be81c8.
+//
+// Solidity: function updateOperatorMetadataURI(string metadataURI) returns()
+func (_DelegationManager *DelegationManagerTransactorSession) UpdateOperatorMetadataURI(metadataURI string) (*types.Transaction, error) {
+	return _DelegationManager.Contract.UpdateOperatorMetadataURI(&_DelegationManager.TransactOpts, metadataURI)
+}
+
+// DelegationManagerBeaconChainScalingFactorDecreasedIterator is returned from FilterBeaconChainScalingFactorDecreased and is used to iterate over the raw logs and unpacked data for BeaconChainScalingFactorDecreased events raised by the DelegationManager contract.
+type DelegationManagerBeaconChainScalingFactorDecreasedIterator struct {
+	Event *DelegationManagerBeaconChainScalingFactorDecreased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerBeaconChainScalingFactorDecreasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerBeaconChainScalingFactorDecreased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerBeaconChainScalingFactorDecreased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerBeaconChainScalingFactorDecreasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerBeaconChainScalingFactorDecreasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerBeaconChainScalingFactorDecreased represents a BeaconChainScalingFactorDecreased event raised by the DelegationManager contract.
+type DelegationManagerBeaconChainScalingFactorDecreased struct {
+	Staker                      common.Address
+	NewBeaconChainScalingFactor uint64
+	Raw                         types.Log // Blockchain specific contextual infos
+}
+
+// FilterBeaconChainScalingFactorDecreased is a free log retrieval operation binding the contract event 0xddf935ec8825c7afee6a15d4731e28963ee96dfcb85d0a1e794b43318bbca4fd.
+//
+// Solidity: event BeaconChainScalingFactorDecreased(address staker, uint64 newBeaconChainScalingFactor)
+func (_DelegationManager *DelegationManagerFilterer) FilterBeaconChainScalingFactorDecreased(opts *bind.FilterOpts) (*DelegationManagerBeaconChainScalingFactorDecreasedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "BeaconChainScalingFactorDecreased")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerBeaconChainScalingFactorDecreasedIterator{contract: _DelegationManager.contract, event: "BeaconChainScalingFactorDecreased", logs: logs, sub: sub}, nil
+}
+
+// WatchBeaconChainScalingFactorDecreased is a free log subscription operation binding the contract event 0xddf935ec8825c7afee6a15d4731e28963ee96dfcb85d0a1e794b43318bbca4fd.
+//
+// Solidity: event BeaconChainScalingFactorDecreased(address staker, uint64 newBeaconChainScalingFactor)
+func (_DelegationManager *DelegationManagerFilterer) WatchBeaconChainScalingFactorDecreased(opts *bind.WatchOpts, sink chan<- *DelegationManagerBeaconChainScalingFactorDecreased) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "BeaconChainScalingFactorDecreased")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerBeaconChainScalingFactorDecreased)
+				if err := _DelegationManager.contract.UnpackLog(event, "BeaconChainScalingFactorDecreased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBeaconChainScalingFactorDecreased is a log parse operation binding the contract event 0xddf935ec8825c7afee6a15d4731e28963ee96dfcb85d0a1e794b43318bbca4fd.
+//
+// Solidity: event BeaconChainScalingFactorDecreased(address staker, uint64 newBeaconChainScalingFactor)
+func (_DelegationManager *DelegationManagerFilterer) ParseBeaconChainScalingFactorDecreased(log types.Log) (*DelegationManagerBeaconChainScalingFactorDecreased, error) {
+	event := new(DelegationManagerBeaconChainScalingFactorDecreased)
+	if err := _DelegationManager.contract.UnpackLog(event, "BeaconChainScalingFactorDecreased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerDepositScalingFactorUpdatedIterator is returned from FilterDepositScalingFactorUpdated and is used to iterate over the raw logs and unpacked data for DepositScalingFactorUpdated events raised by the DelegationManager contract.
+type DelegationManagerDepositScalingFactorUpdatedIterator struct {
+	Event *DelegationManagerDepositScalingFactorUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerDepositScalingFactorUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerDepositScalingFactorUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerDepositScalingFactorUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerDepositScalingFactorUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerDepositScalingFactorUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerDepositScalingFactorUpdated represents a DepositScalingFactorUpdated event raised by the DelegationManager contract.
+type DelegationManagerDepositScalingFactorUpdated struct {
+	Staker                  common.Address
+	Strategy                common.Address
+	NewDepositScalingFactor *big.Int
+	Raw                     types.Log // Blockchain specific contextual infos
+}
+
+// FilterDepositScalingFactorUpdated is a free log retrieval operation binding the contract event 0x8be932bac54561f27260f95463d9b8ab37e06b2842e5ee2404157cc13df6eb8f.
+//
+// Solidity: event DepositScalingFactorUpdated(address staker, address strategy, uint256 newDepositScalingFactor)
+func (_DelegationManager *DelegationManagerFilterer) FilterDepositScalingFactorUpdated(opts *bind.FilterOpts) (*DelegationManagerDepositScalingFactorUpdatedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "DepositScalingFactorUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerDepositScalingFactorUpdatedIterator{contract: _DelegationManager.contract, event: "DepositScalingFactorUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchDepositScalingFactorUpdated is a free log subscription operation binding the contract event 0x8be932bac54561f27260f95463d9b8ab37e06b2842e5ee2404157cc13df6eb8f.
+//
+// Solidity: event DepositScalingFactorUpdated(address staker, address strategy, uint256 newDepositScalingFactor)
+func (_DelegationManager *DelegationManagerFilterer) WatchDepositScalingFactorUpdated(opts *bind.WatchOpts, sink chan<- *DelegationManagerDepositScalingFactorUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "DepositScalingFactorUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerDepositScalingFactorUpdated)
+				if err := _DelegationManager.contract.UnpackLog(event, "DepositScalingFactorUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDepositScalingFactorUpdated is a log parse operation binding the contract event 0x8be932bac54561f27260f95463d9b8ab37e06b2842e5ee2404157cc13df6eb8f.
+//
+// Solidity: event DepositScalingFactorUpdated(address staker, address strategy, uint256 newDepositScalingFactor)
+func (_DelegationManager *DelegationManagerFilterer) ParseDepositScalingFactorUpdated(log types.Log) (*DelegationManagerDepositScalingFactorUpdated, error) {
+	event := new(DelegationManagerDepositScalingFactorUpdated)
+	if err := _DelegationManager.contract.UnpackLog(event, "DepositScalingFactorUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the DelegationManager contract.
+type DelegationManagerInitializedIterator struct {
+	Event *DelegationManagerInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerInitialized represents a Initialized event raised by the DelegationManager contract.
+type DelegationManagerInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_DelegationManager *DelegationManagerFilterer) FilterInitialized(opts *bind.FilterOpts) (*DelegationManagerInitializedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerInitializedIterator{contract: _DelegationManager.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_DelegationManager *DelegationManagerFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *DelegationManagerInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerInitialized)
+				if err := _DelegationManager.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_DelegationManager *DelegationManagerFilterer) ParseInitialized(log types.Log) (*DelegationManagerInitialized, error) {
+	event := new(DelegationManagerInitialized)
+	if err := _DelegationManager.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorDetailsModifiedIterator is returned from FilterOperatorDetailsModified and is used to iterate over the raw logs and unpacked data for OperatorDetailsModified events raised by the DelegationManager contract.
+type DelegationManagerOperatorDetailsModifiedIterator struct {
+	Event *DelegationManagerOperatorDetailsModified // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorDetailsModifiedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorDetailsModified)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorDetailsModified)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorDetailsModifiedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorDetailsModifiedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorDetailsModified represents a OperatorDetailsModified event raised by the DelegationManager contract.
+type DelegationManagerOperatorDetailsModified struct {
+	Operator           common.Address
+	NewOperatorDetails IDelegationManagerTypesOperatorDetails
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorDetailsModified is a free log retrieval operation binding the contract event 0xfebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac.
+//
+// Solidity: event OperatorDetailsModified(address indexed operator, (address,address,uint32) newOperatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorDetailsModified(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorDetailsModifiedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorDetailsModified", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorDetailsModifiedIterator{contract: _DelegationManager.contract, event: "OperatorDetailsModified", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorDetailsModified is a free log subscription operation binding the contract event 0xfebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac.
+//
+// Solidity: event OperatorDetailsModified(address indexed operator, (address,address,uint32) newOperatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorDetailsModified(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorDetailsModified, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorDetailsModified", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorDetailsModified)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorDetailsModified", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorDetailsModified is a log parse operation binding the contract event 0xfebe5cd24b2cbc7b065b9d0fdeb904461e4afcff57dd57acda1e7832031ba7ac.
+//
+// Solidity: event OperatorDetailsModified(address indexed operator, (address,address,uint32) newOperatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorDetailsModified(log types.Log) (*DelegationManagerOperatorDetailsModified, error) {
+	event := new(DelegationManagerOperatorDetailsModified)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorDetailsModified", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorMetadataURIUpdatedIterator is returned from FilterOperatorMetadataURIUpdated and is used to iterate over the raw logs and unpacked data for OperatorMetadataURIUpdated events raised by the DelegationManager contract.
+type DelegationManagerOperatorMetadataURIUpdatedIterator struct {
+	Event *DelegationManagerOperatorMetadataURIUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorMetadataURIUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorMetadataURIUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorMetadataURIUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorMetadataURIUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorMetadataURIUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorMetadataURIUpdated represents a OperatorMetadataURIUpdated event raised by the DelegationManager contract.
+type DelegationManagerOperatorMetadataURIUpdated struct {
+	Operator    common.Address
+	MetadataURI string
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorMetadataURIUpdated is a free log retrieval operation binding the contract event 0x02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b6708090.
+//
+// Solidity: event OperatorMetadataURIUpdated(address indexed operator, string metadataURI)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorMetadataURIUpdated(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorMetadataURIUpdatedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorMetadataURIUpdated", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorMetadataURIUpdatedIterator{contract: _DelegationManager.contract, event: "OperatorMetadataURIUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorMetadataURIUpdated is a free log subscription operation binding the contract event 0x02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b6708090.
+//
+// Solidity: event OperatorMetadataURIUpdated(address indexed operator, string metadataURI)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorMetadataURIUpdated(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorMetadataURIUpdated, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorMetadataURIUpdated", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorMetadataURIUpdated)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorMetadataURIUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorMetadataURIUpdated is a log parse operation binding the contract event 0x02a919ed0e2acad1dd90f17ef2fa4ae5462ee1339170034a8531cca4b6708090.
+//
+// Solidity: event OperatorMetadataURIUpdated(address indexed operator, string metadataURI)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorMetadataURIUpdated(log types.Log) (*DelegationManagerOperatorMetadataURIUpdated, error) {
+	event := new(DelegationManagerOperatorMetadataURIUpdated)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorMetadataURIUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorRegisteredIterator is returned from FilterOperatorRegistered and is used to iterate over the raw logs and unpacked data for OperatorRegistered events raised by the DelegationManager contract.
+type DelegationManagerOperatorRegisteredIterator struct {
+	Event *DelegationManagerOperatorRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorRegistered represents a OperatorRegistered event raised by the DelegationManager contract.
+type DelegationManagerOperatorRegistered struct {
+	Operator        common.Address
+	OperatorDetails IDelegationManagerTypesOperatorDetails
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorRegistered is a free log retrieval operation binding the contract event 0x8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e2.
+//
+// Solidity: event OperatorRegistered(address indexed operator, (address,address,uint32) operatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorRegistered(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorRegisteredIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorRegistered", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorRegisteredIterator{contract: _DelegationManager.contract, event: "OperatorRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorRegistered is a free log subscription operation binding the contract event 0x8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e2.
+//
+// Solidity: event OperatorRegistered(address indexed operator, (address,address,uint32) operatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorRegistered(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorRegistered, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorRegistered", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorRegistered)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorRegistered is a log parse operation binding the contract event 0x8e8485583a2310d41f7c82b9427d0bd49bad74bb9cff9d3402a29d8f9b28a0e2.
+//
+// Solidity: event OperatorRegistered(address indexed operator, (address,address,uint32) operatorDetails)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorRegistered(log types.Log) (*DelegationManagerOperatorRegistered, error) {
+	event := new(DelegationManagerOperatorRegistered)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorSharesDecreasedIterator is returned from FilterOperatorSharesDecreased and is used to iterate over the raw logs and unpacked data for OperatorSharesDecreased events raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesDecreasedIterator struct {
+	Event *DelegationManagerOperatorSharesDecreased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorSharesDecreasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorSharesDecreased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorSharesDecreased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorSharesDecreasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorSharesDecreasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorSharesDecreased represents a OperatorSharesDecreased event raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesDecreased struct {
+	Operator common.Address
+	Staker   common.Address
+	Strategy common.Address
+	Shares   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorSharesDecreased is a free log retrieval operation binding the contract event 0x6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd.
+//
+// Solidity: event OperatorSharesDecreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorSharesDecreased(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorSharesDecreasedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorSharesDecreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorSharesDecreasedIterator{contract: _DelegationManager.contract, event: "OperatorSharesDecreased", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorSharesDecreased is a free log subscription operation binding the contract event 0x6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd.
+//
+// Solidity: event OperatorSharesDecreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorSharesDecreased(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorSharesDecreased, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorSharesDecreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorSharesDecreased)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesDecreased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorSharesDecreased is a log parse operation binding the contract event 0x6909600037b75d7b4733aedd815442b5ec018a827751c832aaff64eba5d6d2dd.
+//
+// Solidity: event OperatorSharesDecreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorSharesDecreased(log types.Log) (*DelegationManagerOperatorSharesDecreased, error) {
+	event := new(DelegationManagerOperatorSharesDecreased)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesDecreased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOperatorSharesIncreasedIterator is returned from FilterOperatorSharesIncreased and is used to iterate over the raw logs and unpacked data for OperatorSharesIncreased events raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesIncreasedIterator struct {
+	Event *DelegationManagerOperatorSharesIncreased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOperatorSharesIncreasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOperatorSharesIncreased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOperatorSharesIncreased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOperatorSharesIncreasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOperatorSharesIncreasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOperatorSharesIncreased represents a OperatorSharesIncreased event raised by the DelegationManager contract.
+type DelegationManagerOperatorSharesIncreased struct {
+	Operator common.Address
+	Staker   common.Address
+	Strategy common.Address
+	Shares   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorSharesIncreased is a free log retrieval operation binding the contract event 0x1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c.
+//
+// Solidity: event OperatorSharesIncreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) FilterOperatorSharesIncreased(opts *bind.FilterOpts, operator []common.Address) (*DelegationManagerOperatorSharesIncreasedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OperatorSharesIncreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOperatorSharesIncreasedIterator{contract: _DelegationManager.contract, event: "OperatorSharesIncreased", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorSharesIncreased is a free log subscription operation binding the contract event 0x1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c.
+//
+// Solidity: event OperatorSharesIncreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) WatchOperatorSharesIncreased(opts *bind.WatchOpts, sink chan<- *DelegationManagerOperatorSharesIncreased, operator []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OperatorSharesIncreased", operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOperatorSharesIncreased)
+				if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesIncreased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorSharesIncreased is a log parse operation binding the contract event 0x1ec042c965e2edd7107b51188ee0f383e22e76179041ab3a9d18ff151405166c.
+//
+// Solidity: event OperatorSharesIncreased(address indexed operator, address staker, address strategy, uint256 shares)
+func (_DelegationManager *DelegationManagerFilterer) ParseOperatorSharesIncreased(log types.Log) (*DelegationManagerOperatorSharesIncreased, error) {
+	event := new(DelegationManagerOperatorSharesIncreased)
+	if err := _DelegationManager.contract.UnpackLog(event, "OperatorSharesIncreased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the DelegationManager contract.
+type DelegationManagerOwnershipTransferredIterator struct {
+	Event *DelegationManagerOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerOwnershipTransferred represents a OwnershipTransferred event raised by the DelegationManager contract.
+type DelegationManagerOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_DelegationManager *DelegationManagerFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*DelegationManagerOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerOwnershipTransferredIterator{contract: _DelegationManager.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_DelegationManager *DelegationManagerFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *DelegationManagerOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerOwnershipTransferred)
+				if err := _DelegationManager.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_DelegationManager *DelegationManagerFilterer) ParseOwnershipTransferred(log types.Log) (*DelegationManagerOwnershipTransferred, error) {
+	event := new(DelegationManagerOwnershipTransferred)
+	if err := _DelegationManager.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the DelegationManager contract.
+type DelegationManagerPausedIterator struct {
+	Event *DelegationManagerPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerPaused represents a Paused event raised by the DelegationManager contract.
+type DelegationManagerPaused struct {
+	Account         common.Address
+	NewPausedStatus *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0xab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d.
+//
+// Solidity: event Paused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) FilterPaused(opts *bind.FilterOpts, account []common.Address) (*DelegationManagerPausedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "Paused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerPausedIterator{contract: _DelegationManager.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0xab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d.
+//
+// Solidity: event Paused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *DelegationManagerPaused, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "Paused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerPaused)
+				if err := _DelegationManager.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0xab40a374bc51de372200a8bc981af8c9ecdc08dfdaef0bb6e09f88f3c616ef3d.
+//
+// Solidity: event Paused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) ParsePaused(log types.Log) (*DelegationManagerPaused, error) {
+	event := new(DelegationManagerPaused)
+	if err := _DelegationManager.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerPauserRegistrySetIterator is returned from FilterPauserRegistrySet and is used to iterate over the raw logs and unpacked data for PauserRegistrySet events raised by the DelegationManager contract.
+type DelegationManagerPauserRegistrySetIterator struct {
+	Event *DelegationManagerPauserRegistrySet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerPauserRegistrySetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerPauserRegistrySet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerPauserRegistrySet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerPauserRegistrySetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerPauserRegistrySetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerPauserRegistrySet represents a PauserRegistrySet event raised by the DelegationManager contract.
+type DelegationManagerPauserRegistrySet struct {
+	PauserRegistry    common.Address
+	NewPauserRegistry common.Address
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterPauserRegistrySet is a free log retrieval operation binding the contract event 0x6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6.
+//
+// Solidity: event PauserRegistrySet(address pauserRegistry, address newPauserRegistry)
+func (_DelegationManager *DelegationManagerFilterer) FilterPauserRegistrySet(opts *bind.FilterOpts) (*DelegationManagerPauserRegistrySetIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "PauserRegistrySet")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerPauserRegistrySetIterator{contract: _DelegationManager.contract, event: "PauserRegistrySet", logs: logs, sub: sub}, nil
+}
+
+// WatchPauserRegistrySet is a free log subscription operation binding the contract event 0x6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6.
+//
+// Solidity: event PauserRegistrySet(address pauserRegistry, address newPauserRegistry)
+func (_DelegationManager *DelegationManagerFilterer) WatchPauserRegistrySet(opts *bind.WatchOpts, sink chan<- *DelegationManagerPauserRegistrySet) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "PauserRegistrySet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerPauserRegistrySet)
+				if err := _DelegationManager.contract.UnpackLog(event, "PauserRegistrySet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePauserRegistrySet is a log parse operation binding the contract event 0x6e9fcd539896fca60e8b0f01dd580233e48a6b0f7df013b89ba7f565869acdb6.
+//
+// Solidity: event PauserRegistrySet(address pauserRegistry, address newPauserRegistry)
+func (_DelegationManager *DelegationManagerFilterer) ParsePauserRegistrySet(log types.Log) (*DelegationManagerPauserRegistrySet, error) {
+	event := new(DelegationManagerPauserRegistrySet)
+	if err := _DelegationManager.contract.UnpackLog(event, "PauserRegistrySet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerSlashingWithdrawalCompletedIterator is returned from FilterSlashingWithdrawalCompleted and is used to iterate over the raw logs and unpacked data for SlashingWithdrawalCompleted events raised by the DelegationManager contract.
+type DelegationManagerSlashingWithdrawalCompletedIterator struct {
+	Event *DelegationManagerSlashingWithdrawalCompleted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerSlashingWithdrawalCompletedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerSlashingWithdrawalCompleted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerSlashingWithdrawalCompleted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerSlashingWithdrawalCompletedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerSlashingWithdrawalCompletedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerSlashingWithdrawalCompleted represents a SlashingWithdrawalCompleted event raised by the DelegationManager contract.
+type DelegationManagerSlashingWithdrawalCompleted struct {
+	WithdrawalRoot [32]byte
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashingWithdrawalCompleted is a free log retrieval operation binding the contract event 0x1f40400889274ed07b24845e5054a87a0cab969eb1277aafe61ae352e7c32a00.
+//
+// Solidity: event SlashingWithdrawalCompleted(bytes32 withdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) FilterSlashingWithdrawalCompleted(opts *bind.FilterOpts) (*DelegationManagerSlashingWithdrawalCompletedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "SlashingWithdrawalCompleted")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerSlashingWithdrawalCompletedIterator{contract: _DelegationManager.contract, event: "SlashingWithdrawalCompleted", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashingWithdrawalCompleted is a free log subscription operation binding the contract event 0x1f40400889274ed07b24845e5054a87a0cab969eb1277aafe61ae352e7c32a00.
+//
+// Solidity: event SlashingWithdrawalCompleted(bytes32 withdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) WatchSlashingWithdrawalCompleted(opts *bind.WatchOpts, sink chan<- *DelegationManagerSlashingWithdrawalCompleted) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "SlashingWithdrawalCompleted")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerSlashingWithdrawalCompleted)
+				if err := _DelegationManager.contract.UnpackLog(event, "SlashingWithdrawalCompleted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashingWithdrawalCompleted is a log parse operation binding the contract event 0x1f40400889274ed07b24845e5054a87a0cab969eb1277aafe61ae352e7c32a00.
+//
+// Solidity: event SlashingWithdrawalCompleted(bytes32 withdrawalRoot)
+func (_DelegationManager *DelegationManagerFilterer) ParseSlashingWithdrawalCompleted(log types.Log) (*DelegationManagerSlashingWithdrawalCompleted, error) {
+	event := new(DelegationManagerSlashingWithdrawalCompleted)
+	if err := _DelegationManager.contract.UnpackLog(event, "SlashingWithdrawalCompleted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerSlashingWithdrawalQueuedIterator is returned from FilterSlashingWithdrawalQueued and is used to iterate over the raw logs and unpacked data for SlashingWithdrawalQueued events raised by the DelegationManager contract.
+type DelegationManagerSlashingWithdrawalQueuedIterator struct {
+	Event *DelegationManagerSlashingWithdrawalQueued // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerSlashingWithdrawalQueuedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerSlashingWithdrawalQueued)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerSlashingWithdrawalQueued)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerSlashingWithdrawalQueuedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerSlashingWithdrawalQueuedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerSlashingWithdrawalQueued represents a SlashingWithdrawalQueued event raised by the DelegationManager contract.
+type DelegationManagerSlashingWithdrawalQueued struct {
+	WithdrawalRoot   [32]byte
+	Withdrawal       IDelegationManagerTypesWithdrawal
+	SharesToWithdraw []*big.Int
+	Raw              types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashingWithdrawalQueued is a free log retrieval operation binding the contract event 0x26b2aae26516e8719ef50ea2f6831a2efbd4e37dccdf0f6936b27bc08e793e30.
+//
+// Solidity: event SlashingWithdrawalQueued(bytes32 withdrawalRoot, (address,address,address,uint256,uint32,address[],uint256[]) withdrawal, uint256[] sharesToWithdraw)
+func (_DelegationManager *DelegationManagerFilterer) FilterSlashingWithdrawalQueued(opts *bind.FilterOpts) (*DelegationManagerSlashingWithdrawalQueuedIterator, error) {
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "SlashingWithdrawalQueued")
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerSlashingWithdrawalQueuedIterator{contract: _DelegationManager.contract, event: "SlashingWithdrawalQueued", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashingWithdrawalQueued is a free log subscription operation binding the contract event 0x26b2aae26516e8719ef50ea2f6831a2efbd4e37dccdf0f6936b27bc08e793e30.
+//
+// Solidity: event SlashingWithdrawalQueued(bytes32 withdrawalRoot, (address,address,address,uint256,uint32,address[],uint256[]) withdrawal, uint256[] sharesToWithdraw)
+func (_DelegationManager *DelegationManagerFilterer) WatchSlashingWithdrawalQueued(opts *bind.WatchOpts, sink chan<- *DelegationManagerSlashingWithdrawalQueued) (event.Subscription, error) {
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "SlashingWithdrawalQueued")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerSlashingWithdrawalQueued)
+				if err := _DelegationManager.contract.UnpackLog(event, "SlashingWithdrawalQueued", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashingWithdrawalQueued is a log parse operation binding the contract event 0x26b2aae26516e8719ef50ea2f6831a2efbd4e37dccdf0f6936b27bc08e793e30.
+//
+// Solidity: event SlashingWithdrawalQueued(bytes32 withdrawalRoot, (address,address,address,uint256,uint32,address[],uint256[]) withdrawal, uint256[] sharesToWithdraw)
+func (_DelegationManager *DelegationManagerFilterer) ParseSlashingWithdrawalQueued(log types.Log) (*DelegationManagerSlashingWithdrawalQueued, error) {
+	event := new(DelegationManagerSlashingWithdrawalQueued)
+	if err := _DelegationManager.contract.UnpackLog(event, "SlashingWithdrawalQueued", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerStakerDelegatedIterator is returned from FilterStakerDelegated and is used to iterate over the raw logs and unpacked data for StakerDelegated events raised by the DelegationManager contract.
+type DelegationManagerStakerDelegatedIterator struct {
+	Event *DelegationManagerStakerDelegated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerStakerDelegatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerStakerDelegated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerStakerDelegated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerStakerDelegatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerStakerDelegatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerStakerDelegated represents a StakerDelegated event raised by the DelegationManager contract.
+type DelegationManagerStakerDelegated struct {
+	Staker   common.Address
+	Operator common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakerDelegated is a free log retrieval operation binding the contract event 0xc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d8743304.
+//
+// Solidity: event StakerDelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) FilterStakerDelegated(opts *bind.FilterOpts, staker []common.Address, operator []common.Address) (*DelegationManagerStakerDelegatedIterator, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "StakerDelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerStakerDelegatedIterator{contract: _DelegationManager.contract, event: "StakerDelegated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakerDelegated is a free log subscription operation binding the contract event 0xc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d8743304.
+//
+// Solidity: event StakerDelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) WatchStakerDelegated(opts *bind.WatchOpts, sink chan<- *DelegationManagerStakerDelegated, staker []common.Address, operator []common.Address) (event.Subscription, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "StakerDelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerStakerDelegated)
+				if err := _DelegationManager.contract.UnpackLog(event, "StakerDelegated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakerDelegated is a log parse operation binding the contract event 0xc3ee9f2e5fda98e8066a1f745b2df9285f416fe98cf2559cd21484b3d8743304.
+//
+// Solidity: event StakerDelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) ParseStakerDelegated(log types.Log) (*DelegationManagerStakerDelegated, error) {
+	event := new(DelegationManagerStakerDelegated)
+	if err := _DelegationManager.contract.UnpackLog(event, "StakerDelegated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerStakerForceUndelegatedIterator is returned from FilterStakerForceUndelegated and is used to iterate over the raw logs and unpacked data for StakerForceUndelegated events raised by the DelegationManager contract.
+type DelegationManagerStakerForceUndelegatedIterator struct {
+	Event *DelegationManagerStakerForceUndelegated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerStakerForceUndelegatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerStakerForceUndelegated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerStakerForceUndelegated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerStakerForceUndelegatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerStakerForceUndelegatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerStakerForceUndelegated represents a StakerForceUndelegated event raised by the DelegationManager contract.
+type DelegationManagerStakerForceUndelegated struct {
+	Staker   common.Address
+	Operator common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakerForceUndelegated is a free log retrieval operation binding the contract event 0xf0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a.
+//
+// Solidity: event StakerForceUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) FilterStakerForceUndelegated(opts *bind.FilterOpts, staker []common.Address, operator []common.Address) (*DelegationManagerStakerForceUndelegatedIterator, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "StakerForceUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerStakerForceUndelegatedIterator{contract: _DelegationManager.contract, event: "StakerForceUndelegated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakerForceUndelegated is a free log subscription operation binding the contract event 0xf0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a.
+//
+// Solidity: event StakerForceUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) WatchStakerForceUndelegated(opts *bind.WatchOpts, sink chan<- *DelegationManagerStakerForceUndelegated, staker []common.Address, operator []common.Address) (event.Subscription, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "StakerForceUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerStakerForceUndelegated)
+				if err := _DelegationManager.contract.UnpackLog(event, "StakerForceUndelegated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakerForceUndelegated is a log parse operation binding the contract event 0xf0eddf07e6ea14f388b47e1e94a0f464ecbd9eed4171130e0fc0e99fb4030a8a.
+//
+// Solidity: event StakerForceUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) ParseStakerForceUndelegated(log types.Log) (*DelegationManagerStakerForceUndelegated, error) {
+	event := new(DelegationManagerStakerForceUndelegated)
+	if err := _DelegationManager.contract.UnpackLog(event, "StakerForceUndelegated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerStakerUndelegatedIterator is returned from FilterStakerUndelegated and is used to iterate over the raw logs and unpacked data for StakerUndelegated events raised by the DelegationManager contract.
+type DelegationManagerStakerUndelegatedIterator struct {
+	Event *DelegationManagerStakerUndelegated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerStakerUndelegatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerStakerUndelegated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerStakerUndelegated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerStakerUndelegatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerStakerUndelegatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerStakerUndelegated represents a StakerUndelegated event raised by the DelegationManager contract.
+type DelegationManagerStakerUndelegated struct {
+	Staker   common.Address
+	Operator common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakerUndelegated is a free log retrieval operation binding the contract event 0xfee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af44676.
+//
+// Solidity: event StakerUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) FilterStakerUndelegated(opts *bind.FilterOpts, staker []common.Address, operator []common.Address) (*DelegationManagerStakerUndelegatedIterator, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "StakerUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerStakerUndelegatedIterator{contract: _DelegationManager.contract, event: "StakerUndelegated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakerUndelegated is a free log subscription operation binding the contract event 0xfee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af44676.
+//
+// Solidity: event StakerUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) WatchStakerUndelegated(opts *bind.WatchOpts, sink chan<- *DelegationManagerStakerUndelegated, staker []common.Address, operator []common.Address) (event.Subscription, error) {
+
+	var stakerRule []interface{}
+	for _, stakerItem := range staker {
+		stakerRule = append(stakerRule, stakerItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "StakerUndelegated", stakerRule, operatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerStakerUndelegated)
+				if err := _DelegationManager.contract.UnpackLog(event, "StakerUndelegated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakerUndelegated is a log parse operation binding the contract event 0xfee30966a256b71e14bc0ebfc94315e28ef4a97a7131a9e2b7a310a73af44676.
+//
+// Solidity: event StakerUndelegated(address indexed staker, address indexed operator)
+func (_DelegationManager *DelegationManagerFilterer) ParseStakerUndelegated(log types.Log) (*DelegationManagerStakerUndelegated, error) {
+	event := new(DelegationManagerStakerUndelegated)
+	if err := _DelegationManager.contract.UnpackLog(event, "StakerUndelegated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// DelegationManagerUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the DelegationManager contract.
+type DelegationManagerUnpausedIterator struct {
+	Event *DelegationManagerUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *DelegationManagerUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(DelegationManagerUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(DelegationManagerUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *DelegationManagerUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *DelegationManagerUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// DelegationManagerUnpaused represents a Unpaused event raised by the DelegationManager contract.
+type DelegationManagerUnpaused struct {
+	Account         common.Address
+	NewPausedStatus *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c.
+//
+// Solidity: event Unpaused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) FilterUnpaused(opts *bind.FilterOpts, account []common.Address) (*DelegationManagerUnpausedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.FilterLogs(opts, "Unpaused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationManagerUnpausedIterator{contract: _DelegationManager.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c.
+//
+// Solidity: event Unpaused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *DelegationManagerUnpaused, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _DelegationManager.contract.WatchLogs(opts, "Unpaused", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(DelegationManagerUnpaused)
+				if err := _DelegationManager.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x3582d1828e26bf56bd801502bc021ac0bc8afb57c826e4986b45593c8fad389c.
+//
+// Solidity: event Unpaused(address indexed account, uint256 newPausedStatus)
+func (_DelegationManager *DelegationManagerFilterer) ParseUnpaused(log types.Log) (*DelegationManagerUnpaused, error) {
+	event := new(DelegationManagerUnpaused)
+	if err := _DelegationManager.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/eigenState/withdrawals/withdrawals.go
+++ b/internal/eigenState/withdrawals/withdrawals.go
@@ -1,0 +1,357 @@
+package withdrawals
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Layr-Labs/go-sidecar/internal/config"
+	"github.com/Layr-Labs/go-sidecar/internal/eigenState/base"
+	m2DelegationManager "github.com/Layr-Labs/go-sidecar/internal/eigenState/bindings/DelegationManagerM2"
+	slashingDelegationManager "github.com/Layr-Labs/go-sidecar/internal/eigenState/bindings/DelegationManagerSlashing"
+	"github.com/Layr-Labs/go-sidecar/internal/eigenState/stateManager"
+	"github.com/Layr-Labs/go-sidecar/internal/eigenState/types"
+	"github.com/Layr-Labs/go-sidecar/internal/storage"
+	"github.com/Layr-Labs/go-sidecar/internal/utils"
+	"go.uber.org/zap"
+	"golang.org/x/xerrors"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type ShareWithdrawal struct {
+	Staker   string
+	Operator string
+	Strategy string
+	Shares   string
+
+	Nonce string
+	Root  string
+
+	QueueBlockNumber uint64
+	QueueBlockTime   time.Time
+
+	Completed            bool
+	CompletedBlockNumber uint64
+	CompletedBlockTime   time.Time
+}
+
+func NewSlotID(staker string, nonce string) types.SlotID {
+	return types.SlotID(fmt.Sprintf("%s_%s", staker, nonce))
+}
+
+type WithdrawalsModel struct {
+	base.BaseEigenState
+	DB           *gorm.DB
+	logger       *zap.Logger
+	globalConfig *config.Config
+
+	// Accumulates state changes for SlotIds, grouped by block number
+	stateAccumulator map[uint64][]*ShareWithdrawal
+}
+
+func NewWithdrawalsModel(
+	esm *stateManager.EigenStateManager,
+	grm *gorm.DB,
+	logger *zap.Logger,
+	globalConfig *config.Config,
+) (*WithdrawalsModel, error) {
+	model := &WithdrawalsModel{
+		BaseEigenState: base.BaseEigenState{
+			Logger: logger,
+		},
+		DB:               grm,
+		logger:           logger,
+		globalConfig:     globalConfig,
+		stateAccumulator: make(map[uint64][]*ShareWithdrawal),
+	}
+
+	esm.RegisterState(model, 69)
+
+	return model, nil
+}
+
+func (w *WithdrawalsModel) GetModelName() string {
+	return "WithdrawalsModel"
+}
+
+func (w *WithdrawalsModel) parseWithdrawalQueuedLog(log *storage.TransactionLog) (*ShareWithdrawals, error) {
+	withdrawalQueued := &m2DelegationManager.DelegationManagerWithdrawalQueued{}
+	logBytes, err := log.CombineArgs()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to combine log arguments: %w", err)
+	}
+
+	err = json.Unmarshal(logBytes, withdrawalQueued)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal WithdrawalQueued log: %w", err)
+	}
+
+	shareWithdrawals := make([]*ShareWithdrawal, len(withdrawalQueued.Withdrawal.Strategies))
+	for i, strategy := range withdrawalQueued.Withdrawal.Strategies {
+		shareWithdrawals[i] = &ShareWithdrawal{
+			Staker:           withdrawalQueued.Withdrawal.Staker.String(),
+			Operator:         withdrawalQueued.Withdrawal.DelegatedTo.String(),
+			Strategy:         strategy.String(),
+			Shares:           withdrawalQueued.Withdrawal.Shares[i].String(),
+			Nonce:            withdrawalQueued.Withdrawal.Nonce.String(),
+			Root:             hex.EncodeToString(withdrawalQueued.WithdrawalRoot[:]),
+			QueueBlockNumber: log.BlockNumber,
+			QueueBlockTime:   log.BlockTime,
+			Completed:        false,
+		}
+	}
+
+	return &ShareWithdrawals{ShareWithdrawals: shareWithdrawals}, nil
+}
+
+func (w *WithdrawalsModel) parseWithdrawalCompletedLog(log *storage.TransactionLog) (*ShareWithdrawals, error) {
+	withdrawalCompleted := &m2DelegationManager.DelegationManagerWithdrawalCompleted{}
+	logBytes, err := log.CombineArgs()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to combine log arguments: %w", err)
+	}
+
+	err = json.Unmarshal(logBytes, withdrawalCompleted)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal WithdrawalCompleted log: %w", err)
+	}
+
+	shareWithdrawals := make([]*ShareWithdrawal, 1)
+	shareWithdrawals[0] = &ShareWithdrawal{
+		Root:                 hex.EncodeToString(withdrawalCompleted.WithdrawalRoot[:]),
+		Completed:            true,
+		CompletedBlockNumber: log.BlockNumber,
+		CompletedBlockTime:   log.BlockTime,
+	}
+
+	return &ShareWithdrawals{ShareWithdrawals: shareWithdrawals}, nil
+}
+
+func (w *WithdrawalsModel) parseSlashingWithdrawalQueuedLog(log *storage.TransactionLog) (*ShareWithdrawals, error) {
+	slashingWithdrawalQueued := &slashingDelegationManager.DelegationManagerSlashingWithdrawalQueued{}
+	logBytes, err := log.CombineArgs()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to combine log arguments: %w", err)
+	}
+
+	err = json.Unmarshal(logBytes, slashingWithdrawalQueued)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal SlashingWithdrawalQueued log: %w", err)
+	}
+
+	shareWithdrawals := make([]*ShareWithdrawal, len(slashingWithdrawalQueued.Withdrawal.Strategies))
+	for i, strategy := range slashingWithdrawalQueued.Withdrawal.Strategies {
+		shareWithdrawals[i] = &ShareWithdrawal{
+			Staker:           slashingWithdrawalQueued.Withdrawal.Staker.String(),
+			Operator:         slashingWithdrawalQueued.Withdrawal.DelegatedTo.String(),
+			Strategy:         strategy.String(),
+			Shares:           slashingWithdrawalQueued.SharesToWithdraw[i].String(),
+			Nonce:            slashingWithdrawalQueued.Withdrawal.Nonce.String(),
+			Root:             hex.EncodeToString(slashingWithdrawalQueued.WithdrawalRoot[:]),
+			QueueBlockNumber: log.BlockNumber,
+			QueueBlockTime:   log.BlockTime,
+			Completed:        false,
+		}
+	}
+
+	return &ShareWithdrawals{ShareWithdrawals: shareWithdrawals}, nil
+}
+
+func (w *WithdrawalsModel) parseSlashingWithdrawalCompletedLog(log *storage.TransactionLog) (*ShareWithdrawals, error) {
+	slashingWithdrawalCompleted := &slashingDelegationManager.DelegationManagerSlashingWithdrawalCompleted{}
+	logBytes, err := log.CombineArgs()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to combine log arguments: %w", err)
+	}
+
+	err = json.Unmarshal(logBytes, slashingWithdrawalCompleted)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal SlashingWithdrawalCompleted log: %w", err)
+	}
+
+	shareWithdrawals := make([]*ShareWithdrawal, 1)
+	shareWithdrawals[0] = &ShareWithdrawal{
+		Root:                 hex.EncodeToString(slashingWithdrawalCompleted.WithdrawalRoot[:]),
+		Completed:            true,
+		CompletedBlockNumber: log.BlockNumber,
+		CompletedBlockTime:   log.BlockTime,
+	}
+
+	return &ShareWithdrawals{ShareWithdrawals: shareWithdrawals}, nil
+}
+
+type ShareWithdrawals struct {
+	ShareWithdrawals []*ShareWithdrawal
+}
+
+func (w *WithdrawalsModel) GetStateTransitions() ([]uint64, types.StateTransitions[ShareWithdrawals]) {
+	stateChanges := make(types.StateTransitions[ShareWithdrawals])
+
+	stateChanges[0] = func(log *storage.TransactionLog) (*ShareWithdrawals, error) {
+		shareWithdrawalsForLog := &ShareWithdrawals{}
+		var err error
+		switch log.EventName {
+		case "WithdrawalQueued":
+			shareWithdrawalsForLog, err = w.parseWithdrawalQueuedLog(log)
+		case "WithdrawalCompleted":
+			shareWithdrawalsForLog, err = w.parseWithdrawalCompletedLog(log)
+		case "SlashingWithdrawalQueued":
+			shareWithdrawalsForLog, err = w.parseSlashingWithdrawalQueuedLog(log)
+		case "SlashingWithdrawalCompleted":
+			shareWithdrawalsForLog, err = w.parseSlashingWithdrawalCompletedLog(log)
+		}
+
+		if err != nil {
+			// include event name in error message
+			return nil, xerrors.Errorf("error parsing %s log: %w", log.EventName, err)
+		}
+
+		return shareWithdrawalsForLog, nil
+	}
+
+	// sort the fork block numbers in descending order
+	forkBlockNumbers := make([]uint64, 0)
+	for blockNumber := range stateChanges {
+		forkBlockNumbers = append(forkBlockNumbers, blockNumber)
+	}
+	sort.Slice(forkBlockNumbers, func(i, j int) bool {
+		return forkBlockNumbers[i] > forkBlockNumbers[j]
+	})
+
+	return forkBlockNumbers, stateChanges
+}
+
+func (w *WithdrawalsModel) getContractAddressesForEnvironment() map[string][]string {
+	contracts := w.globalConfig.GetContractsMapForChain()
+	return map[string][]string{
+		contracts.DelegationManager: {
+			"WithdrawalQueued",
+			"WithdrawalCompleted",
+			"SlashingWithdrawalQueued",
+			"SlashingWithdrawalCompleted",
+		},
+	}
+}
+
+func (w *WithdrawalsModel) IsInterestingLog(log *storage.TransactionLog) bool {
+	addresses := w.getContractAddressesForEnvironment()
+	return w.BaseEigenState.IsInterestingLog(addresses, log)
+}
+
+func (w *WithdrawalsModel) SetupStateForBlock(blockNumber uint64) error {
+	w.stateAccumulator[blockNumber] = make([]*ShareWithdrawal, 0)
+	return nil
+}
+
+func (w *WithdrawalsModel) CleanupProcessedStateForBlock(blockNumber uint64) error {
+	delete(w.stateAccumulator, blockNumber)
+	return nil
+}
+
+func (w *WithdrawalsModel) HandleStateChange(log *storage.TransactionLog) (interface{}, error) {
+	sortedBlockNumbers, stateChanges := w.GetStateTransitions()
+
+	for _, blockNumber := range sortedBlockNumbers {
+		if log.BlockNumber >= blockNumber {
+			w.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", blockNumber))
+
+			change, err := stateChanges[blockNumber](log)
+			if err != nil {
+				return nil, err
+			}
+			if change == nil {
+				return nil, xerrors.Errorf("No state change found for block %d", blockNumber)
+			}
+			return change, nil
+		}
+	}
+	return nil, nil
+}
+
+func (w *WithdrawalsModel) prepareState(blockNumber uint64) ([]*ShareWithdrawal, []*ShareWithdrawal, error) {
+	shareWithdrawals := w.stateAccumulator[blockNumber]
+	if shareWithdrawals == nil {
+		return nil, nil, errors.New("no state changes found for block")
+	}
+
+	inserts := make([]*ShareWithdrawal, 0)
+	updates := make([]*ShareWithdrawal, 0)
+
+	for _, shareWithdrawal := range shareWithdrawals {
+		if !shareWithdrawal.Completed {
+			inserts = append(inserts, shareWithdrawal)
+		} else {
+			updates = append(updates, shareWithdrawal)
+		}
+	}
+
+	return inserts, updates, nil
+}
+
+func (w *WithdrawalsModel) CommitFinalState(blockNumber uint64) error {
+	inserts, updates, err := w.prepareState(blockNumber)
+	if err != nil {
+		return err
+	}
+
+	if len(inserts) > 0 {
+		res := w.DB.Model(&ShareWithdrawal{}).Clauses(clause.Returning{}).Create(&inserts)
+		if res.Error != nil {
+			return err
+		}
+	}
+
+	if len(updates) > 0 {
+		completedRoots := make([]string, 0)
+		for _, update := range updates {
+			completedRoots = append(completedRoots, update.Root)
+		}
+
+		// update the complete columns of each share withdrawal
+		// can batch update all because they're all at the same block number and timestamp
+		res := w.DB.Model(&ShareWithdrawal{}).Where("root IN ?", completedRoots).Updates(map[string]interface{}{
+			"completed":              updates[0].Completed,
+			"completed_block_number": updates[0].CompletedBlockNumber,
+			"completed_block_time":   updates[0].CompletedBlockTime,
+		})
+		if res.Error != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *WithdrawalsModel) GenerateStateRoot(blockNumber uint64) (types.StateRoot, error) {
+	diffs := w.stateAccumulator[blockNumber]
+	if diffs == nil {
+		return "", errors.New("no state changes found for block")
+	}
+
+	inputs := make([]*base.MerkleTreeInput, 0)
+	for _, diff := range diffs {
+		inputs = append(inputs, &base.MerkleTreeInput{
+			SlotID: NewSlotID(diff.Staker, diff.Nonce),
+			Value:  []byte(diff.Root),
+		})
+	}
+
+	// sort by slotId
+	sort.Slice(inputs, func(i, j int) bool {
+		return inputs[i].SlotID < inputs[j].SlotID
+	})
+
+	fullTree, err := w.MerkleizeState(blockNumber, inputs)
+	if err != nil {
+		return "", err
+	}
+	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
+}
+
+func (w *WithdrawalsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
+	return w.BaseEigenState.DeleteState("share_withdrawals", startBlockNumber, endBlockNumber, w.DB)
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/Layr-Labs/go-sidecar/internal/clients/ethereum"
 	"github.com/Layr-Labs/go-sidecar/internal/clients/etherscan"
@@ -182,7 +183,7 @@ func (idx *Indexer) ParseAndIndexTransactionLogs(ctx context.Context, fetchedBlo
 		}
 
 		for _, log := range parsedTransactionLogs.Logs {
-			_, err := idx.IndexLog(ctx, fetchedBlock.Block.Number.Value(), tx.Hash.Value(), tx.Index.Value(), log)
+			_, err := idx.IndexLog(ctx, fetchedBlock.Block.Number.Value(), time.Unix(int64(fetchedBlock.Block.Timestamp.Value()), 0), tx.Hash.Value(), tx.Index.Value(), log)
 			if err != nil {
 				idx.Logger.Sugar().Errorw("failed to index log",
 					zap.Error(err),
@@ -294,6 +295,7 @@ func (idx *Indexer) IndexTransaction(
 ) (*storage.Transaction, error) {
 	return idx.MetadataStore.InsertBlockTransaction(
 		block.Number,
+		block.BlockTime,
 		tx.Hash.Value(),
 		tx.Index.Value(),
 		tx.From.Value(),
@@ -389,6 +391,7 @@ func (idx *Indexer) handleContractCreation(
 func (idx *Indexer) IndexLog(
 	ctx context.Context,
 	blockNumber uint64,
+	blockTime time.Time,
 	txHash string,
 	txIndex uint64,
 	log *parser.DecodedLog,
@@ -397,6 +400,7 @@ func (idx *Indexer) IndexLog(
 		txHash,
 		txIndex,
 		blockNumber,
+		blockTime,
 		log,
 		log.OutputData,
 	)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -97,6 +97,7 @@ func (p *Pipeline) RunForBlock(ctx context.Context, blockNumber uint64) error {
 			indexedLog, err := p.Indexer.IndexLog(
 				ctx,
 				indexedBlock.Number,
+				indexedTransaction.BlockTime,
 				indexedTransaction.TransactionHash,
 				indexedTransaction.TransactionIndex,
 				log,

--- a/internal/sqlite/migrations/202409061249_bootstrapDb/up.go
+++ b/internal/sqlite/migrations/202409061249_bootstrapDb/up.go
@@ -21,6 +21,7 @@ func (m *SqliteMigration) Up(grm *gorm.DB) error {
     	)`,
 		`CREATE TABLE IF NOT EXISTS transactions (
 			block_number INTEGER NOT NULL REFERENCES blocks(number) ON DELETE CASCADE,
+			block_time DATETIME NOT NULL,
 			transaction_hash TEXT NOT NULL PRIMARY KEY,
 			transaction_index INTEGER NOT NULL,
 			from_address TEXT NOT NULL,
@@ -42,6 +43,7 @@ func (m *SqliteMigration) Up(grm *gorm.DB) error {
 			event_name TEXT NOT NULL,
 			log_index INTEGER NOT NULL,
 			block_number INTEGER NOT NULL REFERENCES blocks(number) ON DELETE CASCADE,
+			block_time DATETIME NOT NULL,
 			transaction_index INTEGER NOT NULL,
 			output_data TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -90,6 +90,7 @@ func Test_SqliteBlockstore(t *testing.T) {
 		t.Run("InsertBlockTransaction", func(t *testing.T) {
 			tx := storage.Transaction{
 				BlockNumber:      block.Number,
+				BlockTime:        block.BlockTime,
 				TransactionHash:  "txHash",
 				TransactionIndex: 0,
 				FromAddress:      "from",
@@ -99,6 +100,7 @@ func Test_SqliteBlockstore(t *testing.T) {
 			}
 			insertedTx, err := sqliteStore.InsertBlockTransaction(
 				tx.BlockNumber,
+				tx.BlockTime,
 				tx.TransactionHash,
 				tx.TransactionIndex,
 				tx.FromAddress,
@@ -130,6 +132,7 @@ func Test_SqliteBlockstore(t *testing.T) {
 			}
 			_, err := sqliteStore.InsertBlockTransaction(
 				tx.BlockNumber,
+				tx.BlockTime,
 				tx.TransactionHash,
 				tx.TransactionIndex,
 				tx.FromAddress,
@@ -167,12 +170,14 @@ func Test_SqliteBlockstore(t *testing.T) {
 				TransactionHash:  insertedTransactions[0].TransactionHash,
 				TransactionIndex: insertedTransactions[0].TransactionIndex,
 				BlockNumber:      insertedTransactions[0].BlockNumber,
+				BlockTime:        insertedTransactions[0].BlockTime,
 			}
 
 			insertedTxLog, err := sqliteStore.InsertTransactionLog(
 				txLog.TransactionHash,
 				txLog.TransactionIndex,
 				txLog.BlockNumber,
+				txLog.BlockTime,
 				decodedLog,
 				decodedLog.OutputData,
 			)
@@ -209,12 +214,14 @@ func Test_SqliteBlockstore(t *testing.T) {
 				TransactionHash:  insertedTransactions[0].TransactionHash,
 				TransactionIndex: insertedTransactions[0].TransactionIndex,
 				BlockNumber:      insertedTransactions[0].BlockNumber,
+				BlockTime:        insertedTransactions[0].BlockTime,
 			}
 
 			_, err := sqliteStore.InsertTransactionLog(
 				txLog.TransactionHash,
 				txLog.TransactionIndex,
 				txLog.BlockNumber,
+				txLog.BlockTime,
 				decodedLog,
 				decodedLog.OutputData,
 			)

--- a/internal/storage/sqlite/storage.go
+++ b/internal/storage/sqlite/storage.go
@@ -59,6 +59,7 @@ func (s *SqliteBlockStore) InsertBlockAtHeight(
 
 func (s *SqliteBlockStore) InsertBlockTransaction(
 	blockNumber uint64,
+	blockTime time.Time,
 	txHash string,
 	txIndex uint64,
 	from string,
@@ -72,6 +73,7 @@ func (s *SqliteBlockStore) InsertBlockTransaction(
 
 	tx := &storage.Transaction{
 		BlockNumber:      blockNumber,
+		BlockTime:        blockTime,
 		TransactionHash:  txHash,
 		TransactionIndex: txIndex,
 		FromAddress:      from,
@@ -92,6 +94,7 @@ func (s *SqliteBlockStore) InsertTransactionLog(
 	txHash string,
 	transactionIndex uint64,
 	blockNumber uint64,
+	blockTime time.Time,
 	log *parser.DecodedLog,
 	outputData map[string]interface{},
 ) (*storage.TransactionLog, error) {
@@ -109,6 +112,7 @@ func (s *SqliteBlockStore) InsertTransactionLog(
 		TransactionHash:  txHash,
 		TransactionIndex: transactionIndex,
 		BlockNumber:      blockNumber,
+		BlockTime:        blockTime,
 		Address:          strings.ToLower(log.Address),
 		Arguments:        string(argsJson),
 		EventName:        log.EventName,
@@ -217,7 +221,7 @@ func (s *SqliteBlockStore) DeleteCorruptedState(startBlockNumber uint64, endBloc
 			zap.Uint64("startBlockNumber", startBlockNumber),
 			zap.Uint64("endBlockNumber", endBlockNumber),
 		)
-		return fmt.Errorf("Invalid block range; endBlockNumber must be greater than or equal to startBlockNumber")
+		return fmt.Errorf("invalid block range; endBlockNumber must be greater than or equal to startBlockNumber")
 	}
 
 	tablesWithBlockNumber := []string{


### PR DESCRIPTION
Adding the withdrawals model. This is critical protocol data that needs to be kept track of for serving data to customers via RPC. This does not include RPC endpoints.

Notably this
- Adds bindings to the eigenState directory
- - how to avoid this?
- Adds blocktimes to the logs and transaction tables