### PR TITLE
feat: add optional `verified` flag when getting latest block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.5.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241204030420-83d31161930e
+	github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241204194134-d3c82f365d7a
 	github.com/ethereum/go-ethereum v1.14.9
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241203225729-619c724a75e3 h1:
 github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241203225729-619c724a75e3/go.mod h1:prNA2/mLO5vpMZ2q78Nsn0m97wm28uiRnwO+/yOxigk=
 github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241204030420-83d31161930e h1:h6ptdsDTKiTldAyel+XXfbusrarpF2+arhPlaFUeq7M=
 github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241204030420-83d31161930e/go.mod h1:prNA2/mLO5vpMZ2q78Nsn0m97wm28uiRnwO+/yOxigk=
+github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241204194134-d3c82f365d7a h1:KgeRP8HuUI6OR7v3oe8l4vXbhBiZfu4htao4yiHlbsk=
+github.com/Layr-Labs/protocol-apis v1.0.0-rc.1.0.20241204194134-d3c82f365d7a/go.mod h1:prNA2/mLO5vpMZ2q78Nsn0m97wm28uiRnwO+/yOxigk=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=


### PR DESCRIPTION
This will return the latest verified block based on the presence of a corresponding state root rather than a block that was indexed that does not yet have a state root.