### PR TITLE
feat: handle slashing withdrawals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test-db
 /sqlite-extensions/build
 .DS_Store
 node_modules
+.env

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Layr-Labs/go-sidecar/pkg/storage"
-	"github.com/Layr-Labs/go-sidecar/pkg/types/numbers"
 	"math/big"
 	"slices"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Layr-Labs/go-sidecar/pkg/storage"
+	"github.com/Layr-Labs/go-sidecar/pkg/types/numbers"
 
 	"github.com/Layr-Labs/go-sidecar/internal/config"
 	"github.com/Layr-Labs/go-sidecar/pkg/eigenState/base"
@@ -554,6 +555,7 @@ func (ss *StakerSharesModel) getContractAddressesForEnvironment() map[string][]s
 		contracts.DelegationManager: {
 			"WithdrawalMigrated",
 			"WithdrawalQueued",
+			"SlashingWithdrawalQueued",
 		},
 		contracts.StrategyManager: {
 			"Deposit",

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -1,13 +1,14 @@
 package stakerShares
 
 import (
-	"github.com/Layr-Labs/go-sidecar/pkg/postgres"
-	"github.com/Layr-Labs/go-sidecar/pkg/storage"
-	"github.com/Layr-Labs/go-sidecar/pkg/types/numbers"
 	"math/big"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Layr-Labs/go-sidecar/pkg/postgres"
+	"github.com/Layr-Labs/go-sidecar/pkg/storage"
+	"github.com/Layr-Labs/go-sidecar/pkg/types/numbers"
 
 	"github.com/Layr-Labs/go-sidecar/internal/config"
 	"github.com/Layr-Labs/go-sidecar/internal/logger"

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -547,4 +547,85 @@ func Test_StakerSharesState(t *testing.T) {
 	t.Cleanup(func() {
 		postgres.TeardownTestDatabase(dbName, cfg, grm, l)
 	})
+
+	t.Run("Should capture Slashing withdrawals", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+		log := storage.TransactionLog{
+			TransactionHash:  "some hash",
+			TransactionIndex: big.NewInt(300).Uint64(),
+			BlockNumber:      blockNumber,
+			Address:          cfg.GetContractsMapForChain().DelegationManager,
+			Arguments:        `[{"Name": "withdrawalRoot", "Type": "bytes32", "Value": ""}, {"Name": "withdrawal", "Type": "(address,address,address,uint256,uint32,address[],uint256[])", "Value": ""}]`,
+			EventName:        "SlashingWithdrawalQueued",
+			LogIndex:         big.NewInt(600).Uint64(),
+			OutputData:       `{"withdrawal": {"nonce": 0, "scaledShares": [1000000000000000000], "staker": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "startBlock": 1215690, "strategies": ["0xd523267698c81a372191136e477fdebfa33d9fb4"], "withdrawer": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "delegatedTo": "0x2177dee1f66d6dbfbf517d9c4f316024c6a21aeb"}, "withdrawalRoot": [24, 23, 49, 137, 14, 63, 119, 12, 234, 225, 63, 35, 109, 249, 112, 24, 241, 118, 212, 52, 22, 107, 202, 56, 105, 37, 68, 47, 169, 23, 142, 135], "sharesToWithdraw": [50000000000000]}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := model.HandleStateChange(&log)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+
+		typedChange := change.(*AccumulatedStateChanges)
+		assert.Equal(t, 1, len(typedChange.Changes))
+
+		expectedShares, _ := numbers.NewBig257().SetString("-50000000000000", 10)
+		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[0].Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", typedChange.Changes[0].Strategy)
+
+		teardown(model)
+	})
+
+	t.Run("Should capture Slashing withdrawals for multiple strategies", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+		log := storage.TransactionLog{
+			TransactionHash:  "some hash",
+			TransactionIndex: big.NewInt(300).Uint64(),
+			BlockNumber:      blockNumber,
+			Address:          cfg.GetContractsMapForChain().DelegationManager,
+			Arguments:        `[{"Name": "withdrawalRoot", "Type": "bytes32", "Value": ""}, {"Name": "withdrawal", "Type": "(address,address,address,uint256,uint32,address[],uint256[])", "Value": ""}]`,
+			EventName:        "SlashingWithdrawalQueued",
+			LogIndex:         big.NewInt(600).Uint64(),
+			OutputData:       `{"withdrawal": {"nonce": 0, "scaledShares": [1000000000000000000, 2000000000000000000], "staker": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "startBlock": 1215690, "strategies": ["0xd523267698c81a372191136e477fdebfa33d9fb4", "0xe523267698c81a372191136e477fdebfa33d9fb5"], "withdrawer": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "delegatedTo": "0x2177dee1f66d6dbfbf517d9c4f316024c6a21aeb"}, "withdrawalRoot": [24, 23, 49, 137, 14, 63, 119, 12, 234, 225, 63, 35, 109, 249, 112, 24, 241, 118, 212, 52, 22, 107, 202, 56, 105, 37, 68, 47, 169, 23, 142, 135], "sharesToWithdraw": [50000000000000, 100000000000000]}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := model.HandleStateChange(&log)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+
+		typedChange := change.(*AccumulatedStateChanges)
+		assert.Equal(t, 2, len(typedChange.Changes))
+
+		expectedShares, _ := numbers.NewBig257().SetString("-50000000000000", 10)
+		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[0].Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", typedChange.Changes[0].Strategy)
+
+		expectedShares, _ = numbers.NewBig257().SetString("-100000000000000", 10)
+		assert.Equal(t, expectedShares, typedChange.Changes[1].Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[1].Staker)
+		assert.Equal(t, "0xe523267698c81a372191136e477fdebfa33d9fb5", typedChange.Changes[1].Strategy)
+
+		teardown(model)
+	})
 }


### PR DESCRIPTION
This adds support for the new `SlashingWithdrawalQueued` event. Merging this change makes us maggie-compatible for rewards.