### PR TITLE
fix: inconsistent number formatting

### DIFF
--- a/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
+++ b/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
@@ -320,12 +320,12 @@ func (odrs *OperatorDirectedRewardSubmissionsModel) sortValuesForMerkleTree(subm
 
 		multiplierBig, success := new(big.Int).SetString(submission.Multiplier, 10)
 		if !success {
-			return nil, fmt.Errorf("failed to parse multiplier to Big257: %s", submission.Multiplier)
+			return nil, fmt.Errorf("failed to parse multiplier to BigInt: %s", submission.Multiplier)
 		}
 
 		amountBig, success := new(big.Int).SetString(submission.Amount, 10)
 		if !success {
-			return nil, fmt.Errorf("failed to parse amount to Big257: %s", submission.Amount)
+			return nil, fmt.Errorf("failed to parse amount to BigInt: %s", submission.Amount)
 		}
 
 		// Multiplier is a uint96 in the contracts, which translates to 24 hex characters

--- a/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
+++ b/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
@@ -3,6 +3,7 @@ package operatorDirectedRewardSubmissions
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"slices"
 	"sort"
 	"strings"
@@ -317,12 +318,12 @@ func (odrs *OperatorDirectedRewardSubmissionsModel) sortValuesForMerkleTree(subm
 	for _, submission := range submissions {
 		slotID := NewSlotID(submission.TransactionHash, submission.LogIndex, submission.RewardHash, submission.StrategyIndex, submission.OperatorIndex)
 
-		multiplierBig, success := numbers.NewBig257().SetString(submission.Multiplier, 10)
+		multiplierBig, success := new(big.Int).SetString(submission.Multiplier, 10)
 		if !success {
 			return nil, fmt.Errorf("failed to parse multiplier to Big257: %s", submission.Multiplier)
 		}
 
-		amountBig, success := numbers.NewBig257().SetString(submission.Amount, 10)
+		amountBig, success := new(big.Int).SetString(submission.Amount, 10)
 		if !success {
 			return nil, fmt.Errorf("failed to parse amount to Big257: %s", submission.Amount)
 		}


### PR DESCRIPTION
# Motivation

As part of the Rewards v2 SigmaPrime audit, we need to tackle the following issues:

1.  ELSC2-04: Inconsistent Number Formatting In Merkle Tree Values

Specifically for the multiplier and amount fields in the Operator Directed Rewards Submission Model.

# Modifications

* Handling as `%064x` and `%024x` instead of strings.

# Result
`ELSC2-04` SigmaPrime audit fix.
