### PR TITLE
Refactor stakerShares EigenState model

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,7 +176,7 @@ func (c *Config) GetGenesisBlockNumber() uint64 {
 	case Chain_Holesky:
 		return 1167044
 	case Chain_Mainnet:
-		return 19492759
+		return 17445563
 	default:
 		return 0
 	}

--- a/internal/tests/testdata/fetchExpectedResults.sh
+++ b/internal/tests/testdata/fetchExpectedResults.sh
@@ -18,7 +18,7 @@ if [[ $NETWORK == "testnet-reduced" ]]; then
     sqlFileName="testnetReduced_${sqlFileName}"
 fi
 
-for d in 7_goldStaging; do
+for d in stakerShares; do
     echo "Processing directory: $d"
         if [[ $d == "7_goldStaging" ]]; then
             files=$(ls "./${d}" | grep "_generateExpectedResults_")

--- a/internal/tests/testdata/stakerShares/README.md
+++ b/internal/tests/testdata/stakerShares/README.md
@@ -1,0 +1,19 @@
+
+
+### Mainnet reduced
+
+```sql
+select * from transaction_logs
+where
+    block_number <= 20470136
+    and (
+        -- delegation manager
+        (address = '0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a' and (event_name = 'WithdrawalQueued' or event_name = 'WithdrawalMigrated'))
+        -- strategy manager
+        or (address = '0x858646372cc42e1a627fce94aa7a7033e7cf075a' and (event_name = 'ShareWithdrawalQueued' or event_name = 'Deposit'))
+        -- eigenpod shares
+        or (address = '0x91e677b07f7af907ec9a428aafa9fc14a0d3a338' and event_name = 'PodSharesUpdated')
+    )
+order by block_number asc, log_index asc
+
+```

--- a/internal/tests/testdata/stakerShares/README.md
+++ b/internal/tests/testdata/stakerShares/README.md
@@ -1,6 +1,6 @@
 
 
-### Mainnet reduced
+### Mainnet reduced raw events
 
 ```sql
 select * from transaction_logs
@@ -15,5 +15,45 @@ where
         or (address = '0x91e677b07f7af907ec9a428aafa9fc14a0d3a338' and event_name = 'PodSharesUpdated')
     )
 order by block_number asc, log_index asc
+
+```
+### Mainnet reduced deltas
+
+```sql
+SELECT
+    staker,
+    strategy,
+    shares,
+    transaction_hash,
+    log_index,
+    strategy_index,
+    block_time,
+    block_date,
+    block_number
+FROM (
+    SELECT staker, strategy, shares, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.staker_deposits
+    where block_date < '2024-08-20'
+
+    UNION ALL
+
+    -- Subtract m1 & m2 withdrawals
+    SELECT staker, strategy, shares * -1, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.m1_staker_withdrawals
+    where block_date < '2024-08-20'
+
+    UNION ALL
+
+    SELECT staker, strategy, shares * -1, strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.m2_staker_withdrawals
+    where block_date < '2024-08-20'
+
+    UNION all
+
+    -- Shares in eigenpod are positive or negative, so no need to multiply by -1
+    SELECT staker, '0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0' as strategy, shares, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.eigenpod_shares
+    where block_date < '2024-08-20'
+) combined_staker_shares
 
 ```

--- a/internal/tests/testdata/stakerShares/README.md
+++ b/internal/tests/testdata/stakerShares/README.md
@@ -2,21 +2,71 @@
 
 ### Mainnet reduced raw events
 
+
+
 ```sql
 select * from transaction_logs
 where
-    block_number <= 20470136
+    block_number < 19613000
     and (
-        -- delegation manager
-        (address = '0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a' and (event_name = 'WithdrawalQueued' or event_name = 'WithdrawalMigrated'))
         -- strategy manager
-        or (address = '0x858646372cc42e1a627fce94aa7a7033e7cf075a' and (event_name = 'ShareWithdrawalQueued' or event_name = 'Deposit'))
+        (address = '0x858646372cc42e1a627fce94aa7a7033e7cf075a' and event_name = 'Deposit')
+        -- m1 withdrawals
+        or (address = '0x858646372cc42e1a627fce94aa7a7033e7cf075a' and event_name = 'ShareWithdrawalQueued')
+        -- m2 migration & withdrawals
+        or (address = '0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a' and event_name = 'WithdrawalQueued')
+        or (address = '0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a' and event_name = 'WithdrawalMigrated')
         -- eigenpod shares
         or (address = '0x91e677b07f7af907ec9a428aafa9fc14a0d3a338' and event_name = 'PodSharesUpdated')
     )
 order by block_number asc, log_index asc
 
 ```
