### PR TITLE
Gpsanant/slashing events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,17 @@ lint:
 test:
 	./scripts/goTest.sh -v -p 1 -parallel 1 ./...
 
+# Run tests in a specific test file
+# Usage: make test-file FILE=path/to/your_test_file.go
+.PHONY: test-file
+test-file:
+	@if [ -z "$(FILE)" ]; then \
+		echo "Error: FILE variable is not set."; \
+		echo "Usage: make test-file FILE=path/to/your_test_file.go"; \
+		exit 1; \
+	fi
+	./scripts/goTest.sh -v -p 1 -parallel 1 $(FILE)
+
 .PHONY: staticcheck
 staticcheck:
 	staticcheck ./...

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,9 +3,10 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/viper"
 )
 
 type EnvScope string
@@ -121,6 +122,7 @@ type ContractAddresses struct {
 	StrategyManager    string
 	DelegationManager  string
 	AvsDirectory       string
+	AllocationManager  string
 }
 
 func (c *Config) GetContractsMapForChain() *ContractAddresses {
@@ -131,6 +133,7 @@ func (c *Config) GetContractsMapForChain() *ContractAddresses {
 			StrategyManager:    "0xf9fbf2e35d8803273e214c99bf15174139f4e67a",
 			DelegationManager:  "0x75dfe5b44c2e530568001400d3f704bc8ae350cc",
 			AvsDirectory:       "0x141d6995556135d4997b2ff72eb443be300353bc",
+			AllocationManager:  "0x16D3F63d18549f035Bc69b553006684B69cE8148",
 		}
 	} else if c.Chain == Chain_Holesky {
 		return &ContractAddresses{
@@ -139,6 +142,7 @@ func (c *Config) GetContractsMapForChain() *ContractAddresses {
 			StrategyManager:    "0xdfb5f6ce42aaa7830e94ecfccad411bef4d4d5b6",
 			DelegationManager:  "0xa44151489861fe9e3055d95adc98fbd462b948e7",
 			AvsDirectory:       "0x055733000064333caddbc92763c58bf0192ffebf",
+			AllocationManager:  "0x16D3F63d18549f035Bc69b553006684B69cE8148",
 		}
 	} else if c.Chain == Chain_Mainnet {
 		return &ContractAddresses{
@@ -147,6 +151,7 @@ func (c *Config) GetContractsMapForChain() *ContractAddresses {
 			StrategyManager:    "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
 			DelegationManager:  "0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a",
 			AvsDirectory:       "0x135dda560e946695d6f155dacafc6f1f25c1f5af",
+			AllocationManager:  "0x16D3F63d18549f035Bc69b553006684B69cE8148",
 		}
 	} else {
 		return nil

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 	"sort"
@@ -26,16 +27,6 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-var WAD = big.NewInt(1e18)
-
-type StateDiffEvent interface {
-	SlotID() types.SlotID
-}
-
-type StateDiff struct {
-	Event StateDiffEvent
-}
-
 type SlashDiff struct {
 	Operator        string
 	Strategy        string
@@ -45,10 +36,6 @@ type SlashDiff struct {
 	BlockTime       time.Time
 	BlockDate       string
 	BlockNumber     uint64
-}
-
-func (u *SlashDiff) SlotID() types.SlotID {
-	return types.SlotID(fmt.Sprintf("MAX_MAGNITUDE_%s_%s", u.Operator, u.Strategy))
 }
 
 // Table staker_share_deltas
@@ -62,10 +49,6 @@ type StakerShareDeltas struct {
 	BlockTime       time.Time
 	BlockDate       string
 	BlockNumber     uint64
-}
-
-func (ss *StakerShareDeltas) SlotID() types.SlotID {
-	return NewShareDeltaSlotID(ss.Staker, ss.Strategy)
 }
 
 func NewShareDeltaSlotID(staker, strategy string) types.SlotID {
@@ -87,7 +70,7 @@ type StakerSharesDiff struct {
 	BlockNumber uint64
 }
 
-func (ss *StakerShares) ToStakerSharesDiff() (*StakerSharesDiff, error) {
+func StakerSharesToStakerSharesDiff(ss *StakerShares) (*StakerSharesDiff, error) {
 	shares, success := numbers.NewBig257().SetString(ss.Shares, 10)
 	if !success {
 		return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", ss.Shares)
@@ -106,7 +89,9 @@ type StakerSharesModel struct {
 	logger       *zap.Logger
 	globalConfig *config.Config
 
-	diffAccumulator  map[uint64][]*StateDiff
+	eventDeltaAccumulator map[uint64][]*StakerShareDeltas
+	slashingAccumulator   map[uint64][]*SlashDiff
+
 	deltaAccumulator map[uint64][]*StakerShareDeltas
 }
 
@@ -117,12 +102,13 @@ func NewStakerSharesModel(
 	globalConfig *config.Config,
 ) (*StakerSharesModel, error) {
 	model := &StakerSharesModel{
-		BaseEigenState:   base.BaseEigenState{},
-		DB:               grm,
-		logger:           logger,
-		globalConfig:     globalConfig,
-		diffAccumulator:  make(map[uint64][]*StateDiff),
-		deltaAccumulator: make(map[uint64][]*StakerShareDeltas),
+		BaseEigenState:        base.BaseEigenState{},
+		DB:                    grm,
+		logger:                logger,
+		globalConfig:          globalConfig,
+		eventDeltaAccumulator: make(map[uint64][]*StakerShareDeltas),
+		slashingAccumulator:   make(map[uint64][]*SlashDiff),
+		deltaAccumulator:      make(map[uint64][]*StakerShareDeltas),
 	}
 
 	esm.RegisterState(model, 3)
@@ -159,7 +145,7 @@ func parseLogOutputForDepositEvent(outputDataStr string) (*depositOutputData, er
 	return outputData, err
 }
 
-func (ss *StakerSharesModel) handleStakerDepositEvent(log *storage.TransactionLog) (*StateDiff, error) {
+func (ss *StakerSharesModel) handleStakerDepositEvent(log *storage.TransactionLog) (*StakerShareDeltas, error) {
 	outputData, err := parseLogOutputForDepositEvent(log.OutputData)
 	if err != nil {
 		return nil, err
@@ -182,16 +168,14 @@ func (ss *StakerSharesModel) handleStakerDepositEvent(log *storage.TransactionLo
 		return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", outputData.Shares)
 	}
 
-	return &StateDiff{
-		Event: &StakerShareDeltas{
-			Staker:          stakerAddress,
-			Strategy:        outputData.Strategy,
-			Shares:          shares.String(),
-			StrategyIndex:   uint64(0),
-			LogIndex:        log.LogIndex,
-			TransactionHash: log.TransactionHash,
-			BlockNumber:     log.BlockNumber,
-		},
+	return &StakerShareDeltas{
+		Staker:          stakerAddress,
+		Strategy:        outputData.Strategy,
+		Shares:          shares.String(),
+		StrategyIndex:   uint64(0),
+		LogIndex:        log.LogIndex,
+		TransactionHash: log.TransactionHash,
+		BlockNumber:     log.BlockNumber,
 	}, nil
 }
 
@@ -211,7 +195,7 @@ func parseLogOutputForPodSharesUpdatedEvent(outputDataStr string) (*podSharesUpd
 	return outputData, err
 }
 
-func (ss *StakerSharesModel) handlePodSharesUpdatedEvent(log *storage.TransactionLog) (*StateDiff, error) {
+func (ss *StakerSharesModel) handlePodSharesUpdatedEvent(log *storage.TransactionLog) (*StakerShareDeltas, error) {
 	arguments, err := ss.ParseLogArguments(log)
 	if err != nil {
 		return nil, err
@@ -230,20 +214,18 @@ func (ss *StakerSharesModel) handlePodSharesUpdatedEvent(log *storage.Transactio
 		return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", sharesDelta)
 	}
 
-	return &StateDiff{
-		Event: &StakerShareDeltas{
-			Staker:          staker,
-			Strategy:        "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0",
-			Shares:          sharesDelta.String(),
-			StrategyIndex:   uint64(0),
-			LogIndex:        log.LogIndex,
-			TransactionHash: log.TransactionHash,
-			BlockNumber:     log.BlockNumber,
-		},
+	return &StakerShareDeltas{
+		Staker:          staker,
+		Strategy:        "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0",
+		Shares:          sharesDelta.String(),
+		StrategyIndex:   uint64(0),
+		LogIndex:        log.LogIndex,
+		TransactionHash: log.TransactionHash,
+		BlockNumber:     log.BlockNumber,
 	}, nil
 }
 
-func (ss *StakerSharesModel) handleM1StakerWithdrawals(log *storage.TransactionLog) (*StateDiff, error) {
+func (ss *StakerSharesModel) handleM1StakerWithdrawals(log *storage.TransactionLog) (*StakerShareDeltas, error) {
 	outputData, err := parseLogOutputForDepositEvent(log.OutputData)
 	if err != nil {
 		return nil, err
@@ -266,16 +248,14 @@ func (ss *StakerSharesModel) handleM1StakerWithdrawals(log *storage.TransactionL
 		return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", outputData.Shares)
 	}
 
-	return &StateDiff{
-		Event: &StakerShareDeltas{
-			Staker:          stakerAddress,
-			Strategy:        outputData.Strategy,
-			Shares:          shares.Mul(shares, big.NewInt(-1)).String(),
-			StrategyIndex:   uint64(0),
-			LogIndex:        log.LogIndex,
-			TransactionHash: log.TransactionHash,
-			BlockNumber:     log.BlockNumber,
-		},
+	return &StakerShareDeltas{
+		Staker:          stakerAddress,
+		Strategy:        outputData.Strategy,
+		Shares:          shares.Mul(shares, big.NewInt(-1)).String(),
+		StrategyIndex:   uint64(0),
+		LogIndex:        log.LogIndex,
+		TransactionHash: log.TransactionHash,
+		BlockNumber:     log.BlockNumber,
 	}, nil
 }
 
@@ -302,7 +282,7 @@ func parseLogOutputForM2MigrationEvent(outputDataStr string) (*m2MigrationOutput
 // Since we have already counted M1 withdrawals due to processing events block-by-block, we need to handle not double subtracting.
 // Assuming that M2 WithdrawalQueued events always result in a subtraction, if we encounter a migration event, we need
 // to add the amount back to the shares to get the correct final state.
-func (ss *StakerSharesModel) handleMigratedM2StakerWithdrawals(log *storage.TransactionLog) ([]*StateDiff, error) {
+func (ss *StakerSharesModel) handleMigratedM2StakerWithdrawals(log *storage.TransactionLog) ([]*StakerShareDeltas, error) {
 	outputData, err := parseLogOutputForM2MigrationEvent(log.OutputData)
 	if err != nil {
 		return nil, err
@@ -353,7 +333,7 @@ func (ss *StakerSharesModel) handleMigratedM2StakerWithdrawals(log *storage.Tran
 		return nil, res.Error
 	}
 
-	changes := make([]*StateDiff, 0)
+	changes := make([]*StakerShareDeltas, 0)
 	for _, l := range logs {
 		c, err := ss.handleStakerDepositEvent(&l)
 		if err != nil {
@@ -392,29 +372,27 @@ func parseLogOutputForM2WithdrawalEvent(outputDataStr string) (*m2WithdrawalOutp
 }
 
 // handleM2QueuedWithdrawal handles the WithdrawalQueued event from the DelegationManager contract for M2.
-func (ss *StakerSharesModel) handleM2QueuedWithdrawal(log *storage.TransactionLog) ([]*StateDiff, error) {
+func (ss *StakerSharesModel) handleM2QueuedWithdrawal(log *storage.TransactionLog) ([]*StakerShareDeltas, error) {
 	outputData, err := parseLogOutputForM2WithdrawalEvent(log.OutputData)
 	if err != nil {
 		return nil, err
 	}
 
-	records := make([]*StateDiff, 0)
+	records := make([]*StakerShareDeltas, 0)
 
 	for i, strategy := range outputData.Withdrawal.Strategies {
 		shares, success := numbers.NewBig257().SetString(outputData.Withdrawal.Shares[i].String(), 10)
 		if !success {
 			return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", outputData.Withdrawal.Shares[i])
 		}
-		r := &StateDiff{
-			Event: &StakerShareDeltas{
-				Staker:          outputData.Withdrawal.Staker,
-				Strategy:        strategy,
-				Shares:          shares.Mul(shares, big.NewInt(-1)).String(),
-				StrategyIndex:   uint64(i),
-				LogIndex:        log.LogIndex,
-				TransactionHash: log.TransactionHash,
-				BlockNumber:     log.BlockNumber,
-			},
+		r := &StakerShareDeltas{
+			Staker:          outputData.Withdrawal.Staker,
+			Strategy:        strategy,
+			Shares:          shares.Mul(shares, big.NewInt(-1)).String(),
+			StrategyIndex:   uint64(i),
+			LogIndex:        log.LogIndex,
+			TransactionHash: log.TransactionHash,
+			BlockNumber:     log.BlockNumber,
 		}
 		records = append(records, r)
 	}
@@ -449,29 +427,27 @@ func parseLogOutputForSlashingWithdrawalQueuedEvent(outputDataStr string) (*slas
 }
 
 // handleM2QueuedWithdrawal handles the WithdrawalQueued event from the DelegationManager contract for M2.
-func (ss *StakerSharesModel) handleSlashingQueuedWithdrawal(log *storage.TransactionLog) ([]*StateDiff, error) {
+func (ss *StakerSharesModel) handleSlashingQueuedWithdrawal(log *storage.TransactionLog) ([]*StakerShareDeltas, error) {
 	outputData, err := parseLogOutputForSlashingWithdrawalQueuedEvent(log.OutputData)
 	if err != nil {
 		return nil, err
 	}
 
-	records := make([]*StateDiff, 0)
+	records := make([]*StakerShareDeltas, 0)
 
 	for i, strategy := range outputData.Withdrawal.Strategies {
 		shares, success := numbers.NewBig257().SetString(outputData.SharesToWithdraw[i].String(), 10)
 		if !success {
 			return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", outputData.SharesToWithdraw[i])
 		}
-		r := &StateDiff{
-			Event: &StakerShareDeltas{
-				Staker:          outputData.Withdrawal.Staker,
-				Strategy:        strategy,
-				Shares:          shares.Mul(shares, big.NewInt(-1)).String(),
-				StrategyIndex:   uint64(i),
-				LogIndex:        log.LogIndex,
-				TransactionHash: log.TransactionHash,
-				BlockNumber:     log.BlockNumber,
-			},
+		r := &StakerShareDeltas{
+			Staker:          outputData.Withdrawal.Staker,
+			Strategy:        strategy,
+			Shares:          shares.Mul(shares, big.NewInt(-1)).String(),
+			StrategyIndex:   uint64(i),
+			LogIndex:        log.LogIndex,
+			TransactionHash: log.TransactionHash,
+			BlockNumber:     log.BlockNumber,
 		}
 		records = append(records, r)
 	}
@@ -479,14 +455,9 @@ func (ss *StakerSharesModel) handleSlashingQueuedWithdrawal(log *storage.Transac
 }
 
 type operatorSlashedOutputData struct {
-	Operator string `json:"operator"`
-	// OperatorSet struct {
-	// 	Avs           string `json:"avs"`
-	// 	OperatorSetId uint32 `json:"operatorSetId"`
-	// }
+	Operator    string        `json:"operator"`
 	Strategies  []string      `json:"strategies"`
 	WadsSlashed []json.Number `json:"wadsSlashed"`
-	// Description string        `json:"description"`
 }
 
 func parseLogOutputForOperatorSlashedEvent(outputDataStr string) (*operatorSlashedOutputData, error) {
@@ -502,28 +473,26 @@ func parseLogOutputForOperatorSlashedEvent(outputDataStr string) (*operatorSlash
 	return outputData, err
 }
 
-func (ss *StakerSharesModel) handleOperatorSlashedEvent(log *storage.TransactionLog) ([]*StateDiff, error) {
+func (ss *StakerSharesModel) handleOperatorSlashedEvent(log *storage.TransactionLog) ([]*SlashDiff, error) {
 	outputData, err := parseLogOutputForOperatorSlashedEvent(log.OutputData)
 	if err != nil {
 		return nil, err
 	}
 
-	stateDiffs := make([]*StateDiff, 0)
+	stateDiffs := make([]*SlashDiff, 0)
 
 	for i, strategy := range outputData.Strategies {
 		wadsSlashed, success := numbers.NewBig257().SetString(outputData.WadsSlashed[i].String(), 10)
 		if !success {
 			return nil, xerrors.Errorf("Failed to convert wadsSlashed to big.Int: %s", outputData.WadsSlashed[i])
 		}
-		stateDiffs = append(stateDiffs, &StateDiff{
-			Event: &SlashDiff{
-				Operator:        outputData.Operator,
-				Strategy:        strategy,
-				WadsSlashed:     wadsSlashed,
-				TransactionHash: log.TransactionHash,
-				LogIndex:        log.LogIndex,
-				BlockNumber:     log.BlockNumber,
-			},
+		stateDiffs = append(stateDiffs, &SlashDiff{
+			Operator:        outputData.Operator,
+			Strategy:        strategy,
+			WadsSlashed:     wadsSlashed,
+			TransactionHash: log.TransactionHash,
+			LogIndex:        log.LogIndex,
+			BlockNumber:     log.BlockNumber,
 		})
 	}
 
@@ -531,15 +500,17 @@ func (ss *StakerSharesModel) handleOperatorSlashedEvent(log *storage.Transaction
 }
 
 type AccumulatedStateDiffs struct {
-	StateDiffs []*StateDiff
+	ShareDeltas []*StakerShareDeltas
+	SlashDiffs  []*SlashDiff
 }
 
 func (ss *StakerSharesModel) GetStateTransitions() (types.StateTransitions[AccumulatedStateDiffs], []uint64) {
 	stateChanges := make(types.StateTransitions[AccumulatedStateDiffs])
 
 	stateChanges[0] = func(log *storage.TransactionLog) (*AccumulatedStateDiffs, error) {
-		var stateDiff *StateDiff
-		var stateDiffs []*StateDiff
+		var shareDelta *StakerShareDeltas
+		slashDiffs := make([]*SlashDiff, 0)
+		shareDeltas := make([]*StakerShareDeltas, 0)
 		var err error
 
 		contractAddresses := ss.globalConfig.GetContractsMapForChain()
@@ -547,22 +518,22 @@ func (ss *StakerSharesModel) GetStateTransitions() (types.StateTransitions[Accum
 		// Staker shares is a bit more complex and has 4 possible contract/event combinations
 		// that we need to handle
 		if log.Address == contractAddresses.StrategyManager && log.EventName == "Deposit" {
-			stateDiff, err = ss.handleStakerDepositEvent(log)
-			stateDiffs = []*StateDiff{stateDiff}
+			shareDelta, err = ss.handleStakerDepositEvent(log)
+			shareDeltas = []*StakerShareDeltas{shareDelta}
 		} else if log.Address == contractAddresses.EigenpodManager && log.EventName == "PodSharesUpdated" {
-			stateDiff, err = ss.handlePodSharesUpdatedEvent(log)
-			stateDiffs = []*StateDiff{stateDiff}
+			shareDelta, err = ss.handlePodSharesUpdatedEvent(log)
+			shareDeltas = []*StakerShareDeltas{shareDelta}
 		} else if log.Address == contractAddresses.StrategyManager && log.EventName == "ShareWithdrawalQueued" && log.TransactionHash != "0x62eb0d0865b2636c74ed146e2d161e39e42b09bac7f86b8905fc7a830935dc1e" {
-			stateDiff, err = ss.handleM1StakerWithdrawals(log)
-			stateDiffs = []*StateDiff{stateDiff}
+			shareDelta, err = ss.handleM1StakerWithdrawals(log)
+			shareDeltas = []*StakerShareDeltas{shareDelta}
 		} else if log.Address == contractAddresses.DelegationManager && log.EventName == "WithdrawalQueued" {
-			stateDiffs, err = ss.handleM2QueuedWithdrawal(log)
+			shareDeltas, err = ss.handleM2QueuedWithdrawal(log)
 		} else if log.Address == contractAddresses.DelegationManager && log.EventName == "WithdrawalMigrated" {
-			stateDiffs, err = ss.handleMigratedM2StakerWithdrawals(log)
+			shareDeltas, err = ss.handleMigratedM2StakerWithdrawals(log)
 		} else if log.Address == contractAddresses.DelegationManager && log.EventName == "SlashingWithdrawalQueued" {
-			stateDiffs, err = ss.handleSlashingQueuedWithdrawal(log)
+			shareDeltas, err = ss.handleSlashingQueuedWithdrawal(log)
 		} else if log.Address == contractAddresses.AllocationManager && log.EventName == "OperatorSlashed" {
-			stateDiffs, err = ss.handleOperatorSlashedEvent(log)
+			slashDiffs, err = ss.handleOperatorSlashedEvent(log)
 		} else {
 			ss.logger.Sugar().Debugw("Got stakerShares event that we don't handle",
 				zap.String("eventName", log.EventName),
@@ -574,13 +545,20 @@ func (ss *StakerSharesModel) GetStateTransitions() (types.StateTransitions[Accum
 		}
 
 		// Sanity check to make sure we've got an initialized accumulator maps for the block
-		if _, ok := ss.diffAccumulator[log.BlockNumber]; !ok {
-			return nil, xerrors.Errorf("no state accumulator found for block %d", log.BlockNumber)
+		if _, ok := ss.eventDeltaAccumulator[log.BlockNumber]; !ok {
+			return nil, xerrors.Errorf("no event delta accumulator found for block %d", log.BlockNumber)
+		}
+		if _, ok := ss.slashingAccumulator[log.BlockNumber]; !ok {
+			return nil, xerrors.Errorf("no slashing accumulator found for block %d", log.BlockNumber)
 		}
 
-		ss.diffAccumulator[log.BlockNumber] = append(ss.diffAccumulator[log.BlockNumber], stateDiffs...)
+		// Add the share deltas to the accumulator
+		ss.eventDeltaAccumulator[log.BlockNumber] = append(ss.eventDeltaAccumulator[log.BlockNumber], shareDeltas...)
 
-		return &AccumulatedStateDiffs{StateDiffs: stateDiffs}, nil
+		// Add the slashing diffs to the accumulator
+		ss.slashingAccumulator[log.BlockNumber] = append(ss.slashingAccumulator[log.BlockNumber], slashDiffs...)
+
+		return &AccumulatedStateDiffs{ShareDeltas: shareDeltas, SlashDiffs: slashDiffs}, nil
 	}
 
 	// Create an ordered list of block numbers
@@ -623,12 +601,15 @@ func (ss *StakerSharesModel) IsInterestingLog(log *storage.TransactionLog) bool 
 }
 
 func (ss *StakerSharesModel) SetupStateForBlock(blockNumber uint64) error {
-	ss.diffAccumulator[blockNumber] = make([]*StateDiff, 0)
+	ss.eventDeltaAccumulator[blockNumber] = make([]*StakerShareDeltas, 0)
+	ss.slashingAccumulator[blockNumber] = make([]*SlashDiff, 0)
 	ss.deltaAccumulator[blockNumber] = make([]*StakerShareDeltas, 0)
 	return nil
 }
 
 func (ss *StakerSharesModel) CleanupProcessedStateForBlock(blockNumber uint64) error {
+	delete(ss.eventDeltaAccumulator, blockNumber)
+	delete(ss.slashingAccumulator, blockNumber)
 	delete(ss.deltaAccumulator, blockNumber)
 	return nil
 }
@@ -662,124 +643,78 @@ func (ss *StakerSharesModel) prepareState(blockNumber uint64) ([]*StakerSharesDi
 	// keep track of the updated staker shares
 	updatedStakerShares := make(map[types.SlotID]*StakerSharesDiff)
 
-	for _, diff := range ss.diffAccumulator[blockNumber] {
-		switch diff.Event.(type) {
-		case *StakerShareDeltas:
-			shareDelta := diff.Event.(*StakerShareDeltas)
-			slotID := shareDelta.SlotID()
+	eventDeltaIndex := 0
+	slashingIndex := 0
+	for eventDeltaIndex < len(ss.eventDeltaAccumulator[blockNumber]) || slashingIndex < len(ss.slashingAccumulator[blockNumber]) {
+		// initialize to max logIndex so we can compare
+		eventShareDelta := &StakerShareDeltas{LogIndex: math.MaxUint64}
+		slashDiff := &SlashDiff{LogIndex: math.MaxUint64}
+
+		// load the accumulators if index exists
+		if eventDeltaIndex < len(ss.eventDeltaAccumulator[blockNumber]) {
+			eventShareDelta = ss.eventDeltaAccumulator[blockNumber][eventDeltaIndex]
+		}
+
+		if slashingIndex < len(ss.slashingAccumulator[blockNumber]) {
+			slashDiff = ss.slashingAccumulator[blockNumber][slashingIndex]
+		}
+
+		if eventShareDelta.LogIndex < slashDiff.LogIndex {
+			ss.logger.Sugar().Debugw(
+				"Processing share delta",
+				zap.String("staker", eventShareDelta.Staker),
+				zap.String("strategy", eventShareDelta.Strategy),
+				zap.String("shares", eventShareDelta.Shares))
+
+			// if the shareDelta has a lower logIndex, process it
+			slotID := NewShareDeltaSlotID(eventShareDelta.Staker, eventShareDelta.Strategy)
 
 			// append the delta to the delta accumulator
-			ss.deltaAccumulator[blockNumber] = append(ss.deltaAccumulator[blockNumber], shareDelta)
+			ss.deltaAccumulator[blockNumber] = append(ss.deltaAccumulator[blockNumber], eventShareDelta)
 
+			// attempt to load from cache or load from db otherwise
 			currStakerShares, ok := updatedStakerShares[slotID]
 			if !ok {
-				stakerShares := &StakerShares{}
-				// get the record from the database with the given staker and strategy with the latest blockNumber
-				res := ss.DB.Model(&StakerShares{}).Where("staker = ? AND strategy = ?", shareDelta.Staker, shareDelta.Strategy).Order("block_number desc").First(&stakerShares)
-				if res.Error != nil && res.Error != gorm.ErrRecordNotFound {
-					ss.logger.Sugar().Errorw("Failed to fetch staker_shares", zap.Error(res.Error))
-					return nil, res.Error
-				}
-
-				// if the record is not found, create a new record with shares as 0
-				if res.Error == gorm.ErrRecordNotFound {
-					stakerShares = &StakerShares{
-						Staker:      shareDelta.Staker,
-						Strategy:    shareDelta.Strategy,
-						Shares:      "0",
-						BlockNumber: blockNumber,
-					}
-				}
-
 				var err error
-				currStakerShares, err = stakerShares.ToStakerSharesDiff()
+				currStakerShares, err = ss.GetStakerSharesForStakerAndStrategy(eventShareDelta.Staker, eventShareDelta.Strategy, blockNumber)
 				if err != nil {
 					return nil, err
 				}
 			}
 
 			// add the shares to the existing shares
-			shareDeltaShares, success := new(big.Int).SetString(shareDelta.Shares, 10)
+			shareDeltaShares, success := new(big.Int).SetString(eventShareDelta.Shares, 10)
 			if !success {
-				return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", shareDelta.Shares)
+				return nil, xerrors.Errorf("Failed to convert shares to big.Int: %s", eventShareDelta.Shares)
 			}
 			currStakerShares.Shares = currStakerShares.Shares.Add(currStakerShares.Shares, shareDeltaShares)
+			currStakerShares.BlockNumber = blockNumber
 
 			// update the local cache
 			updatedStakerShares[slotID] = currStakerShares
-		case *SlashDiff:
-			slashDiff := diff.Event.(*SlashDiff)
-			query := `
-				with ranked_staker_delegations as (
-					select
-						staker,
-						operator,
-						delegated,
-						ROW_NUMBER() OVER (PARTITION BY staker ORDER BY block_number desc, log_index desc) as rn
-					from staker_delegation_changes
-					where
-						block_number <= @blockNumber and
-						log_index <= @logIndex
-				),
-				delegated_stakers as (
-					select
-						lsd.staker
-					from ranked_staker_delegations as lsd
-					where
-						lsd.operator = @operator
-						and lsd.rn = 1
-				),
-				ranked_staker_shares as (
-					select
-						ds.staker,
-						ss.strategy,
-						COALESCE(ss.shares, 0) as shares,
-						COALESCE(ss.block_number, 0) as block_number, -- Assign a default block number if needed
-						ROW_NUMBER() OVER (
-							PARTITION BY ds.staker, ss.strategy 
-							ORDER BY ss.block_number desc
-						) AS rn
-					from 
-						delegated_stakers as ds
-					left join 
-						staker_shares as ss
-						on ss.staker = ds.staker
-						and ss.strategy = @strategy
-				),
-				latest_staker_shares as (
-					select
-						ls.staker,
-						ls.strategy,
-						ls.shares,
-						ls.block_number
-					from ranked_staker_shares as ls
-					where
-						ls.rn = 1
-				)
-				select * from latest_staker_shares
-			`
-			stakerShares := make([]StakerShares, 0)
 
-			// get the staker shares for the stakers who were delegated to the operator
-			// and update the shares with the new max magnitude
-			res := ss.DB.Raw(query,
-				sql.Named("blockNumber", slashDiff.BlockNumber),
-				sql.Named("logIndex", slashDiff.LogIndex),
-				sql.Named("operator", slashDiff.Operator),
-				sql.Named("strategy", slashDiff.Strategy),
-			).Scan(&stakerShares)
-			if res.Error != nil && res.Error != gorm.ErrRecordNotFound {
-				ss.logger.Sugar().Errorw("Failed to fetch staker_shares", zap.Error(res.Error))
-				return nil, res.Error
+			// increment the index
+			eventDeltaIndex++
+		} else if eventShareDelta.LogIndex > slashDiff.LogIndex {
+			// if the slashDiff has a lower logIndex, process it
+			stakerShares, err := ss.GetDelegatedStakerSharesToSlash(slashDiff)
+			if err != nil {
+				return nil, err
 			}
 
-			for _, stakerSharesRecord := range stakerShares {
+			for _, stakerSharesRecord := range *stakerShares {
+				ss.logger.Sugar().Debugw(
+					"Processing slashing",
+					zap.String("staker", stakerSharesRecord.Staker),
+					zap.String("strategy", stakerSharesRecord.Strategy),
+					zap.String("shares", stakerSharesRecord.Shares))
+
 				slotID := NewShareDeltaSlotID(stakerSharesRecord.Staker, slashDiff.Strategy)
 				var err error
 				currStakerShares, ok := updatedStakerShares[slotID]
 				// if we have not cached but the staker exists in the database for the strategy
 				if !ok && stakerSharesRecord.Strategy == slashDiff.Strategy {
-					currStakerShares, err = stakerSharesRecord.ToStakerSharesDiff()
+					currStakerShares, err = StakerSharesToStakerSharesDiff(&stakerSharesRecord)
 					if err != nil {
 						return nil, err
 					}
@@ -788,7 +723,8 @@ func (ss *StakerSharesModel) prepareState(blockNumber uint64) ([]*StakerSharesDi
 					continue
 				}
 
-				diffShares := new(big.Int).Div(new(big.Int).Mul(currStakerShares.Shares, slashDiff.WadsSlashed), WAD)
+				// use WAD = 1e18
+				diffShares := new(big.Int).Div(new(big.Int).Mul(currStakerShares.Shares, slashDiff.WadsSlashed), big.NewInt(1e18))
 				diffShares = diffShares.Mul(diffShares, big.NewInt(-1))
 
 				// append the delta to the delta accumulator
@@ -809,17 +745,115 @@ func (ss *StakerSharesModel) prepareState(blockNumber uint64) ([]*StakerSharesDi
 				// update the local cache
 				updatedStakerShares[slotID] = currStakerShares
 			}
-		default:
+
+			// increment the index
+			slashingIndex++
 		}
 	}
 
 	// return the values as a slice
 	preparedState := make([]*StakerSharesDiff, 0, len(updatedStakerShares))
 	for _, v := range updatedStakerShares {
+		ss.logger.Sugar().Debugw(
+			"Prepared state",
+			zap.String("staker", v.Staker),
+			zap.String("strategy", v.Strategy),
+			zap.String("shares", v.Shares.String()))
 		preparedState = append(preparedState, v)
 	}
 
 	return preparedState, nil
+}
+
+// GetStakerSharesForStakerAndStrategy returns the latest shares for the staker in the
+func (ss *StakerSharesModel) GetStakerSharesForStakerAndStrategy(staker, strategy string, blockNumber uint64) (*StakerSharesDiff, error) {
+	stakerShares := &StakerShares{}
+	// get the record from the database with the given staker and strategy with the latest blockNumber
+	res := ss.DB.Model(&StakerShares{}).Where("staker = ? AND strategy = ?", staker, strategy).Order("block_number desc").First(&stakerShares)
+	if res.Error != nil && res.Error != gorm.ErrRecordNotFound {
+		ss.logger.Sugar().Errorw("Failed to fetch staker_shares", zap.Error(res.Error))
+		return nil, res.Error
+	}
+
+	// if the record is not found, create a new record with shares as 0
+	if res.Error == gorm.ErrRecordNotFound {
+		stakerShares = &StakerShares{
+			Staker:      staker,
+			Strategy:    strategy,
+			Shares:      "0",
+			BlockNumber: blockNumber,
+		}
+	}
+
+	return StakerSharesToStakerSharesDiff(stakerShares)
+}
+
+// GetDelegatedStakerSharesToSlash returns the staker shares for the stakers who were delegated to the operator that must be slashed for the
+// given slashDiff returns a pointer to slice of their records for performance reasons
+func (ss *StakerSharesModel) GetDelegatedStakerSharesToSlash(slashDiff *SlashDiff) (*[]StakerShares, error) {
+	query := `
+		with ranked_staker_delegations as (
+			select
+				staker,
+				operator,
+				delegated,
+				ROW_NUMBER() OVER (PARTITION BY staker ORDER BY block_number desc, log_index desc) as rn
+			from staker_delegation_changes
+			where
+				block_number <= @blockNumber and
+				log_index <= @logIndex
+		),
+		delegated_stakers as (
+			select
+				lsd.staker
+			from ranked_staker_delegations as lsd
+			where
+				lsd.operator = @operator
+				and lsd.rn = 1
+		),
+		ranked_staker_shares as (
+			select
+				ds.staker,
+				ss.strategy,
+				COALESCE(ss.shares, 0) as shares,
+				COALESCE(ss.block_number, 0) as block_number, -- Assign a default block number if needed
+				ROW_NUMBER() OVER (
+					PARTITION BY ds.staker, ss.strategy 
+					ORDER BY ss.block_number desc
+				) AS rn
+			from 
+				delegated_stakers as ds
+			left join 
+				staker_shares as ss
+				on ss.staker = ds.staker
+		),
+		latest_staker_shares as (
+			select
+				ls.staker,
+				ls.strategy,
+				ls.shares,
+				ls.block_number
+			from ranked_staker_shares as ls
+			where
+				ls.rn = 1
+		)
+		select * from latest_staker_shares
+	`
+	stakerShares := make([]StakerShares, 0)
+
+	// get the staker shares for the stakers who were delegated to the operator
+	// and update the shares with the new max magnitude
+	res := ss.DB.Raw(query,
+		sql.Named("blockNumber", slashDiff.BlockNumber),
+		sql.Named("logIndex", slashDiff.LogIndex),
+		sql.Named("operator", slashDiff.Operator),
+	).Scan(&stakerShares)
+	if res.Error != nil {
+		ss.logger.Sugar().Errorw("Failed to fetch staker_shares", zap.Error(res.Error))
+		return nil, res.Error
+	}
+
+	return &stakerShares, nil
 }
 
 func (ss *StakerSharesModel) writeDeltaRecordsToDeltaTable(blockNumber uint64) error {

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -1,6 +1,8 @@
 package stakerShares
 
 import (
+	"encoding/json"
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -8,11 +10,11 @@ import (
 
 	"github.com/Layr-Labs/go-sidecar/pkg/postgres"
 	"github.com/Layr-Labs/go-sidecar/pkg/storage"
-	"github.com/Layr-Labs/go-sidecar/pkg/types/numbers"
 
 	"github.com/Layr-Labs/go-sidecar/internal/config"
 	"github.com/Layr-Labs/go-sidecar/internal/logger"
 	"github.com/Layr-Labs/go-sidecar/internal/tests"
+	"github.com/Layr-Labs/go-sidecar/pkg/eigenState/stakerDelegations"
 	"github.com/Layr-Labs/go-sidecar/pkg/eigenState/stateManager"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -45,9 +47,11 @@ func teardown(model *StakerSharesModel) {
 		`truncate table blocks cascade`,
 		`truncate table transactions cascade`,
 		`truncate table transaction_logs cascade`,
+		`truncate table delegated_stakers cascade`,
+		`truncate table staker_delegation_Diffs cascade`,
 	}
 	for _, query := range queries {
-		model.DB.Raw(query)
+		model.DB.Exec(query)
 	}
 }
 
@@ -104,14 +108,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
 
-		assert.Equal(t, 1, len(typedChange.Changes))
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
 
-		expectedShares, _ := numbers.NewBig257().SetString("159925690037480381", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", typedChange.Changes[0].Strategy)
+		assert.Equal(t, "159925690037480381", shareDiff.Shares)
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", shareDiff.Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", shareDiff.Strategy)
 
 		t.Cleanup(func() {
 			teardown(model)
@@ -144,13 +148,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
 
-		expectedShares, _ := numbers.NewBig257().SetString("-246393621132195985", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+
+		assert.Equal(t, "-246393621132195985", shareDiff.Shares)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
 
 		t.Cleanup(func() {
 			teardown(model)
@@ -183,13 +188,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
 
-		expectedShares, _ := numbers.NewBig257().SetString("32000000000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x0808D4689B347D499a96f139A5fC5B5101258406"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", typedChange.Changes[0].Strategy)
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+
+		assert.Equal(t, "32000000000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x0808D4689B347D499a96f139A5fC5B5101258406"), shareDiff.Staker)
+		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", shareDiff.Strategy)
 
 		t.Cleanup(func() {
 			teardown(model)
@@ -222,13 +228,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
 
-		expectedShares, _ := numbers.NewBig257().SetString("-1000000000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", typedChange.Changes[0].Strategy)
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+
+		assert.Equal(t, "-1000000000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
 
 		t.Cleanup(func() {
 			teardown(model)
@@ -322,11 +329,13 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "246393621132195985", typedChange.Changes[0].Shares.String())
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
+		assert.Equal(t, "246393621132195985", shareDiff.Shares)
 
 		preparedChange, err := model.prepareState(blockNumber)
 		assert.Nil(t, err)
@@ -402,21 +411,24 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
+		diffs := change.(*AccumulatedStateDiffs)
 
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "-246393621132195985", typedChange.Changes[0].Shares.String())
+		assert.Equal(t, 1, len(diffs.StateDiffs))
 
-		slotId := NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
+		assert.Equal(t, "-246393621132195985", shareDiff.Shares)
 
-		accumulatedState, ok := model.stateAccumulator[originBlockNumber][slotId]
+		deltas, ok := model.diffAccumulator[originBlockNumber]
 		assert.True(t, ok)
-		assert.NotNil(t, accumulatedState)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
-		assert.Equal(t, "-246393621132195985", accumulatedState.Shares.String())
+		assert.NotNil(t, deltas)
+		assert.Equal(t, 1, len(deltas))
+
+		delta := deltas[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", delta.Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", delta.Strategy)
+		assert.Equal(t, "-246393621132195985", delta.Shares)
 
 		// Insert the other half of the M1 event that captures the withdrawalRoot associated with the M1 withdrawal
 		// No need to process this event, we just need it to be present in the DB
@@ -440,7 +452,7 @@ func Test_StakerSharesState(t *testing.T) {
 
 		change, err = model.HandleStateChange(&withdrawalQueued)
 		assert.Nil(t, err)
-		assert.NotNil(t, change)
+		assert.Nil(t, change.(*AccumulatedStateDiffs).StateDiffs) // should be nil since the handler doesnt care about this event
 
 		err = model.CommitFinalState(originBlockNumber)
 		assert.Nil(t, err)
@@ -483,11 +495,13 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange = change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "-246393621132195985", typedChange.Changes[0].Shares.String())
+		diffs = change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		shareDiff = diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
+		assert.Equal(t, "-246393621132195985", shareDiff.Shares)
 
 		// M2 WithdrawalMigrated event. Typically occurs in the same block as the M2 WithdrawalQueued event
 		withdrawalMigratedLog := storage.TransactionLog{
@@ -508,20 +522,22 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange = change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "246393621132195985", typedChange.Changes[0].Shares.String())
+		diffs = change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
 
-		slotId = NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
+		shareDiff = diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
+		assert.Equal(t, "246393621132195985", shareDiff.Shares)
 
-		accumulatedState, ok = model.stateAccumulator[blockNumber][slotId]
-		assert.True(t, ok)
-		assert.NotNil(t, accumulatedState)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
-		assert.Equal(t, "0", accumulatedState.Shares.String())
+		deltas = model.diffAccumulator[originBlockNumber]
+		assert.NotNil(t, deltas)
+		assert.Equal(t, 1, len(deltas))
+
+		delta = deltas[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", delta.Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", delta.Strategy)
+		assert.Equal(t, "-246393621132195985", delta.Shares)
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
@@ -576,13 +592,13 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
 
-		expectedShares, _ := numbers.NewBig257().SetString("-50000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", typedChange.Changes[0].Strategy)
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "-50000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
 
 		teardown(model)
 	})
@@ -614,19 +630,822 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 2, len(typedChange.Changes))
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 2, len(diffs.StateDiffs))
 
-		expectedShares, _ := numbers.NewBig257().SetString("-50000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", typedChange.Changes[0].Strategy)
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "-50000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
 
-		expectedShares, _ = numbers.NewBig257().SetString("-100000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[1].Shares)
-		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[1].Staker)
-		assert.Equal(t, "0xe523267698c81a372191136e477fdebfa33d9fb5", typedChange.Changes[1].Strategy)
+		shareDiff = diffs.StateDiffs[1].Event.(*StakerShareDeltas)
+		assert.Equal(t, "-100000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
+		assert.Equal(t, "0xe523267698c81a372191136e477fdebfa33d9fb5", shareDiff.Strategy)
 
 		teardown(model)
 	})
+
+	t.Run("Should capture Slashing withdrawals", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+		log := storage.TransactionLog{
+			TransactionHash:  "some hash",
+			TransactionIndex: big.NewInt(300).Uint64(),
+			BlockNumber:      blockNumber,
+			Address:          cfg.GetContractsMapForChain().DelegationManager,
+			Arguments:        `[{"Name": "withdrawalRoot", "Type": "bytes32", "Value": ""}, {"Name": "withdrawal", "Type": "(address,address,address,uint256,uint32,address[],uint256[])", "Value": ""}]`,
+			EventName:        "SlashingWithdrawalQueued",
+			LogIndex:         big.NewInt(600).Uint64(),
+			OutputData:       `{"withdrawal": {"nonce": 0, "scaledShares": [1000000000000000000], "staker": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "startBlock": 1215690, "strategies": ["0xd523267698c81a372191136e477fdebfa33d9fb4"], "withdrawer": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "delegatedTo": "0x2177dee1f66d6dbfbf517d9c4f316024c6a21aeb"}, "withdrawalRoot": [24, 23, 49, 137, 14, 63, 119, 12, 234, 225, 63, 35, 109, 249, 112, 24, 241, 118, 212, 52, 22, 107, 202, 56, 105, 37, 68, 47, 169, 23, 142, 135], "sharesToWithdraw": [50000000000000]}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := model.HandleStateChange(&log)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "-50000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
+
+		teardown(model)
+	})
+
+	t.Run("Should capture Slashing withdrawals for multiple strategies", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+		log := storage.TransactionLog{
+			TransactionHash:  "some hash",
+			TransactionIndex: big.NewInt(300).Uint64(),
+			BlockNumber:      blockNumber,
+			Address:          cfg.GetContractsMapForChain().DelegationManager,
+			Arguments:        `[{"Name": "withdrawalRoot", "Type": "bytes32", "Value": ""}, {"Name": "withdrawal", "Type": "(address,address,address,uint256,uint32,address[],uint256[])", "Value": ""}]`,
+			EventName:        "SlashingWithdrawalQueued",
+			LogIndex:         big.NewInt(600).Uint64(),
+			OutputData:       `{"withdrawal": {"nonce": 0, "scaledShares": [1000000000000000000, 2000000000000000000], "staker": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "startBlock": 1215690, "strategies": ["0xd523267698c81a372191136e477fdebfa33d9fb4", "0xe523267698c81a372191136e477fdebfa33d9fb5"], "withdrawer": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "delegatedTo": "0x2177dee1f66d6dbfbf517d9c4f316024c6a21aeb"}, "withdrawalRoot": [24, 23, 49, 137, 14, 63, 119, 12, 234, 225, 63, 35, 109, 249, 112, 24, 241, 118, 212, 52, 22, 107, 202, 56, 105, 37, 68, 47, 169, 23, 142, 135], "sharesToWithdraw": [50000000000000, 100000000000000]}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := model.HandleStateChange(&log)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 2, len(diffs.StateDiffs))
+
+		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		assert.Equal(t, "-50000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
+		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
+
+		shareDiff = diffs.StateDiffs[1].Event.(*StakerShareDeltas)
+		assert.Equal(t, "-100000000000000", shareDiff.Shares)
+		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
+		assert.Equal(t, "0xe523267698c81a372191136e477fdebfa33d9fb5", shareDiff.Strategy)
+
+		teardown(model)
+	})
+
+	t.Run("Should capture delegate, deposit, slash in same block", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[0].Strategy)
+		assert.Equal(t, "900000000000000000", results[0].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should capture many deposits and slash in same block", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 301, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 401, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(2e18))
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+			order by staker asc
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 2, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[0].Strategy)
+		assert.Equal(t, "900000000000000000", results[0].Shares)
+
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", results[1].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[1].Strategy)
+		assert.Equal(t, "1800000000000000000", results[1].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should capture many deposits and slash in a different block", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 301, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 401, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(2e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		blockNumber = blockNumber + 1
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+			order by staker asc
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 2, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[0].Strategy)
+		assert.Equal(t, "900000000000000000", results[0].Shares)
+
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", results[1].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[1].Strategy)
+		assert.Equal(t, "1800000000000000000", results[1].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should not slash delegated staker in a different strategy for a deposit in same block", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x1234567890abcdef1234567890abcdef12345678", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x1234567890abcdef1234567890abcdef12345678", results[0].Strategy)
+		assert.Equal(t, "1000000000000000000", results[0].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should not slash delegated staker in a different strategy deposited in previous block", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x1234567890abcdef1234567890abcdef12345678", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		blockNumber = blockNumber + 1
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x1234567890abcdef1234567890abcdef12345678", results[0].Strategy)
+		assert.Equal(t, "1000000000000000000", results[0].Shares)
+		assert.Equal(t, blockNumber-1, results[0].BlockNumber)
+
+		teardown(model)
+	})
+
+	t.Run("Should not slash deposit after slashing in same block", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		blockNumber = blockNumber + 1
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 600, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[0].Strategy)
+		assert.Equal(t, "1900000000000000000", results[0].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should not slash deposit after slashing in same block", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		blockNumber = blockNumber + 1
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 600, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(2e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[0].Strategy)
+		assert.Equal(t, "2900000000000000000", results[0].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should process slashing for several strategies correctly", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 301, "0x4444444444444444444444444444444444444444", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 401, "0x4444444444444444444444444444444444444444", "0x1234567890abcdef1234567890abcdef12345678", big.NewInt(2e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		blockNumber = blockNumber + 1
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", "0x1234567890abcdef1234567890abcdef12345678"}, []*big.Int{big.NewInt(1e17), big.NewInt(9e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 2, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		slashDiff = diffs.StateDiffs[1].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x1234567890abcdef1234567890abcdef12345678", slashDiff.Strategy)
+		assert.Equal(t, "900000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+			order by staker asc
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 2, len(results))
+		assert.Equal(t, "0x4444444444444444444444444444444444444444", results[0].Staker)
+		assert.Equal(t, "0x1234567890abcdef1234567890abcdef12345678", results[0].Strategy)
+		assert.Equal(t, "200000000000000000", results[0].Shares)
+
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[1].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[1].Strategy)
+		assert.Equal(t, "900000000000000000", results[1].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should handle a full slashing", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		blockNumber = blockNumber + 1
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e18)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "1000000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", results[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[0].Strategy)
+		assert.Equal(t, "0", results[0].Shares)
+
+		teardown(model)
+	})
+
+	t.Run("Should slashing when staker has 0 shares", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		blockNumber := uint64(200)
+
+		delegationModel, err := stakerDelegations.NewStakerDelegationsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = delegationModel.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDelegation(delegationModel, cfg.GetContractsMapForChain().DelegationManager, blockNumber, 300, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0xbde83df53bc7d159700e966ad5d21e8b7c619459")
+		assert.Nil(t, err)
+
+		err = delegationModel.CommitFinalState(blockNumber)
+		assert.Nil(t, err)
+
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		_, err = processDeposit(model, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(0))
+		assert.Nil(t, err)
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		blockNumber = blockNumber + 1
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		change, err := processSlashing(model, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
+		assert.Nil(t, err)
+
+		diffs := change.(*AccumulatedStateDiffs)
+		assert.Equal(t, 1, len(diffs.StateDiffs))
+
+		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
+		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
+
+		err = createBlockAndCommitFinalState(model, blockNumber)
+		assert.Nil(t, err)
+
+		query := `
+			select * from staker_shares
+			where block_number = ?
+		`
+		results := []*StakerShares{}
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, len(results))
+		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", results[0].Staker)
+		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", results[0].Strategy)
+		assert.Equal(t, "0", results[0].Shares)
+
+		teardown(model)
+	})
+
+}
+
+func createBlockAndCommitFinalState(model *StakerSharesModel, blockNumber uint64) error {
+	block := storage.Block{
+		Number: blockNumber,
+		Hash:   "some hash",
+	}
+	res := model.DB.Model(storage.Block{}).Create(&block)
+	if res.Error != nil {
+		return res.Error
+	}
+
+	return model.CommitFinalState(blockNumber)
+}
+
+func processDelegation(delegationModel *stakerDelegations.StakerDelegationsModel, delegationManager string, blockNumber, logIndex uint64, staker, operator string) (interface{}, error) {
+	delegateLog := storage.TransactionLog{
+		TransactionHash:  "some hash",
+		TransactionIndex: 100,
+		BlockNumber:      blockNumber,
+		Address:          delegationManager,
+		Arguments:        fmt.Sprintf(`[{"Name":"staker","Type":"address","Value":"%s","Indexed":true},{"Name":"operator","Type":"address","Value":"%s","Indexed":true}]`, staker, operator),
+		EventName:        "StakerDelegated",
+		LogIndex:         logIndex,
+		OutputData:       `{}`,
+		CreatedAt:        time.Time{},
+		UpdatedAt:        time.Time{},
+		DeletedAt:        time.Time{},
+	}
+
+	return delegationModel.HandleStateChange(&delegateLog)
+}
+
+func processDeposit(stakerSharesModel *StakerSharesModel, strategyManager string, blockNumber, logIndex uint64, staker, strategy string, shares *big.Int) (interface{}, error) {
+	depositLog := storage.TransactionLog{
+		TransactionHash:  "some hash",
+		TransactionIndex: 100,
+		BlockNumber:      blockNumber,
+		Address:          strategyManager,
+		Arguments:        `[{"Name": "staker", "Type": "address", "Value": ""}, {"Name": "token", "Type": "address", "Value": ""}, {"Name": "strategy", "Type": "address", "Value": ""}, {"Name": "shares", "Type": "uint256", "Value": ""}]`,
+		EventName:        "Deposit",
+		LogIndex:         logIndex,
+		OutputData:       fmt.Sprintf(`{"token": "%s", "shares": %s, "staker": "%s", "strategy": "%s"}`, strategy, shares.String(), staker, strategy),
+		CreatedAt:        time.Time{},
+		UpdatedAt:        time.Time{},
+		DeletedAt:        time.Time{},
+	}
+
+	return stakerSharesModel.HandleStateChange(&depositLog)
+}
+
+func processSlashing(stakerSharesModel *StakerSharesModel, allocationManager string, blockNumber, logIndex uint64, operator string, strategies []string, wadsSlashed []*big.Int) (interface{}, error) {
+	wadsSlashedJson := make([]json.Number, len(wadsSlashed))
+	for i, wad := range wadsSlashed {
+		wadsSlashedJson[i] = json.Number(wad.String())
+	}
+
+	operatorSlashedEvent := operatorSlashedOutputData{
+		Operator:    operator,
+		Strategies:  strategies,
+		WadsSlashed: wadsSlashedJson,
+	}
+	operatorJson, err := json.Marshal(operatorSlashedEvent)
+	if err != nil {
+		return nil, err
+	}
+
+	slashingLog := storage.TransactionLog{
+		TransactionHash:  "some hash",
+		TransactionIndex: 100,
+		BlockNumber:      blockNumber,
+		Address:          allocationManager,
+		Arguments:        ``,
+		EventName:        "OperatorSlashed",
+		LogIndex:         logIndex,
+		OutputData:       string(operatorJson),
+		CreatedAt:        time.Time{},
+		UpdatedAt:        time.Time{},
+		DeletedAt:        time.Time{},
+	}
+
+	return stakerSharesModel.HandleStateChange(&slashingLog)
 }

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -109,9 +109,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 
 		assert.Equal(t, "159925690037480381", shareDiff.Shares)
 		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", shareDiff.Staker)
@@ -149,9 +149,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 
 		assert.Equal(t, "-246393621132195985", shareDiff.Shares)
 		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
@@ -189,9 +189,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 
 		assert.Equal(t, "32000000000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x0808D4689B347D499a96f139A5fC5B5101258406"), shareDiff.Staker)
@@ -229,9 +229,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 
 		assert.Equal(t, "-1000000000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
@@ -330,9 +330,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
 		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
 		assert.Equal(t, "246393621132195985", shareDiff.Shares)
@@ -413,22 +413,21 @@ func Test_StakerSharesState(t *testing.T) {
 
 		diffs := change.(*AccumulatedStateDiffs)
 
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
 		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
 		assert.Equal(t, "-246393621132195985", shareDiff.Shares)
 
-		deltas, ok := model.diffAccumulator[originBlockNumber]
+		deltas, ok := model.eventDeltaAccumulator[originBlockNumber]
 		assert.True(t, ok)
 		assert.NotNil(t, deltas)
 		assert.Equal(t, 1, len(deltas))
 
-		delta := deltas[0].Event.(*StakerShareDeltas)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", delta.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", delta.Strategy)
-		assert.Equal(t, "-246393621132195985", delta.Shares)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", deltas[0].Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", deltas[0].Strategy)
+		assert.Equal(t, "-246393621132195985", deltas[0].Shares)
 
 		// Insert the other half of the M1 event that captures the withdrawalRoot associated with the M1 withdrawal
 		// No need to process this event, we just need it to be present in the DB
@@ -452,7 +451,7 @@ func Test_StakerSharesState(t *testing.T) {
 
 		change, err = model.HandleStateChange(&withdrawalQueued)
 		assert.Nil(t, err)
-		assert.Nil(t, change.(*AccumulatedStateDiffs).StateDiffs) // should be nil since the handler doesnt care about this event
+		assert.Len(t, change.(*AccumulatedStateDiffs).ShareDeltas, 0)
 
 		err = model.CommitFinalState(originBlockNumber)
 		assert.Nil(t, err)
@@ -496,9 +495,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs = change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff = diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff = diffs.ShareDeltas[0]
 		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
 		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
 		assert.Equal(t, "-246393621132195985", shareDiff.Shares)
@@ -523,21 +522,20 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs = change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff = diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff = diffs.ShareDeltas[0]
 		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", shareDiff.Staker)
 		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", shareDiff.Strategy)
 		assert.Equal(t, "246393621132195985", shareDiff.Shares)
 
-		deltas = model.diffAccumulator[originBlockNumber]
+		deltas = model.eventDeltaAccumulator[originBlockNumber]
 		assert.NotNil(t, deltas)
 		assert.Equal(t, 1, len(deltas))
 
-		delta = deltas[0].Event.(*StakerShareDeltas)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", delta.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", delta.Strategy)
-		assert.Equal(t, "-246393621132195985", delta.Shares)
+		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", deltas[0].Staker)
+		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", deltas[0].Strategy)
+		assert.Equal(t, "-246393621132195985", deltas[0].Shares)
 
 		err = model.CommitFinalState(blockNumber)
 		assert.Nil(t, err)
@@ -593,9 +591,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 		assert.Equal(t, "-50000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
 		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
@@ -631,14 +629,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 2, len(diffs.StateDiffs))
+		assert.Equal(t, 2, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 		assert.Equal(t, "-50000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
 		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
 
-		shareDiff = diffs.StateDiffs[1].Event.(*StakerShareDeltas)
+		shareDiff = diffs.ShareDeltas[1]
 		assert.Equal(t, "-100000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
 		assert.Equal(t, "0xe523267698c81a372191136e477fdebfa33d9fb5", shareDiff.Strategy)
@@ -674,9 +672,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 		assert.Equal(t, "-50000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
 		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
@@ -712,14 +710,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.NotNil(t, change)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 2, len(diffs.StateDiffs))
+		assert.Equal(t, 2, len(diffs.ShareDeltas))
 
-		shareDiff := diffs.StateDiffs[0].Event.(*StakerShareDeltas)
+		shareDiff := diffs.ShareDeltas[0]
 		assert.Equal(t, "-50000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
 		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", shareDiff.Strategy)
 
-		shareDiff = diffs.StateDiffs[1].Event.(*StakerShareDeltas)
+		shareDiff = diffs.ShareDeltas[1]
 		assert.Equal(t, "-100000000000000", shareDiff.Shares)
 		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), shareDiff.Staker)
 		assert.Equal(t, "0xe523267698c81a372191136e477fdebfa33d9fb5", shareDiff.Strategy)
@@ -756,9 +754,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
@@ -815,9 +813,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
@@ -886,9 +884,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
@@ -946,9 +944,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
@@ -1008,9 +1006,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
@@ -1070,9 +1068,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
@@ -1135,9 +1133,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
@@ -1206,14 +1204,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 2, len(diffs.StateDiffs))
+		assert.Equal(t, 2, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())
 
-		slashDiff = diffs.StateDiffs[1].Event.(*SlashDiff)
+		slashDiff = diffs.SlashDiffs[1]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x1234567890abcdef1234567890abcdef12345678", slashDiff.Strategy)
 		assert.Equal(t, "900000000000000000", slashDiff.WadsSlashed.String())
@@ -1278,9 +1276,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "1000000000000000000", slashDiff.WadsSlashed.String())
@@ -1340,9 +1338,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 
 		diffs := change.(*AccumulatedStateDiffs)
-		assert.Equal(t, 1, len(diffs.StateDiffs))
+		assert.Equal(t, 1, len(diffs.SlashDiffs))
 
-		slashDiff := diffs.StateDiffs[0].Event.(*SlashDiff)
+		slashDiff := diffs.SlashDiffs[0]
 		assert.Equal(t, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", slashDiff.Operator)
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadsSlashed.String())


### PR DESCRIPTION
Adds support for slashing processing by updating the `staker_shares`

This keeps track of a single `diffAccumulator` for the model which stores both share deltas (due to deposits and withdrawals) and slashings.

When `prepareState` is called, the `deltaAccumulator` is populated by converting all slashings to deltas by looking up the shares to slash with data from the existing `staker_shares` table.

Lots of unit tests are provided, however there's a decent amount of duplication. I'm open to suggestions to dedupe!