### PR TITLE
Update state root generation

### DIFF
--- a/pkg/eigenState/avsOperators/avsOperators.go
+++ b/pkg/eigenState/avsOperators/avsOperators.go
@@ -227,8 +227,17 @@ func (a *AvsOperatorsModel) GenerateStateRoot(blockNumber uint64) (types.StateRo
 
 	inputs := a.sortValuesForMerkleTree(deltas)
 
+	if len(inputs) == 0 {
+		return "", nil
+	}
+
 	fullTree, err := a.MerkleizeState(blockNumber, inputs)
 	if err != nil {
+		a.logger.Sugar().Errorw("Failed to create merkle tree",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("inputs", inputs),
+		)
 		return "", err
 	}
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
@@ -250,9 +259,4 @@ func (a *AvsOperatorsModel) sortValuesForMerkleTree(diffs []*AvsOperatorStateCha
 
 func (a *AvsOperatorsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
 	return a.BaseEigenState.DeleteState("avs_operator_state_changes", startBlockNumber, endBlockNumber, a.DB)
-}
-
-// IncludeStateRootForBlock returns true if the state root should be included for the given block number.
-func (a *AvsOperatorsModel) IncludeStateRootForBlock(blockNumber uint64) bool {
-	return true
 }

--- a/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots.go
+++ b/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots.go
@@ -208,8 +208,17 @@ func (ddr *DisabledDistributionRootsModel) GenerateStateRoot(blockNumber uint64)
 
 	sortedInputs := ddr.sortValuesForMerkleTree(diffs)
 
+	if len(sortedInputs) == 0 {
+		return "", nil
+	}
+
 	fullTree, err := ddr.MerkleizeState(blockNumber, sortedInputs)
 	if err != nil {
+		ddr.logger.Sugar().Errorw("Failed to create merkle tree",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("inputs", sortedInputs),
+		)
 		return "", err
 	}
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
@@ -240,13 +249,4 @@ func (ddr *DisabledDistributionRootsModel) GetSubmittedRootsForBlock(blockNumber
 		return nil, res.Error
 	}
 	return records, nil
-}
-
-// IncludeStateRootForBlock returns true if the state root should be included for the given block number.
-func (ddr *DisabledDistributionRootsModel) IncludeStateRootForBlock(blockNumber uint64) bool {
-	switch ddr.globalConfig.Chain {
-	case config.Chain_Mainnet:
-		return blockNumber >= 20893484 // block of the first root that we disabled
-	}
-	return true
 }

--- a/pkg/eigenState/operatorShares/operatorShares.go
+++ b/pkg/eigenState/operatorShares/operatorShares.go
@@ -282,8 +282,17 @@ func (osm *OperatorSharesModel) GenerateStateRoot(blockNumber uint64) (types.Sta
 
 	inputs := osm.sortValuesForMerkleTree(deltas)
 
+	if len(inputs) == 0 {
+		return "", nil
+	}
+
 	fullTree, err := osm.MerkleizeState(blockNumber, inputs)
 	if err != nil {
+		osm.logger.Sugar().Errorw("Failed to create merkle tree",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("inputs", inputs),
+		)
 		return "", err
 	}
 	return types.StateRoot(pkgUtils.ConvertBytesToString(fullTree.Root())), nil
@@ -305,9 +314,4 @@ func (osm *OperatorSharesModel) sortValuesForMerkleTree(diffs []*OperatorShareDe
 
 func (osm *OperatorSharesModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
 	return osm.BaseEigenState.DeleteState("operator_share_deltas", startBlockNumber, endBlockNumber, osm.DB)
-}
-
-// IncludeStateRootForBlock returns true if the state root should be included for the given block number.
-func (osm *OperatorSharesModel) IncludeStateRootForBlock(blockNumber uint64) bool {
-	return true
 }

--- a/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
+++ b/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
@@ -360,8 +360,17 @@ func (rs *RewardSubmissionsModel) GenerateStateRoot(blockNumber uint64) (types.S
 
 	inputs := rs.sortValuesForMerkleTree(combinedResults)
 
+	if len(inputs) == 0 {
+		return "", nil
+	}
+
 	fullTree, err := rs.MerkleizeState(blockNumber, inputs)
 	if err != nil {
+		rs.logger.Sugar().Errorw("Failed to create merkle tree",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("inputs", inputs),
+		)
 		return "", err
 	}
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
@@ -390,9 +399,4 @@ func (rs *RewardSubmissionsModel) sortValuesForMerkleTree(submissions []*RewardS
 
 func (rs *RewardSubmissionsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
 	return rs.BaseEigenState.DeleteState("reward_submissions", startBlockNumber, endBlockNumber, rs.DB)
-}
-
-// IncludeStateRootForBlock returns true if the state root should be included for the given block number.
-func (rs *RewardSubmissionsModel) IncludeStateRootForBlock(blockNumber uint64) bool {
-	return true
 }

--- a/pkg/eigenState/stakerDelegations/stakerDelegations.go
+++ b/pkg/eigenState/stakerDelegations/stakerDelegations.go
@@ -213,8 +213,17 @@ func (s *StakerDelegationsModel) GenerateStateRoot(blockNumber uint64) (types.St
 
 	inputs := s.sortValuesForMerkleTree(deltas)
 
+	if len(inputs) == 0 {
+		return "", nil
+	}
+
 	fullTree, err := s.MerkleizeState(blockNumber, inputs)
 	if err != nil {
+		s.logger.Sugar().Errorw("Failed to create merkle tree",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("inputs", inputs),
+		)
 		return "", err
 	}
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
@@ -236,9 +245,4 @@ func (s *StakerDelegationsModel) sortValuesForMerkleTree(diffs []*StakerDelegati
 
 func (s *StakerDelegationsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
 	return s.BaseEigenState.DeleteState("staker_delegation_changes", startBlockNumber, endBlockNumber, s.DB)
-}
-
-// IncludeStateRootForBlock returns true if the state root should be included for the given block number.
-func (s *StakerDelegationsModel) IncludeStateRootForBlock(blockNumber uint64) bool {
-	return true
 }

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -46,8 +46,8 @@ type StakerShareDeltas struct {
 	WithdrawalRootString string `gorm:"-"`
 }
 
-func NewSlotID(staker string, strategy string, transactionHash string, logIndex uint64) types.SlotID {
-	return types.SlotID(fmt.Sprintf("%s_%s_%s_%d", staker, strategy, transactionHash, logIndex))
+func NewSlotID(staker string, strategy string, strategyIndex uint64, transactionHash string, logIndex uint64) types.SlotID {
+	return types.SlotID(fmt.Sprintf("%s_%s_%d_%s_%d", staker, strategy, strategyIndex, transactionHash, logIndex))
 }
 
 type StakerSharesModel struct {
@@ -601,7 +601,7 @@ func (ss *StakerSharesModel) sortValuesForMerkleTree(diffs []*StakerShareDeltas)
 	inputs := make([]*base.MerkleTreeInput, 0)
 	for _, diff := range diffs {
 		inputs = append(inputs, &base.MerkleTreeInput{
-			SlotID: NewSlotID(diff.Staker, diff.Strategy, diff.TransactionHash, diff.LogIndex),
+			SlotID: NewSlotID(diff.Staker, diff.Strategy, diff.StrategyIndex, diff.TransactionHash, diff.LogIndex),
 			Value:  []byte(diff.Shares),
 		})
 	}

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -581,8 +581,17 @@ func (ss *StakerSharesModel) GenerateStateRoot(blockNumber uint64) (types.StateR
 
 	inputs := ss.sortValuesForMerkleTree(deltas)
 
+	if len(inputs) == 0 {
+		return "", nil
+	}
+
 	fullTree, err := ss.MerkleizeState(blockNumber, inputs)
 	if err != nil {
+		ss.logger.Sugar().Errorw("Failed to create merkle tree",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("inputs", inputs),
+		)
 		return "", err
 	}
 	return types.StateRoot(pkgUtils.ConvertBytesToString(fullTree.Root())), nil
@@ -605,9 +614,4 @@ func (ss *StakerSharesModel) sortValuesForMerkleTree(diffs []*StakerShareDeltas)
 
 func (ss *StakerSharesModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
 	return ss.BaseEigenState.DeleteState("staker_share_deltas", startBlockNumber, endBlockNumber, ss.DB)
-}
-
-// IncludeStateRootForBlock returns true if the state root should be included for the given block number.
-func (ss *StakerSharesModel) IncludeStateRootForBlock(blockNumber uint64) bool {
-	return true
 }

--- a/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
+++ b/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
@@ -286,8 +286,17 @@ func (sdr *SubmittedDistributionRootsModel) GenerateStateRoot(blockNumber uint64
 
 	sortedInputs := sdr.sortValuesForMerkleTree(diffs)
 
+	if len(sortedInputs) == 0 {
+		return "", nil
+	}
+
 	fullTree, err := sdr.MerkleizeState(blockNumber, sortedInputs)
 	if err != nil {
+		sdr.logger.Sugar().Errorw("Failed to create merkle tree",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("inputs", sortedInputs),
+		)
 		return "", err
 	}
 	return types.StateRoot(utils.ConvertBytesToString(fullTree.Root())), nil
@@ -318,9 +327,4 @@ func (sdr *SubmittedDistributionRootsModel) GetSubmittedRootsForBlock(blockNumbe
 		return nil, res.Error
 	}
 	return records, nil
-}
-
-// IncludeStateRootForBlock returns true if the state root should be included for the given block number.
-func (sdr *SubmittedDistributionRootsModel) IncludeStateRootForBlock(blockNumber uint64) bool {
-	return true
 }

--- a/pkg/eigenState/types/types.go
+++ b/pkg/eigenState/types/types.go
@@ -43,8 +43,6 @@ type IEigenStateModel interface {
 	// @param startBlockNumber the block number to start deleting state from (inclusive)
 	// @param endBlockNumber the block number to end deleting state from (inclusive). If 0, delete all state from startBlockNumber
 	DeleteState(startBlockNumber uint64, endBlockNumber uint64) error
-
-	IncludeStateRootForBlock(blockNumber uint64) bool
 }
 
 // StateTransitions


### PR DESCRIPTION
**Add more uniqueness to StakerShares SlotId**
Previously, we thought the existing SlotId format was unique enough,
but we recently encountered an edgecase where we needed more uniqueness.

https://etherscan.io/tx/0x004acdfb302e0fc320ccdbc0bf320b82355525457ca6a9184f19605c5842ea66#eventlog#383

**StateRoot generation update**
Changes StateRoot generation to not include roots from models where nothing changed for the block. This allows us to more easily add forward-looking state models that wont be included until the events appear on chain.