+
+Expected results count:
+```sql
+with staker_shares as (
+SELECT
+    staker,
+    strategy,
+    shares,
+    transaction_hash,
+    log_index,
+    strategy_index,
+    block_time,
+    block_date,
+    block_number
+FROM (
+    SELECT staker, strategy, shares, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.staker_deposits
+    where block_number < 19613000
+
+    UNION ALL
+
+    -- Subtract m1 & m2 withdrawals
+    SELECT staker, strategy, shares * -1, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.m1_staker_withdrawals
+    where block_number < 19613000
+
+    UNION ALL
+
+    SELECT staker, strategy, shares * -1, strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.m2_staker_withdrawals
+    where block_number < 19613000
+
+    UNION all
+
+    -- Shares in eigenpod are positive or negative, so no need to multiply by -1
+    SELECT staker, '0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0' as strategy, shares, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+    FROM dbt_mainnet_ethereum_rewards.eigenpod_shares
+    where block_number < 19613000
+) combined_staker_shares
+)
+select count(*) from staker_shares
+```
+
+---
+
 ### Mainnet reduced deltas
 
 ```sql

--- a/internal/tests/testdata/stakerShares/mainnetReduced_generateExpectedResults.sql
+++ b/internal/tests/testdata/stakerShares/mainnetReduced_generateExpectedResults.sql
@@ -1,0 +1,37 @@
+COPY (
+SELECT
+    staker,
+    strategy,
+    shares,
+    transaction_hash,
+    log_index,
+    SUM(shares) OVER (PARTITION BY staker, strategy ORDER BY block_time, log_index) AS shares,
+    block_time,
+    block_date,
+    block_number
+FROM (
+         SELECT staker, strategy, shares, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+         FROM dbt_mainnet_ethereum_rewards.staker_deposits
+         where block_date < '2024-08-20'
+
+         UNION ALL
+
+         -- Subtract m1 & m2 withdrawals
+         SELECT staker, strategy, shares * -1, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+         FROM dbt_mainnet_ethereum_rewards.m1_staker_withdrawals
+         where block_date < '2024-08-20'
+
+         UNION ALL
+
+         SELECT staker, strategy, shares * -1, strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+         FROM dbt_mainnet_ethereum_rewards.m2_staker_withdrawals
+         where block_date < '2024-08-20'
+
+         UNION all
+
+         -- Shares in eigenpod are positive or negative, so no need to multiply by -1
+         SELECT staker, '0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0' as strategy, shares, 0 as strategy_index, transaction_hash, log_index, block_time, block_date, block_number
+         FROM dbt_mainnet_ethereum_rewards.eigenpod_shares
+         where block_date < '2024-08-20'
+     ) combined_staker_shares
+) TO STDOUT WITH DELIMITER ',' CSV HEADER

--- a/internal/tests/utils.go
+++ b/internal/tests/utils.go
@@ -155,15 +155,34 @@ func GetStakerSharesSqlFile(projectBase string) (string, error) {
 	return getSqlFile(path)
 }
 
-type StakerShareExpectedResult struct {
+func GetStakerShareDeltasSqlFile(projectBase string) (string, error) {
+	path := getTestdataPathFromProjectRoot(projectBase, "/stakerShares/stakerShareDeltas.sql")
+	return getSqlFile(path)
+}
+
+type StakerShareSnapshotExpectedResult struct {
 	Staker   string `csv:"staker"`
 	Strategy string `csv:"strategy"`
 	Snapshot string `csv:"snapshot"`
 	Shares   string `csv:"shares"`
 }
 
-func GetStakerSharesExpectedResults(projectBase string) ([]*StakerShareExpectedResult, error) {
+func GetStakerSharesSnapshotsExpectedResults(projectBase string) ([]*StakerShareSnapshotExpectedResult, error) {
 	path := getTestdataPathFromProjectRoot(projectBase, "/stakerShareSnapshots/expectedResults.csv")
+	return getExpectedResultsCsvFile[StakerShareSnapshotExpectedResult](path)
+}
+
+type StakerShareExpectedResult struct {
+	Staker          string `csv:"staker"`
+	Strategy        string `csv:"strategy"`
+	TransactionHash string `csv:"transaction_hash"`
+	LogIndex        uint64 `csv:"snapshot"`
+	Shares          string `csv:"shares"`
+	BlockNumber     uint64 `csv:"block_number"`
+}
+
+func GetStakerSharesExpectedResults(projectBase string) ([]*StakerShareExpectedResult, error) {
+	path := getTestdataPathFromProjectRoot(projectBase, "/stakerShares/expectedResults.csv")
 	return getExpectedResultsCsvFile[StakerShareExpectedResult](path)
 }
 

--- a/internal/tests/utils.go
+++ b/internal/tests/utils.go
@@ -207,3 +207,7 @@ func GetStakerSharesTransactionLogsSqlFile(projectBase string) (string, error) {
 	path := getTestdataPathFromProjectRoot(projectBase, "/stakerShares/stakerSharesTransactionLogs.sql")
 	return getSqlFile(path)
 }
+
+func LargeTestsEnabled() bool {
+	return os.Getenv("TEST_REWARDS") == "true" || os.Getenv("TEST_LARGE") == "true"
+}

--- a/internal/tests/utils.go
+++ b/internal/tests/utils.go
@@ -202,3 +202,8 @@ func GetGoldExpectedResults(projectBase string, snapshotDate string) ([]*GoldSta
 	path := getTestdataPathFromProjectRoot(projectBase, fmt.Sprintf("/7_goldStaging/expectedResults_%s.csv", snapshotDate))
 	return getExpectedResultsCsvFile[GoldStagingExpectedResult](path)
 }
+
+func GetStakerSharesTransactionLogsSqlFile(projectBase string) (string, error) {
+	path := getTestdataPathFromProjectRoot(projectBase, "/stakerShares/stakerSharesTransactionLogs.sql")
+	return getSqlFile(path)
+}

--- a/pkg/eigenState/avsOperators/avsOperators.go
+++ b/pkg/eigenState/avsOperators/avsOperators.go
@@ -213,7 +213,7 @@ func (a *AvsOperatorsModel) HandleStateChange(log *storage.TransactionLog) (inte
 
 	for _, blockNumber := range sortedBlockNumbers {
 		if log.BlockNumber >= blockNumber {
-			a.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", blockNumber))
+			a.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", log.BlockNumber))
 
 			change, err := stateChanges[blockNumber](log)
 			if err != nil {

--- a/pkg/eigenState/operatorShares/operatorShares.go
+++ b/pkg/eigenState/operatorShares/operatorShares.go
@@ -228,7 +228,7 @@ func (osm *OperatorSharesModel) HandleStateChange(log *storage.TransactionLog) (
 
 	for _, blockNumber := range sortedBlockNumbers {
 		if log.BlockNumber >= blockNumber {
-			osm.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", blockNumber))
+			osm.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", log.BlockNumber))
 
 			change, err := stateChanges[blockNumber](log)
 			if err != nil {

--- a/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
+++ b/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
@@ -252,7 +252,7 @@ func (rs *RewardSubmissionsModel) HandleStateChange(log *storage.TransactionLog)
 
 	for _, blockNumber := range sortedBlockNumbers {
 		if log.BlockNumber >= blockNumber {
-			rs.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", blockNumber))
+			rs.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", log.BlockNumber))
 
 			change, err := stateChanges[blockNumber](log)
 			if err != nil {

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -690,29 +690,7 @@ func (ss *StakerSharesModel) writeDeltaRecordsToDeltaTable(blockNumber uint64) e
 }
 
 func (ss *StakerSharesModel) CommitFinalState(blockNumber uint64) error {
-	records, err := ss.prepareState(blockNumber)
-	if err != nil {
-		return err
-	}
-
-	recordsToInsert := pkgUtils.Map(records, func(r *StakerSharesDiff, i uint64) *StakerShares {
-		return &StakerShares{
-			Staker:      r.Staker,
-			Strategy:    r.Strategy,
-			Shares:      r.Shares.String(),
-			BlockNumber: blockNumber,
-		}
-	})
-
-	if len(recordsToInsert) > 0 {
-		res := ss.DB.Model(&StakerShares{}).Clauses(clause.Returning{}).Create(&recordsToInsert)
-		if res.Error != nil {
-			ss.logger.Sugar().Errorw("Failed to create new operator_shares records", zap.Error(res.Error))
-			return res.Error
-		}
-	}
-
-	if err = ss.writeDeltaRecordsToDeltaTable(blockNumber); err != nil {
+	if err := ss.writeDeltaRecordsToDeltaTable(blockNumber); err != nil {
 		return err
 	}
 

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -554,7 +554,11 @@ func (ss *StakerSharesModel) HandleStateChange(log *storage.TransactionLog) (int
 
 	for _, blockNumber := range sortedBlockNumbers {
 		if log.BlockNumber >= blockNumber {
-			ss.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", blockNumber))
+			ss.logger.Sugar().Debugw("Handling state change",
+				zap.Uint64("blockNumber", blockNumber),
+				zap.String("eventName", log.EventName),
+				zap.String("address", log.Address),
+			)
 
 			change, err := stateChanges[blockNumber](log)
 			if err != nil {

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -555,7 +555,7 @@ func (ss *StakerSharesModel) HandleStateChange(log *storage.TransactionLog) (int
 	for _, blockNumber := range sortedBlockNumbers {
 		if log.BlockNumber >= blockNumber {
 			ss.logger.Sugar().Debugw("Handling state change",
-				zap.Uint64("blockNumber", blockNumber),
+				zap.Uint64("blockNumber", log.BlockNumber),
 				zap.String("eventName", log.EventName),
 				zap.String("address", log.Address),
 			)

--- a/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
+++ b/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/Layr-Labs/go-sidecar/internal/tests"
 	"github.com/Layr-Labs/go-sidecar/pkg/eigenState/stateManager"
+	"github.com/Layr-Labs/go-sidecar/pkg/postgres"
 	"github.com/Layr-Labs/go-sidecar/pkg/storage"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -66,7 +67,7 @@ type blockRange struct {
 }
 
 func Test_StakerSharesIntegration(t *testing.T) {
-	_, grm, l, cfg, err := setup()
+	dbName, grm, l, cfg, err := setup()
 
 	if err != nil {
 		t.Fatal(err)
@@ -149,6 +150,6 @@ func Test_StakerSharesIntegration(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		// postgres.TeardownTestDatabase(dbName, cfg, grm, l)
+		postgres.TeardownTestDatabase(dbName, cfg, grm, l)
 	})
 }

--- a/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
+++ b/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
@@ -135,6 +135,7 @@ func Test_StakerSharesIntegration(t *testing.T) {
 				t.Logf("Completed processing %d blocks, remaining: %d", completed, remaining)
 			}
 		}
+		t.Logf("Completed processing all blocks")
 
 		var count int
 		query = `select count(*) from staker_share_deltas`

--- a/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
+++ b/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
@@ -1,0 +1,143 @@
+package stakerShares
+
+import (
+	"fmt"
+	"github.com/Layr-Labs/go-sidecar/internal/tests"
+	"github.com/Layr-Labs/go-sidecar/pkg/eigenState/stateManager"
+	"github.com/Layr-Labs/go-sidecar/pkg/postgres"
+	"github.com/Layr-Labs/go-sidecar/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func getProjectRootPath() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	p, err := filepath.Abs(fmt.Sprintf("%s/../../..", wd))
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func hydrateAllBlocksTable(grm *gorm.DB, l *zap.Logger) (int, error) {
+	projectRoot := getProjectRootPath()
+	contents, err := tests.GetAllBlocksSqlFile(projectRoot)
+
+	if err != nil {
+		return 0, err
+	}
+
+	count := len(strings.Split(strings.Trim(contents, "\n"), "\n")) - 1
+
+	res := grm.Exec(contents)
+	if res.Error != nil {
+		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
+		return count, res.Error
+	}
+	return count, nil
+}
+
+func hydrateStakerShareTransactionLogs(grm *gorm.DB, l *zap.Logger) error {
+	projectRoot := getProjectRootPath()
+	contents, err := tests.GetStakerSharesTransactionLogsSqlFile(projectRoot)
+
+	if err != nil {
+		return err
+	}
+
+	res := grm.Exec(contents)
+	if res.Error != nil {
+		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
+		return res.Error
+	}
+	return nil
+}
+
+type blockRange struct {
+	minBlockNumber uint64
+	maxBlockNumber uint64
+}
+
+func Test_StakerSharesIntegration(t *testing.T) {
+	dbName, grm, l, cfg, err := setup()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Staker shares calculation through M1 and M2 migration", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		model, err := NewStakerSharesModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		_, err = hydrateAllBlocksTable(grm, l)
+		assert.Nil(t, err)
+		t.Logf("Hydrated all blocks table")
+
+		err = hydrateStakerShareTransactionLogs(grm, l)
+		assert.Nil(t, err)
+		t.Logf("Hydrated staker share transaction logs")
+
+		// get min/max block number
+		var minMaxBlocks blockRange
+		query := `select min(block_number) as min_block_number, max(block_number) as max_block_number from transaction_logs`
+		res := grm.Raw(query).Scan(&minMaxBlocks)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		t.Logf("min block number: %d, max block number: %d", minMaxBlocks.minBlockNumber, minMaxBlocks.maxBlockNumber)
+
+		for i := minMaxBlocks.minBlockNumber; i <= minMaxBlocks.maxBlockNumber; i++ {
+			if err = model.SetupStateForBlock(i); err != nil {
+				t.Logf("Failed to setup state for block %d", i)
+				t.Fatal(err)
+			}
+
+			var logs []*storage.TransactionLog
+			query := `select * from transaction_logs where block_number = ? order by log_index asc`
+			res := grm.Raw(query, i).Scan(&logs)
+			if res.Error != nil {
+				t.Logf("Failed to get transaction logs for block %d", i)
+				t.Fatal(res.Error)
+			}
+
+			for _, log := range logs {
+				if _, err = model.HandleStateChange(log); err != nil {
+					t.Logf("Failed to handle state change for block %d", i)
+					t.Fatal(err)
+				}
+			}
+
+			if err := model.CommitFinalState(i); err != nil {
+				t.Logf("Failed to commit final state for block %d", i)
+				t.Fatal(err)
+			}
+
+			if err := model.CleanupProcessedStateForBlock(i); err != nil {
+				t.Logf("Failed to cleanup processed state for block %d", i)
+				t.Fatal(err)
+			}
+		}
+
+		var count int
+		query = `select count(*) from staker_share_deltas`
+		res = grm.Raw(query).Scan(&count)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		fmt.Printf("Total staker share deltas: %d\n", count)
+	})
+
+	t.Cleanup(func() {
+		postgres.TeardownTestDatabase(dbName, cfg, grm, l)
+	})
+}

--- a/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
+++ b/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
@@ -145,6 +145,7 @@ func Test_StakerSharesIntegration(t *testing.T) {
 		}
 
 		fmt.Printf("Total staker share deltas: %d\n", count)
+		assert.Equal(t, 166160, count)
 	})
 
 	t.Cleanup(func() {

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -3,7 +3,6 @@ package stakerShares
 import (
 	"github.com/Layr-Labs/go-sidecar/pkg/postgres"
 	"github.com/Layr-Labs/go-sidecar/pkg/storage"
-	"github.com/Layr-Labs/go-sidecar/pkg/types/numbers"
 	"math/big"
 	"strings"
 	"testing"
@@ -118,16 +117,14 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, 1, len(typedChange.Changes))
 		assert.Equal(t, "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", typedChange.Changes[0].Staker)
 		assert.Equal(t, "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "502179505706314959", typedChange.Changes[0].Shares.String())
+		assert.Equal(t, "502179505706314959", typedChange.Changes[0].Shares)
 
-		slotId := NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
-
-		accumulatedState, ok := model.stateAccumulator[block.Number][slotId]
+		accumulatedState, ok := model.stateAccumulator[block.Number]
 		assert.True(t, ok)
 		assert.NotNil(t, accumulatedState)
-		assert.Equal(t, "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", accumulatedState.Staker)
-		assert.Equal(t, "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", accumulatedState.Strategy)
-		assert.Equal(t, "502179505706314959", accumulatedState.Shares.String())
+		assert.Equal(t, "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", accumulatedState[0].Staker)
+		assert.Equal(t, "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", accumulatedState[0].Strategy)
+		assert.Equal(t, "502179505706314959", accumulatedState[0].Shares)
 
 		err = model.CommitFinalState(transaction.BlockNumber)
 		assert.Nil(t, err)
@@ -445,8 +442,7 @@ func Test_StakerSharesState(t *testing.T) {
 		typedChange = change.(*AccumulatedStateChanges)
 		assert.Equal(t, 1, len(typedChange.Changes))
 
-		expectedShares, _ := numbers.NewBig257().SetString("32000000000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
+		assert.Equal(t, "32000000000000000000", typedChange.Changes[0].Shares)
 		assert.Equal(t, strings.ToLower("0x049ea11d337f185b1aa910d98e8fbd991f0fba7b"), typedChange.Changes[0].Staker)
 		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", typedChange.Changes[0].Strategy)
 

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -1,7 +1,6 @@
 package stakerShares
 
 import (
-	"database/sql"
 	"github.com/Layr-Labs/go-sidecar/pkg/postgres"
 	"github.com/Layr-Labs/go-sidecar/pkg/storage"
 	"github.com/Layr-Labs/go-sidecar/pkg/types/numbers"
@@ -27,6 +26,7 @@ func setup() (
 	error,
 ) {
 	cfg := config.NewConfig()
+	cfg.Chain = config.Chain_Mainnet
 	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
 
 	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: true})
@@ -39,30 +39,10 @@ func setup() (
 	return dbname, grm, l, cfg, nil
 }
 
-func teardown(model *StakerSharesModel) {
-	queries := []string{
-		`truncate table staker_shares cascade`,
-		`truncate table staker_shaer_deltas cascade`,
-		`truncate table blocks cascade`,
-		`truncate table transactions cascade`,
-		`truncate table transaction_logs cascade`,
-	}
-	for _, query := range queries {
-		model.DB.Raw(query)
-	}
-}
-
-func createBlock(model *StakerSharesModel, blockNumber uint64) error {
-	block := &storage.Block{
-		Number:    blockNumber,
-		Hash:      "some hash",
-		BlockTime: time.Now().Add(time.Hour * time.Duration(blockNumber)),
-	}
-	res := model.DB.Model(&storage.Block{}).Create(block)
-	if res.Error != nil {
-		return res.Error
-	}
-	return nil
+func logChanges(changes *AccumulatedStateChanges) {
+	// for _, change := range changes.Changes {
+	// 	// fmt.Printf("Change: %+v\n", change)
+	// }
 }
 
 func Test_StakerSharesState(t *testing.T) {
@@ -78,173 +58,15 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, model)
 	})
-	t.Run("Should capture a staker share Deposit", func(t *testing.T) {
-		esm := stateManager.NewEigenStateManager(l, grm)
-		blockNumber := uint64(400)
-		log := storage.TransactionLog{
-			TransactionHash:  "some hash",
-			TransactionIndex: big.NewInt(100).Uint64(),
-			BlockNumber:      blockNumber,
-			Address:          cfg.GetContractsMapForChain().StrategyManager,
-			Arguments:        `[{"Name": "staker", "Type": "address", "Value": ""}, {"Name": "token", "Type": "address", "Value": ""}, {"Name": "strategy", "Type": "address", "Value": ""}, {"Name": "shares", "Type": "uint256", "Value": ""}]`,
-			EventName:        "Deposit",
-			LogIndex:         big.NewInt(400).Uint64(),
-			OutputData:       `{"token": "0x3f1c547b21f65e10480de3ad8e19faac46c95034", "shares": 159925690037480381, "staker": "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "strategy": "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}`,
-			CreatedAt:        time.Time{},
-			UpdatedAt:        time.Time{},
-			DeletedAt:        time.Time{},
-		}
-
-		model, err := NewStakerSharesModel(esm, grm, l, cfg)
-		assert.Nil(t, err)
-
-		err = model.SetupStateForBlock(blockNumber)
-		assert.Nil(t, err)
-
-		change, err := model.HandleStateChange(&log)
-		assert.Nil(t, err)
-		assert.NotNil(t, change)
-
-		typedChange := change.(*AccumulatedStateChanges)
-
-		assert.Equal(t, 1, len(typedChange.Changes))
-
-		expectedShares, _ := numbers.NewBig257().SetString("159925690037480381", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", typedChange.Changes[0].Strategy)
-
-		t.Cleanup(func() {
-			teardown(model)
-		})
-	})
-	t.Run("Should capture a staker share M1 Withdrawal", func(t *testing.T) {
-		esm := stateManager.NewEigenStateManager(l, grm)
-		blockNumber := uint64(400)
-		log := storage.TransactionLog{
-			TransactionHash:  "some hash",
-			TransactionIndex: big.NewInt(200).Uint64(),
-			BlockNumber:      blockNumber,
-			Address:          cfg.GetContractsMapForChain().StrategyManager,
-			Arguments:        `[{"Name": "depositor", "Type": "address", "Value": null, "Indexed": false}, {"Name": "nonce", "Type": "uint96", "Value": null, "Indexed": false}, {"Name": "strategy", "Type": "address", "Value": null, "Indexed": false}, {"Name": "shares", "Type": "uint256", "Value": null, "Indexed": false}]`,
-			EventName:        "ShareWithdrawalQueued",
-			LogIndex:         big.NewInt(500).Uint64(),
-			OutputData:       `{"nonce": 0, "shares": 246393621132195985, "strategy": "0x298afb19a105d59e74658c4c334ff360bade6dd2", "depositor": "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78"}`,
-			CreatedAt:        time.Time{},
-			UpdatedAt:        time.Time{},
-			DeletedAt:        time.Time{},
-		}
-
-		model, err := NewStakerSharesModel(esm, grm, l, cfg)
-		assert.Nil(t, err)
-
-		err = model.SetupStateForBlock(blockNumber)
-		assert.Nil(t, err)
-
-		change, err := model.HandleStateChange(&log)
-		assert.Nil(t, err)
-		assert.NotNil(t, change)
-
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-
-		expectedShares, _ := numbers.NewBig257().SetString("-246393621132195985", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-
-		t.Cleanup(func() {
-			teardown(model)
-		})
-	})
-	t.Run("Should capture staker EigenPod shares", func(t *testing.T) {
-		esm := stateManager.NewEigenStateManager(l, grm)
-		blockNumber := uint64(400)
-		log := storage.TransactionLog{
-			TransactionHash:  "some hash",
-			TransactionIndex: big.NewInt(300).Uint64(),
-			BlockNumber:      blockNumber,
-			Address:          cfg.GetContractsMapForChain().EigenpodManager,
-			Arguments:        `[{"Name": "podOwner", "Type": "address", "Value": "0x0808D4689B347D499a96f139A5fC5B5101258406"}, {"Name": "sharesDelta", "Type": "int256", "Value": ""}]`,
-			EventName:        "PodSharesUpdated",
-			LogIndex:         big.NewInt(600).Uint64(),
-			OutputData:       `{"sharesDelta": 32000000000000000000}`,
-			CreatedAt:        time.Time{},
-			UpdatedAt:        time.Time{},
-			DeletedAt:        time.Time{},
-		}
-
-		model, err := NewStakerSharesModel(esm, grm, l, cfg)
-		assert.Nil(t, err)
-
-		err = model.SetupStateForBlock(blockNumber)
-		assert.Nil(t, err)
-
-		change, err := model.HandleStateChange(&log)
-		assert.Nil(t, err)
-		assert.NotNil(t, change)
-
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-
-		expectedShares, _ := numbers.NewBig257().SetString("32000000000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x0808D4689B347D499a96f139A5fC5B5101258406"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", typedChange.Changes[0].Strategy)
-
-		t.Cleanup(func() {
-			teardown(model)
-		})
-	})
-	t.Run("Should capture M2 withdrawals", func(t *testing.T) {
-		esm := stateManager.NewEigenStateManager(l, grm)
-		blockNumber := uint64(400)
-		log := storage.TransactionLog{
-			TransactionHash:  "some hash",
-			TransactionIndex: big.NewInt(300).Uint64(),
-			BlockNumber:      blockNumber,
-			Address:          cfg.GetContractsMapForChain().DelegationManager,
-			Arguments:        `[{"Name": "withdrawalRoot", "Type": "bytes32", "Value": ""}, {"Name": "withdrawal", "Type": "(address,address,address,uint256,uint32,address[],uint256[])", "Value": ""}]`,
-			EventName:        "WithdrawalQueued",
-			LogIndex:         big.NewInt(600).Uint64(),
-			OutputData:       `{"withdrawal": {"nonce": 0, "shares": [1000000000000000000], "staker": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "startBlock": 1215690, "strategies": ["0xd523267698c81a372191136e477fdebfa33d9fb4"], "withdrawer": "0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c", "delegatedTo": "0x2177dee1f66d6dbfbf517d9c4f316024c6a21aeb"}, "withdrawalRoot": [24, 23, 49, 137, 14, 63, 119, 12, 234, 225, 63, 35, 109, 249, 112, 24, 241, 118, 212, 52, 22, 107, 202, 56, 105, 37, 68, 47, 169, 23, 142, 135]}`,
-			CreatedAt:        time.Time{},
-			UpdatedAt:        time.Time{},
-			DeletedAt:        time.Time{},
-		}
-
-		model, err := NewStakerSharesModel(esm, grm, l, cfg)
-		assert.Nil(t, err)
-
-		err = model.SetupStateForBlock(blockNumber)
-		assert.Nil(t, err)
-
-		change, err := model.HandleStateChange(&log)
-		assert.Nil(t, err)
-		assert.NotNil(t, change)
-
-		typedChange := change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-
-		expectedShares, _ := numbers.NewBig257().SetString("-1000000000000000000", 10)
-		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
-		assert.Equal(t, strings.ToLower("0x3c42cd72639e3e8d11ab8d0072cc13bd5d8aa83c"), typedChange.Changes[0].Staker)
-		assert.Equal(t, "0xd523267698c81a372191136e477fdebfa33d9fb4", typedChange.Changes[0].Strategy)
-
-		t.Cleanup(func() {
-			teardown(model)
-		})
-	})
 	t.Run("Should handle an M1 withdrawal and migration to M2 correctly", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
 		model, err := NewStakerSharesModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
-		originBlockNumber := uint64(101)
-		originTxHash := "0x5ff283cb420cdf950036d538e2223d5b504b875828f6e0d243002f429da6faa3"
-
+		// --------------------------------------------------------------------
+		// Deposit
 		block := storage.Block{
-			Number: originBlockNumber,
+			Number: 18816124,
 			Hash:   "some hash",
 		}
 		res := grm.Model(storage.Block{}).Create(&block)
@@ -254,170 +76,366 @@ func Test_StakerSharesState(t *testing.T) {
 
 		transaction := storage.Transaction{
 			BlockNumber:      block.Number,
-			TransactionHash:  originTxHash,
+			TransactionHash:  "0x555472583922cc175caf63496f3a83d29f45ad6570eeced2d0f7d50a6716e93b",
 			TransactionIndex: big.NewInt(200).Uint64(),
-			FromAddress:      "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78",
+			FromAddress:      "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
 		}
 		res = grm.Model(storage.Transaction{}).Create(&transaction)
 		if res.Error != nil {
 			t.Fatal(res.Error)
 		}
 
-		// Insert the M1 withdrawal since we'll need it later
-		shareWithdrawalQueued := storage.TransactionLog{
-			TransactionHash:  originTxHash,
-			TransactionIndex: big.NewInt(1).Uint64(),
-			BlockNumber:      originBlockNumber,
+		// Insert deposit
+		depositTx := storage.TransactionLog{
+			TransactionHash:  "0x555472583922cc175caf63496f3a83d29f45ad6570eeced2d0f7d50a6716e93b",
+			TransactionIndex: transaction.TransactionIndex,
+			BlockNumber:      transaction.BlockNumber,
 			Address:          cfg.GetContractsMapForChain().StrategyManager,
-			Arguments:        `[{"Name": "depositor", "Type": "address", "Value": null, "Indexed": false}, {"Name": "nonce", "Type": "uint96", "Value": null, "Indexed": false}, {"Name": "strategy", "Type": "address", "Value": null, "Indexed": false}, {"Name": "shares", "Type": "uint256", "Value": null, "Indexed": false}]`,
-			EventName:        "ShareWithdrawalQueued",
-			LogIndex:         big.NewInt(1).Uint64(),
-			OutputData:       `{"nonce": 0, "shares": 246393621132195985, "strategy": "0x298afb19a105d59e74658c4c334ff360bade6dd2", "depositor": "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78"}`,
+			Arguments:        `[{"Name": "depositor", "Type": "address", "Value": null, "Indexed": false}, {"Name": "token", "Type": "address", "Value": null, "Indexed": false}, {"Name": "strategy", "Type": "address", "Value": null, "Indexed": false}, {"Name": "shares", "Type": "uint256", "Value": null, "Indexed": false}]`,
+			EventName:        "Deposit",
+			LogIndex:         big.NewInt(229).Uint64(),
+			OutputData:       `{"token": "0xf951e335afb289353dc249e82926178eac7ded78", "shares": 502179505706314959, "strategy": "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", "depositor": "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0"}`,
 			CreatedAt:        time.Time{},
 			UpdatedAt:        time.Time{},
 			DeletedAt:        time.Time{},
 		}
-		res = grm.Model(storage.TransactionLog{}).Create(&shareWithdrawalQueued)
+		res = grm.Model(storage.TransactionLog{}).Create(&depositTx)
 		if res.Error != nil {
 			t.Fatal(res.Error)
 		}
 
-		// init processing for the M1 withdrawal
-		err = model.SetupStateForBlock(originBlockNumber)
+		err = model.SetupStateForBlock(transaction.BlockNumber)
 		assert.Nil(t, err)
 
-		change, err := model.HandleStateChange(&shareWithdrawalQueued)
+		change, err := model.HandleStateChange(&depositTx)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
 		typedChange := change.(*AccumulatedStateChanges)
+		logChanges(typedChange)
 
 		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "-246393621132195985", typedChange.Changes[0].Shares.String())
+		assert.Equal(t, "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", typedChange.Changes[0].Staker)
+		assert.Equal(t, "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", typedChange.Changes[0].Strategy)
+		assert.Equal(t, "502179505706314959", typedChange.Changes[0].Shares.String())
 
 		slotId := NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
 
-		accumulatedState, ok := model.stateAccumulator[originBlockNumber][slotId]
+		accumulatedState, ok := model.stateAccumulator[block.Number][slotId]
 		assert.True(t, ok)
 		assert.NotNil(t, accumulatedState)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
-		assert.Equal(t, "-246393621132195985", accumulatedState.Shares.String())
+		assert.Equal(t, "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", accumulatedState.Staker)
+		assert.Equal(t, "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", accumulatedState.Strategy)
+		assert.Equal(t, "502179505706314959", accumulatedState.Shares.String())
 
-		// Insert the other half of the M1 event that captures the withdrawalRoot associated with the M1 withdrawal
-		// No need to process this event, we just need it to be present in the DB
-		withdrawalQueued := storage.TransactionLog{
-			TransactionHash:  originTxHash,
-			TransactionIndex: big.NewInt(200).Uint64(),
-			BlockNumber:      originBlockNumber,
-			Address:          cfg.GetContractsMapForChain().StrategyManager,
-			Arguments: `[
-								  {
-									"Name": "depositor",
-									"Type": "address",
-									"Value": null,
-									"Indexed": false
-								  },
-								  {
-									"Name": "nonce",
-									"Type": "uint96",
-									"Value": null,
-									"Indexed": false
-								  },
-								  {
-									"Name": "withdrawer",
-									"Type": "address",
-									"Value": null,
-									"Indexed": false
-								  },
-								  {
-									"Name": "delegatedAddress",
-									"Type": "address",
-									"Value": null,
-									"Indexed": false
-								  },
-								  {
-									"Name": "withdrawalRoot",
-									"Type": "bytes32",
-									"Value": null,
-									"Indexed": false
-								  }
-								]`,
-			EventName: "WithdrawalQueued",
-			LogIndex:  big.NewInt(2).Uint64(),
-			OutputData: `{
-								  "nonce": 0,
-								  "depositor": "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78",
-								  "withdrawer": "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78",
-								  "withdrawalRoot": [ 31,200,156,159,43,41,112,204,139,225,142,72,58,63,194,149,59,254,218,227,162,25,237,7,103,240,24,255,31,152,236,84],
-								  "delegatedAddress": "0x0000000000000000000000000000000000000000"
-								}`,
-			CreatedAt: time.Time{},
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+		err = model.CommitFinalState(transaction.BlockNumber)
+		assert.Nil(t, err)
+
+		// --------------------------------------------------------------------
+		// M1 Withdrawal
+		block = storage.Block{
+			Number: 19518613,
+			Hash:   "some hash",
+		}
+		res = grm.Model(storage.Block{}).Create(&block)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		transaction = storage.Transaction{
+			BlockNumber:      block.Number,
+			TransactionHash:  "0xa6315a9a988d3c643ce123ca3a218913ea14cf3e0f51b720488bb2367fc75465",
+			TransactionIndex: big.NewInt(128).Uint64(),
+			FromAddress:      "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
+		}
+		res = grm.Model(storage.Transaction{}).Create(&transaction)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		err = model.SetupStateForBlock(transaction.BlockNumber)
+		assert.Nil(t, err)
+
+		shareWithdrawalQueuedTx := &storage.TransactionLog{
+			TransactionHash:  transaction.TransactionHash,
+			TransactionIndex: transaction.TransactionIndex,
+			BlockNumber:      transaction.BlockNumber,
+			Address:          "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
+			Arguments:        `[{"Name": "depositor", "Type": "address", "Value": null, "Indexed": false}, {"Name": "nonce", "Type": "uint96", "Value": null, "Indexed": false}, {"Name": "strategy", "Type": "address", "Value": null, "Indexed": false}, {"Name": "shares", "Type": "uint256", "Value": null, "Indexed": false}]`,
+			EventName:        "ShareWithdrawalQueued",
+			LogIndex:         302,
+			OutputData:       `{"nonce": 0, "shares": 502179505706314959, "strategy": "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", "depositor": "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0"}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+		res = grm.Model(storage.TransactionLog{}).Create(&shareWithdrawalQueuedTx)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		withdrawalQueuedTx := &storage.TransactionLog{
+			TransactionHash:  transaction.TransactionHash,
+			TransactionIndex: transaction.TransactionIndex,
+			BlockNumber:      transaction.BlockNumber,
+			Address:          "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
+			Arguments:        `[{"Name": "depositor", "Type": "address", "Value": null, "Indexed": false}, {"Name": "nonce", "Type": "uint96", "Value": null, "Indexed": false}, {"Name": "withdrawer", "Type": "address", "Value": null, "Indexed": false}, {"Name": "delegatedAddress", "Type": "address", "Value": null, "Indexed": false}, {"Name": "withdrawalRoot", "Type": "bytes32", "Value": null, "Indexed": false}]`,
+			EventName:        "WithdrawalQueued",
+			LogIndex:         303,
+			OutputData:       `{"nonce": 0, "depositor": "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", "withdrawer": "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", "withdrawalRoot": [181, 96, 205, 58, 97, 121, 217, 167, 18, 132, 193, 76, 115, 179, 69, 201, 63, 185, 242, 68, 128, 94, 225, 114, 13, 173, 1, 156, 214, 81, 24, 83], "delegatedAddress": "0x0000000000000000000000000000000000000000"}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+		res = grm.Model(storage.TransactionLog{}).Create(&withdrawalQueuedTx)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		change, err = model.HandleStateChange(shareWithdrawalQueuedTx)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+
+		typedChange = change.(*AccumulatedStateChanges)
+		logChanges(typedChange)
+
+		change, err = model.HandleStateChange(withdrawalQueuedTx)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+		typedChange = change.(*AccumulatedStateChanges)
+		logChanges(typedChange)
+
+		err = model.CommitFinalState(transaction.BlockNumber)
+		assert.Nil(t, err)
+
+		// --------------------------------------------------------------------
+		// M2 migration
+		block = storage.Block{
+			Number: 19612227,
+			Hash:   "some hash",
+		}
+		res = grm.Model(storage.Block{}).Create(&block)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		transaction = storage.Transaction{
+			BlockNumber:      block.Number,
+			TransactionHash:  "0xf231201ad19e9d35a72d0269a1a9a01236986525449da3e2ea42124fb4410aac",
+			TransactionIndex: big.NewInt(128).Uint64(),
+			FromAddress:      "0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a",
+		}
+		res = grm.Model(storage.Transaction{}).Create(&transaction)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		err = model.SetupStateForBlock(transaction.BlockNumber)
+		assert.Nil(t, err)
+
+		withdrawalQueued := &storage.TransactionLog{
+			TransactionHash:  transaction.TransactionHash,
+			TransactionIndex: transaction.TransactionIndex,
+			BlockNumber:      transaction.BlockNumber,
+			Address:          "0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a",
+			Arguments:        `[{"Name": "withdrawalRoot", "Type": "bytes32", "Value": null, "Indexed": false}, {"Name": "withdrawal", "Type": "(address,address,address,uint256,uint32,address[],uint256[])", "Value": null, "Indexed": false}]`,
+			EventName:        "WithdrawalQueued",
+			LogIndex:         207,
+			OutputData:       `{"withdrawal": {"nonce": 0, "shares": [502179505706314959], "staker": "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", "startBlock": 19518613, "strategies": ["0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6"], "withdrawer": "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", "delegatedTo": "0x0000000000000000000000000000000000000000"}, "withdrawalRoot": [169, 79, 1, 179, 199, 73, 184, 145, 60, 107, 232, 188, 151, 104, 19, 21, 140, 92, 208, 223, 223, 213, 246, 143, 171, 232, 217, 181, 177, 46, 115, 78]}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
 		}
 		res = grm.Model(storage.TransactionLog{}).Create(&withdrawalQueued)
 		if res.Error != nil {
 			t.Fatal(res.Error)
 		}
 
