### PR TITLE
fix: handle same staker, multiple strategy case

### DIFF
--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jackc/pgx/v5/pgconn"
 	"math"
 	"math/big"
 	"slices"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"github.com/Layr-Labs/sidecar/pkg/types/numbers"
@@ -849,6 +850,12 @@ func (ss *StakerSharesModel) prepareState(blockNumber uint64) ([]*StakerShareDel
 
 		if shareDelta.LogIndex < slashDiff.LogIndex {
 			key := fmt.Sprintf("%s-%s", shareDelta.Staker, shareDelta.Strategy)
+
+			ss.logger.Sugar().Infow("regular share delta",
+				zap.String("staker", shareDelta.Staker),
+				zap.String("strategy", shareDelta.Strategy),
+				zap.String("shares", shareDelta.Shares),
+			)
 
 			// apply the shareDelta
 			if _, ok := netDeltas[key]; !ok {


### PR DESCRIPTION
Before, we looped through each slashDiff and queried the DB for every shareDelta record for every staker delegated to the slashed operator **for every strategy** they had deposited.

Then, we would loop through each returned shareDelta record and process a slashing (i.e. add a share delta record) if
1. the record returned from the database was of the same strategy that was being slashed in the slashDiff
2. or there were existing deltas for the (staker, slashedStrategy) pair in the current block, to account for other slashings, deposits, or withdrawals that may have happened

However, this led to a bug where 
1. if a staker had deposited into strat1 and strat2
2. and slashing for their operator for strat1
3. (staker, strat1, shares1), (staker, strat2, shares2) would be fetched from the DB
4. We would loop through both records
a. slash the existing shares (staker, strat1, shares1) since the strategy matches up
b. slash the existing shares in (staker, strat2, shares2) since the there have already been diffs for (staker, strat1) due to the previous processing in 4a

Obviously, 4b is problematic.

To fix this, we have altered the slashing query to old select the records for each staker for the slashedStrategy for each slashDiff. This makes it so that, when processing each slashDiff, each delegated staker only shows up once for the shares they had in that strategy.