### PR TITLE
fix: add postgresql client to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN make build
 
 FROM debian:testing-slim
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates postgresql-client
 
 COPY --from=builder /build/bin/sidecar /usr/local/bin/sidecar
 


### PR DESCRIPTION
adds postgresql-client to the docker build for pg_dump and pg_restore which https://github.com/habx/pg-commands uses for snapshot create and snapshot restore