-		change, err = model.HandleStateChange(&withdrawalQueued)
+		withdrawalMigrated := &storage.TransactionLog{
+			TransactionHash:  transaction.TransactionHash,
+			TransactionIndex: transaction.TransactionIndex,
+			BlockNumber:      transaction.BlockNumber,
+			Address:          "0x39053d51b77dc0d36036fc1fcc8cb819df8ef37a",
+			Arguments:        `[{"Name": "oldWithdrawalRoot", "Type": "bytes32", "Value": null, "Indexed": false}, {"Name": "newWithdrawalRoot", "Type": "bytes32", "Value": null, "Indexed": false}]`,
+			EventName:        "WithdrawalMigrated",
+			LogIndex:         208,
+			OutputData:       `{"newWithdrawalRoot": [169, 79, 1, 179, 199, 73, 184, 145, 60, 107, 232, 188, 151, 104, 19, 21, 140, 92, 208, 223, 223, 213, 246, 143, 171, 232, 217, 181, 177, 46, 115, 78], "oldWithdrawalRoot": [181, 96, 205, 58, 97, 121, 217, 167, 18, 132, 193, 76, 115, 179, 69, 201, 63, 185, 242, 68, 128, 94, 225, 114, 13, 173, 1, 156, 214, 81, 24, 83]}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+		res = grm.Model(storage.TransactionLog{}).Create(&withdrawalMigrated)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		change, err = model.HandleStateChange(withdrawalQueued)
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
+		typedChange = change.(*AccumulatedStateChanges)
+		logChanges(typedChange)
 
-		err = model.CommitFinalState(originBlockNumber)
+		change, err = model.HandleStateChange(withdrawalMigrated)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+		typedChange = change.(*AccumulatedStateChanges)
+		logChanges(typedChange)
+
+		err = model.CommitFinalState(transaction.BlockNumber)
 		assert.Nil(t, err)
 
-		// verify the M1 withdrawal was processed correctly
-		query := `select * from staker_shares where block_number = ?`
-		results := []*StakerShares{}
-		res = model.DB.Raw(query, originBlockNumber).Scan(&results)
-
-		assert.Nil(t, res.Error)
-		assert.Equal(t, 1, len(results))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", results[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", results[0].Strategy)
-		assert.Equal(t, "-246393621132195985", results[0].Shares)
-
-		// setup M2 migration
-		blockNumber := uint64(102)
-		err = model.SetupStateForBlock(blockNumber)
-		assert.Nil(t, err)
-
-		err = createBlock(model, blockNumber)
-		assert.Nil(t, err)
-
-		// M2 WithdrawalQueued comes before the M2 WithdrawalMigrated event
-		log := storage.TransactionLog{
-			TransactionHash:  "some hash",
-			TransactionIndex: big.NewInt(1).Uint64(),
-			BlockNumber:      blockNumber,
-			Address:          cfg.GetContractsMapForChain().DelegationManager,
-			Arguments:        `[{"Name": "withdrawalRoot", "Type": "bytes32", "Value": ""}, {"Name": "withdrawal", "Type": "(address,address,address,uint256,uint32,address[],uint256[])", "Value": ""}]`,
-			EventName:        "WithdrawalQueued",
-			LogIndex:         big.NewInt(600).Uint64(),
-			OutputData: `{
-								  "withdrawal": {
-									"nonce": 0,
-									"shares": [
-									  246393621132195985
-									],
-									"staker": "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78",
-									"startBlock": 1215690,
-									"strategies": [
-									  "0x298afb19a105d59e74658c4c334ff360bade6dd2"
-									],
-									"withdrawer": "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78",
-									"delegatedTo": "0x2177dee1f66d6dbfbf517d9c4f316024c6a21aeb"
-								  },
-								  "withdrawalRoot": [24, 23, 49, 137, 14, 63, 119, 12, 234, 225, 63, 35, 109, 249, 112, 24, 241, 118, 212, 52, 22, 107, 202, 56, 105, 37, 68, 47, 169, 23, 142, 135]
-								}`,
-			CreatedAt: time.Time{},
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+		// --------------------------------------------------------------------
+		// Deposit
+		block = storage.Block{
+			Number: 20104478,
+			Hash:   "some hash",
 		}
+		res = grm.Model(storage.Block{}).Create(&block)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		transaction = storage.Transaction{
+			BlockNumber:      block.Number,
+			TransactionHash:  "0x75ab8bde9be4282d7eeff081b6510f1d076d2b739c0524d3080182828ca412c4",
+			TransactionIndex: big.NewInt(128).Uint64(),
+			ToAddress:        "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
+		}
+		res = grm.Model(storage.Transaction{}).Create(&transaction)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		err = model.SetupStateForBlock(transaction.BlockNumber)
+		assert.Nil(t, err)
+
+		deposit2 := &storage.TransactionLog{
+			TransactionHash:  transaction.TransactionHash,
+			TransactionIndex: transaction.TransactionIndex,
+			BlockNumber:      transaction.BlockNumber,
+			Address:          "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
+			Arguments:        `[{"Name": "staker", "Type": "address", "Value": null, "Indexed": false}, {"Name": "token", "Type": "address", "Value": null, "Indexed": false}, {"Name": "strategy", "Type": "address", "Value": null, "Indexed": false}, {"Name": "shares", "Type": "uint256", "Value": null, "Indexed": false}]`,
+			EventName:        "Deposit",
+			LogIndex:         540,
+			OutputData:       `{"token": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83", "shares": 126014635232337198545, "staker": "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0", "strategy": "0xacb55c530acdb2849e6d4f36992cd8c9d50ed8f7"}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+		res = grm.Model(storage.TransactionLog{}).Create(&deposit2)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		change, err = model.HandleStateChange(deposit2)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+		typedChange = change.(*AccumulatedStateChanges)
+		logChanges(typedChange)
+
+		err = model.CommitFinalState(transaction.BlockNumber)
+		assert.Nil(t, err)
+
+		query := `select * from staker_share_deltas order by block_number asc`
+		results := []StakerShareDeltas{}
+		res = model.DB.Raw(query).Scan(&results)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+
+		assert.Equal(t, 3, len(results))
+
+		query = `
+		with combined_values as (
+			select
+				staker,
+				strategy,
+				log_index,
+				block_number,
+				SUM(shares) OVER (PARTITION BY staker, strategy order by block_number, log_index) as shares
+			from staker_share_deltas
+		)
+		select * from combined_values order by block_number asc, log_index asc
+		`
+		type resultsRow struct {
+			Staker      string
+			Strategy    string
+			LogIndex    uint64
+			BlockNumber uint64
+			Shares      string
+		}
+		var shareResults []resultsRow
+		res = grm.Raw(query).Scan(&shareResults)
+		assert.Nil(t, res.Error)
+
+		expectedResults := []resultsRow{
+			resultsRow{
+				Staker:      "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0",
+				Strategy:    "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6",
+				Shares:      "502179505706314959",
+				LogIndex:    229,
+				BlockNumber: 18816124,
+			},
+			resultsRow{
+				Staker:      "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0",
+				Strategy:    "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6",
+				Shares:      "0",
+				LogIndex:    302,
+				BlockNumber: 19518613,
+			},
+			resultsRow{
+				Staker:      "0x00105f70bf0a2dec987dbfc87a869c3090abf6a0",
+				Strategy:    "0xacb55c530acdb2849e6d4f36992cd8c9d50ed8f7",
+				Shares:      "126014635232337198545",
+				LogIndex:    540,
+				BlockNumber: 20104478,
+			},
+		}
+
+		for i, result := range shareResults {
+			assert.Equal(t, expectedResults[i].Staker, result.Staker)
+			assert.Equal(t, expectedResults[i].Strategy, result.Strategy)
+			assert.Equal(t, expectedResults[i].Shares, result.Shares)
+			assert.Equal(t, expectedResults[i].LogIndex, result.LogIndex)
+			assert.Equal(t, expectedResults[i].BlockNumber, result.BlockNumber)
+		}
+
+		// --------------------------------------------------------------------
+		// EigenPod deposit
+
+		block = storage.Block{
+			Number: 20468489,
+			Hash:   "some hash",
+		}
+		res = grm.Model(storage.Block{}).Create(&block)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		transaction = storage.Transaction{
+			BlockNumber:      block.Number,
+			TransactionHash:  "0xcaa01689e4f1a3ea35f0d632e43bb0991e674148f9b5e8ed8e03d8ba88cf7eba",
+			TransactionIndex: big.NewInt(128).Uint64(),
+			ToAddress:        "0x91e677b07f7af907ec9a428aafa9fc14a0d3a338",
+		}
+		res = grm.Model(storage.Transaction{}).Create(&transaction)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		err = model.SetupStateForBlock(transaction.BlockNumber)
+		assert.Nil(t, err)
+
+		log := storage.TransactionLog{
+			TransactionHash:  transaction.TransactionHash,
+			TransactionIndex: transaction.TransactionIndex,
+			BlockNumber:      transaction.BlockNumber,
+			Address:          cfg.GetContractsMapForChain().EigenpodManager,
+			Arguments:        `[{"Name": "podOwner", "Type": "address", "Value": "0x049ea11d337f185b1aa910d98e8fbd991f0fba7b", "Indexed": true}, {"Name": "sharesDelta", "Type": "int256", "Value": null, "Indexed": false}]`,
+			EventName:        "PodSharesUpdated",
+			LogIndex:         big.NewInt(188).Uint64(),
+			OutputData:       `{"sharesDelta": 32000000000000000000}`,
+			CreatedAt:        time.Time{},
+			UpdatedAt:        time.Time{},
+			DeletedAt:        time.Time{},
+		}
+
+		err = model.SetupStateForBlock(block.Number)
+		assert.Nil(t, err)
 
 		change, err = model.HandleStateChange(&log)
 		assert.Nil(t, err)
@@ -425,77 +443,21 @@ func Test_StakerSharesState(t *testing.T) {
 
 		typedChange = change.(*AccumulatedStateChanges)
 		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "-246393621132195985", typedChange.Changes[0].Shares.String())
 
-		// M2 WithdrawalMigrated event. Typically occurs in the same block as the M2 WithdrawalQueued event
-		withdrawalMigratedLog := storage.TransactionLog{
-			TransactionHash:  "some hash",
-			TransactionIndex: big.NewInt(2).Uint64(),
-			BlockNumber:      blockNumber,
-			Address:          cfg.GetContractsMapForChain().DelegationManager,
-			Arguments:        `[{"Name": "oldWithdrawalRoot", "Type": "bytes32", "Value": ""}, {"Name": "newWithdrawalRoot", "Type": "bytes32", "Value": ""}]`,
-			EventName:        "WithdrawalMigrated",
-			LogIndex:         big.NewInt(600).Uint64(),
-			OutputData: `{
-  							"newWithdrawalRoot": [24, 23, 49, 137, 14, 63, 119, 12, 234, 225, 63, 35, 109, 249, 112, 24, 241, 118, 212, 52, 22, 107, 202, 56, 105, 37, 68, 47, 169, 23, 142, 135],
-							"oldWithdrawalRoot": [31, 200, 156, 159, 43, 41, 112, 204, 139, 225, 142, 72, 58, 63, 194, 149, 59, 254, 218, 227, 162, 25, 237, 7, 103, 240, 24, 255, 31, 152, 236, 84]
-						}`,
-			CreatedAt: time.Time{},
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
-		}
+		expectedShares, _ := numbers.NewBig257().SetString("32000000000000000000", 10)
+		assert.Equal(t, expectedShares, typedChange.Changes[0].Shares)
+		assert.Equal(t, strings.ToLower("0x049ea11d337f185b1aa910d98e8fbd991f0fba7b"), typedChange.Changes[0].Staker)
+		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", typedChange.Changes[0].Strategy)
 
-		change, err = model.HandleStateChange(&withdrawalMigratedLog)
-		assert.Nil(t, err)
-		assert.NotNil(t, change)
-
-		typedChange = change.(*AccumulatedStateChanges)
-		assert.Equal(t, 1, len(typedChange.Changes))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", typedChange.Changes[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", typedChange.Changes[0].Strategy)
-		assert.Equal(t, "246393621132195985", typedChange.Changes[0].Shares.String())
-
-		slotId = NewSlotID(typedChange.Changes[0].Staker, typedChange.Changes[0].Strategy)
-
-		accumulatedState, ok = model.stateAccumulator[blockNumber][slotId]
-		assert.True(t, ok)
-		assert.NotNil(t, accumulatedState)
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", accumulatedState.Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", accumulatedState.Strategy)
-		assert.Equal(t, "0", accumulatedState.Shares.String())
-
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(transaction.BlockNumber)
 		assert.Nil(t, err)
 
