### PR TITLE
feat: use a lock to ensure only one rewards calculation happens at a time

### DIFF
--- a/pkg/rewards/rewards_test.go
+++ b/pkg/rewards/rewards_test.go
@@ -354,6 +354,7 @@ func Test_RewardsCalculatorLock(t *testing.T) {
 
 	sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
 	rc, err := NewRewardsCalculator(cfg, grm, bs, sog, l)
+	assert.Nil(t, err)
 
 	// Setup all tables and source data
 	_, err = hydrateAllBlocksTable(grm, l)


### PR DESCRIPTION
Since the rewards generation process relies on stateful tables relative to the provided cutoffDate, we can only allow one calculation to run at a time. This adds a locking mechanism on the rewards calculator to ensure this is the case with additional polling logic that will wait for the next available lock.