-		// Get the state at the new block and verify the shares amount is correct
-		query = `
-			select * from staker_shares
-			where block_number = ?
-		`
-		results = []*StakerShares{}
-		res = model.DB.Raw(query, blockNumber).Scan(&results)
-		assert.Nil(t, res.Error)
-
-		assert.Equal(t, 1, len(results))
-		assert.Equal(t, "0x9c01148c464cf06d135ad35d3d633ab4b46b9b78", results[0].Staker)
-		assert.Equal(t, "0x298afb19a105d59e74658c4c334ff360bade6dd2", results[0].Strategy)
-		assert.Equal(t, "-246393621132195985", results[0].Shares)
-		assert.Equal(t, blockNumber, results[0].BlockNumber)
-
-		query = `
-			select count(*) from staker_share_deltas
-			where block_number = @blockNumber
-		`
 		var count int
-		res = model.DB.Raw(query, sql.Named("blockNumber", blockNumber)).Scan(&count)
-		assert.Nil(t, res.Error)
-		assert.Equal(t, 0, count)
-
-		t.Cleanup(func() {
-			teardown(model)
-		})
+		res = grm.Raw(`select count(*) from staker_share_deltas`).Scan(&count)
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		assert.Equal(t, 4, count)
 	})
 	t.Cleanup(func() {
 		postgres.TeardownTestDatabase(dbName, cfg, grm, l)

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -27,9 +27,10 @@ func setup() (
 ) {
 	cfg := config.NewConfig()
 	cfg.Chain = config.Chain_Mainnet
+	cfg.Debug = false
 	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
 
-	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: true})
+	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
 
 	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, l)
 	if err != nil {

--- a/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
+++ b/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
@@ -202,7 +202,7 @@ func (sdr *SubmittedDistributionRootsModel) HandleStateChange(log *storage.Trans
 
 	for _, blockNumber := range sortedBlockNumbers {
 		if log.BlockNumber >= blockNumber {
-			sdr.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", blockNumber))
+			sdr.logger.Sugar().Debugw("Handling state change", zap.Uint64("blockNumber", log.BlockNumber))
 
 			change, err := stateChanges[blockNumber](log)
 			if err != nil {

--- a/pkg/postgres/migrations/202411061451_transactionLogsIndex/up.go
+++ b/pkg/postgres/migrations/202411061451_transactionLogsIndex/up.go
@@ -1,0 +1,23 @@
+package _202411061451_transactionLogsIndex
+
+import (
+	"database/sql"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB) error {
+	query := `create index idx_transaction_logs_block_number on transaction_logs (block_number)`
+
+	res := grm.Exec(query)
+	if res.Error != nil {
+		return res.Error
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202411061451_transactionLogsIndex"
+}

--- a/pkg/postgres/migrations/202411061501_stakerSharesReimagined/up.go
+++ b/pkg/postgres/migrations/202411061501_stakerSharesReimagined/up.go
@@ -1,0 +1,25 @@
+package _202411061501_stakerSharesReimagined
+
+import (
+	"database/sql"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB) error {
+	queries := []string{
+		`drop table if exists staker_shares`,
+	}
+	for _, query := range queries {
+		if res := grm.Exec(query); res.Error != nil {
+			return res.Error
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202411061501_stakerSharesReimagined"
+}

--- a/pkg/postgres/migrations/202411061501_stakerSharesReimagined/up.go
+++ b/pkg/postgres/migrations/202411061501_stakerSharesReimagined/up.go
@@ -11,6 +11,17 @@ type Migration struct {
 func (m *Migration) Up(db *sql.DB, grm *gorm.DB) error {
 	queries := []string{
 		`drop table if exists staker_shares`,
+		`create table if not exists staker_shares (
+			staker varchar not null,
+			strategy varchar not null,
+			shares numeric not null,
+			strategy_index bigint not null,
+			transaction_hash varchar not null,
+			log_index bigint not null,
+			block_time timestamp not null,
+			block_date varchar not null,
+			block_number bigint not null
+		)`,
 	}
 	for _, query := range queries {
 		if res := grm.Exec(query); res.Error != nil {

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -26,6 +26,7 @@ import (
 	_202411042033_cleanupDuplicates "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411042033_cleanupDuplicates"
 	_202411051308_submittedDistributionRootIndex "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411051308_submittedDistributionRootIndex"
 	_202411061451_transactionLogsIndex "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411061451_transactionLogsIndex"
+	_202411061501_stakerSharesReimagined "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411061501_stakerSharesReimagined"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"time"
@@ -76,6 +77,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202411042033_cleanupDuplicates.Migration{},
 		&_202411051308_submittedDistributionRootIndex.Migration{},
 		&_202411061451_transactionLogsIndex.Migration{},
+		&_202411061501_stakerSharesReimagined.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -25,6 +25,7 @@ import (
 	_202411041332_stakerShareDeltaBlockFk "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411041332_stakerShareDeltaBlockFk"
 	_202411042033_cleanupDuplicates "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411042033_cleanupDuplicates"
 	_202411051308_submittedDistributionRootIndex "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411051308_submittedDistributionRootIndex"
+	_202411061451_transactionLogsIndex "github.com/Layr-Labs/go-sidecar/pkg/postgres/migrations/202411061451_transactionLogsIndex"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"time"
@@ -74,6 +75,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202411041332_stakerShareDeltaBlockFk.Migration{},
 		&_202411042033_cleanupDuplicates.Migration{},
 		&_202411051308_submittedDistributionRootIndex.Migration{},
+		&_202411061451_transactionLogsIndex.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -248,6 +248,12 @@ func (rc *RewardsCalculator) generateSnapshotData(snapshotDate string) error {
 	}
 	rc.logger.Sugar().Debugw("Generated combined rewards")
 
+	if err = rc.GenerateAndInsertStakerShares(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate staker shares", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Debugw("Generated staker shares")
+
 	if err = rc.GenerateAndInsertOperatorAvsRegistrationSnapshots(snapshotDate); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate operator AVS registration snapshots", "error", err)
 		return err

--- a/pkg/rewards/rewards_test.go
+++ b/pkg/rewards/rewards_test.go
@@ -156,7 +156,7 @@ func Test_Rewards(t *testing.T) {
 		err = hydrateStakerDelegations(grm, l)
 		assert.Nil(t, err)
 
-		err = hydrateStakerShares(grm, l)
+		err = hydrateStakerShareDeltas(grm, l)
 		assert.Nil(t, err)
 
 		err = hydrateRewardSubmissionsTable(grm, l)

--- a/pkg/rewards/stakerShareSnapshots.go
+++ b/pkg/rewards/stakerShareSnapshots.go
@@ -4,7 +4,7 @@ const stakerShareSnapshotsQuery = `
 WITH ranked_staker_records as (
     SELECT *,
            ROW_NUMBER() OVER (PARTITION BY staker, strategy, cast(block_time AS DATE) ORDER BY block_time DESC, log_index DESC) AS rn
-    FROM staker_share_deltas
+    FROM staker_shares
 	-- pipeline bronze table uses this to filter the correct records
 	where block_time < TIMESTAMP '{{.cutoffDate}}'
 ),

--- a/pkg/rewards/stakerShares.go
+++ b/pkg/rewards/stakerShares.go
@@ -1,0 +1,46 @@
+package rewards
+
+const stakerSharesQuery = `
+	select
+		staker,
+		strategy,
+		-- Sum each share amount over the window to get total shares for each (staker, strategy) at every timestamp update */
+		SUM(shares) OVER (PARTITION BY staker, strategy ORDER BY block_time, log_index) AS shares, 
+		transaction_hash,
+		log_index,
+		strategy_index,
+		block_time,
+		block_date,
+		block_number
+	from staker_share_deltas
+	where block_date < '{{.cutoffDate}}'
+`
+
+func (r *RewardsCalculator) GenerateAndInsertStakerShares(snapshotDate string) error {
+	tableName := "staker_shares"
+
+	query, err := renderQueryTemplate(stakerSharesQuery, map[string]string{
+		"cutoffDate": snapshotDate,
+	})
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	err = r.generateAndInsertFromQuery(tableName, query, nil)
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to generate staker_shares", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (r *RewardsCalculator) ListStakerShares() ([]*StakerShares, error) {
+	var stakerShares []*StakerShares
+	res := r.grm.Model(&StakerShares{}).Find(&stakerShares)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to list staker share stakerShares", "error", res.Error)
+		return nil, res.Error
+	}
+	return stakerShares, nil
+}

--- a/pkg/rewards/tables.go
+++ b/pkg/rewards/tables.go
@@ -53,3 +53,15 @@ type StakerShareSnapshot struct {
 	Snapshot time.Time
 	Shares   string
 }
+
+type StakerShares struct {
+	Staker          string
+	Strategy        string
+	Shares          string
+	StrategyIndex   uint64
+	TransactionHash string
+	LogIndex        uint64
+	BlockTime       time.Time
+	BlockDate       string
+	BlockNumber     uint64
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -99,7 +99,7 @@ func (r RewardSnapshotStatus) String() string {
 
 var (
 	RewardSnapshotStatusProcessing RewardSnapshotStatus = "processing"
-	RewardSnapshotStatusCompleted  RewardSnapshotStatus = "completed"
+	RewardSnapshotStatusCompleted  RewardSnapshotStatus = "complete"
 	RewardSnapshotStatusFailed     RewardSnapshotStatus = "failed"
 )
 


### PR DESCRIPTION
Fix a bug with rewards state enum

**Refactor stakerShares EigenState model to only keep track of deltas rather than a constant running total.**

Until now, stakerShares was too complex; we were keeping track of delta changes down to the log_index level AND summarized shares at each block height. The summarized values (`staker_shares` table) was not used. The delta table was used, but the stakerShareSnapshot stage was expecting summed values at each log_index that included the previous values, NOT pure deltas. With this in mind we make a few changes:

* StakerShares EigenState model is now delta values only
* Added a StakerShares pre-gold table that sums staker shares on a `partition over staker, strategy order by block_time, log_index` to be match what was actually expected