### PR TITLE
feat: rewards 2.1 calculation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,11 +34,12 @@ const (
 
 // Rewards forks named after rivers
 const (
-	RewardsFork_Nile    ForkName = "nile"
-	RewardsFork_Amazon  ForkName = "amazon"
-	RewardsFork_Panama  ForkName = "panama"
-	RewardsFork_Arno    ForkName = "arno"
-	RewardsFork_Trinity ForkName = "trinity"
+	RewardsFork_Nile        ForkName = "nile"
+	RewardsFork_Amazon      ForkName = "amazon"
+	RewardsFork_Panama      ForkName = "panama"
+	RewardsFork_Arno        ForkName = "arno"
+	RewardsFork_Trinity     ForkName = "trinity"
+	RewardsFork_Mississippi ForkName = "mississippi"
 )
 
 func normalizeFlagName(name string) string {
@@ -293,27 +294,30 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 	switch c.Chain {
 	case Chain_Preprod:
 		return ForkMap{
-			RewardsFork_Amazon:  "1970-01-01", // Amazon hard fork was never on preprod as we backfilled
-			RewardsFork_Nile:    "2024-08-14", // Last calculation end timestamp was 8-13: https://holesky.etherscan.io/tx/0xb5a6855e88c79312b7c0e1c9f59ae9890b97f157ea27e69e4f0fadada4712b64#eventlog
-			RewardsFork_Panama:  "2024-10-01",
-			RewardsFork_Arno:    "2024-12-11",
-			RewardsFork_Trinity: "2025-01-09",
+			RewardsFork_Amazon:      "1970-01-01", // Amazon hard fork was never on preprod as we backfilled
+			RewardsFork_Nile:        "2024-08-14", // Last calculation end timestamp was 8-13: https://holesky.etherscan.io/tx/0xb5a6855e88c79312b7c0e1c9f59ae9890b97f157ea27e69e4f0fadada4712b64#eventlog
+			RewardsFork_Panama:      "2024-10-01",
+			RewardsFork_Arno:        "2024-12-11",
+			RewardsFork_Trinity:     "2025-01-09",
+			RewardsFork_Mississippi: "2025-02-03",
 		}, nil
 	case Chain_Holesky:
 		return ForkMap{
-			RewardsFork_Amazon:  "1970-01-01", // Amazon hard fork was never on testnet as we backfilled
-			RewardsFork_Nile:    "2024-08-13", // Last calculation end timestamp was 8-12: https://holesky.etherscan.io/tx/0x5fc81b5ed2a78b017ef313c181d8627737a97fef87eee85acedbe39fc8708c56#eventlog
-			RewardsFork_Panama:  "2024-10-01",
-			RewardsFork_Arno:    "2024-12-13",
-			RewardsFork_Trinity: "2025-01-09",
+			RewardsFork_Amazon:      "1970-01-01", // Amazon hard fork was never on testnet as we backfilled
+			RewardsFork_Nile:        "2024-08-13", // Last calculation end timestamp was 8-12: https://holesky.etherscan.io/tx/0x5fc81b5ed2a78b017ef313c181d8627737a97fef87eee85acedbe39fc8708c56#eventlog
+			RewardsFork_Panama:      "2024-10-01",
+			RewardsFork_Arno:        "2024-12-13",
+			RewardsFork_Trinity:     "2025-01-09",
+			RewardsFork_Mississippi: "2025-02-10",
 		}, nil
 	case Chain_Mainnet:
 		return ForkMap{
-			RewardsFork_Amazon:  "2024-08-02", // Last calculation end timestamp was 8-01: https://etherscan.io/tx/0x2aff6f7b0132092c05c8f6f41a5e5eeeb208aa0d95ebcc9022d7823e343dd012#eventlog
-			RewardsFork_Nile:    "2024-08-12", // Last calculation end timestamp was 8-11: https://etherscan.io/tx/0x922d29d93c02d189fc2332041f01a80e0007cd7a625a5663ef9d30082f7ef66f#eventlog
-			RewardsFork_Panama:  "2024-10-01",
-			RewardsFork_Arno:    "2025-01-21",
-			RewardsFork_Trinity: "2025-01-21",
+			RewardsFork_Amazon:      "2024-08-02", // Last calculation end timestamp was 8-01: https://etherscan.io/tx/0x2aff6f7b0132092c05c8f6f41a5e5eeeb208aa0d95ebcc9022d7823e343dd012#eventlog
+			RewardsFork_Nile:        "2024-08-12", // Last calculation end timestamp was 8-11: https://etherscan.io/tx/0x922d29d93c02d189fc2332041f01a80e0007cd7a625a5663ef9d30082f7ef66f#eventlog
+			RewardsFork_Panama:      "2024-10-01",
+			RewardsFork_Arno:        "2025-01-21",
+			RewardsFork_Trinity:     "2025-01-21",
+			RewardsFork_Mississippi: "2025-03-27",
 		}, nil
 	}
 	return nil, errors.New("unsupported chain")
@@ -384,6 +388,23 @@ func (c *Config) IsRewardsV2EnabledForCutoffDate(cutoffDate string) (bool, error
 	}
 
 	return cutoffDateTime.Compare(arnoForkDateTime) >= 0, nil
+}
+
+func (c *Config) IsRewardsV2_1EnabledForCutoffDate(cutoffDate string) (bool, error) {
+	forks, err := c.GetRewardsSqlForkDates()
+	if err != nil {
+		return false, err
+	}
+	cutoffDateTime, err := time.Parse(time.DateOnly, cutoffDate)
+	if err != nil {
+		return false, errors.Join(fmt.Errorf("failed to parse cutoff date %s", cutoffDate), err)
+	}
+	mississippiForkDateTime, err := time.Parse(time.DateOnly, forks[RewardsFork_Mississippi])
+	if err != nil {
+		return false, errors.Join(fmt.Errorf("failed to parse Mississippi fork date %s", forks[RewardsFork_Mississippi]), err)
+	}
+
+	return cutoffDateTime.Compare(mississippiForkDateTime) >= 0, nil
 }
 
 // CanIgnoreIncorrectRewardsRoot returns true if the rewards root can be ignored for the given block number

--- a/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
+++ b/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
@@ -106,8 +106,8 @@ func (osor *OperatorSetOperatorRegistrationModel) handleOperatorSetOperatorRegis
 
 	operatorRegistration := &OperatorSetOperatorRegistration{
 		Operator:        strings.ToLower(arguments[0].Value.(string)),
-		Avs:             outputData.OperatorSet.Avs,
-		OperatorSetId:   outputData.OperatorSet.Id,
+		Avs:             strings.ToLower(outputData.OperatorSet.Avs),
+		OperatorSetId:   uint64(outputData.OperatorSet.Id),
 		IsActive:        isActive,
 		BlockNumber:     log.BlockNumber,
 		TransactionHash: log.TransactionHash,

--- a/pkg/eigenState/operatorSetStrategyRegistrations/operatorSetStrategyRegistrations.go
+++ b/pkg/eigenState/operatorSetStrategyRegistrations/operatorSetStrategyRegistrations.go
@@ -101,9 +101,9 @@ func (ossr *OperatorSetStrategyRegistrationModel) handleOperatorSetStrategyRegis
 	}
 
 	strategyRegistration := &OperatorSetStrategyRegistration{
-		Strategy:        outputData.Strategy,
-		Avs:             outputData.OperatorSet.Avs,
-		OperatorSetId:   outputData.OperatorSet.Id,
+		Strategy:        strings.ToLower(outputData.Strategy),
+		Avs:             strings.ToLower(outputData.OperatorSet.Avs),
+		OperatorSetId:   uint64(outputData.OperatorSet.Id),
 		IsActive:        isActive,
 		BlockNumber:     log.BlockNumber,
 		TransactionHash: log.TransactionHash,

--- a/pkg/postgres/migrations/202501301458_operatorSetSplitSnapshots/up.go
+++ b/pkg/postgres/migrations/202501301458_operatorSetSplitSnapshots/up.go
@@ -1,0 +1,33 @@
+package _202501301458_operatorSetSplitSnapshots
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS operator_set_split_snapshots (
+			operator varchar not null,
+			avs varchar not null,
+			operator_set_id bigint not null,
+			split integer not null,
+			snapshot date not null
+		)`,
+	}
+	for _, query := range queries {
+		if _, err := db.Exec(query); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202501301458_operatorSetSplitSnapshots"
+}

--- a/pkg/postgres/migrations/202501301458_operatorSetSplitSnapshots/up.go
+++ b/pkg/postgres/migrations/202501301458_operatorSetSplitSnapshots/up.go
@@ -17,7 +17,8 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 			avs varchar not null,
 			operator_set_id bigint not null,
 			split integer not null,
-			snapshot date not null
+			snapshot date not null,
+			UNIQUE (operator, avs, operator_set_id, snapshot)
 		)`,
 	}
 	for _, query := range queries {

--- a/pkg/postgres/migrations/202501301502_operatorSetOperatorRegistrationSnapshots/up.go
+++ b/pkg/postgres/migrations/202501301502_operatorSetOperatorRegistrationSnapshots/up.go
@@ -16,7 +16,8 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 			operator varchar not null,
 			avs varchar not null,
 			operator_set_id bigint not null,
-			snapshot date not null
+			snapshot date not null,
+			UNIQUE (operator, avs, operator_set_id, snapshot)
 		)`,
 	}
 	for _, query := range queries {

--- a/pkg/postgres/migrations/202501301502_operatorSetOperatorRegistrationSnapshots/up.go
+++ b/pkg/postgres/migrations/202501301502_operatorSetOperatorRegistrationSnapshots/up.go
@@ -1,0 +1,32 @@
+package _202501301502_operatorSetOperatorRegistrationSnapshots
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS operator_set_operator_registration_snapshots (
+			operator varchar not null,
+			avs varchar not null,
+			operator_set_id bigint not null,
+			snapshot date not null
+		)`,
+	}
+	for _, query := range queries {
+		if _, err := db.Exec(query); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202501301502_operatorSetOperatorRegistrationSnapshots"
+}

--- a/pkg/postgres/migrations/202501301505_operatorSetStrategyRegistrationSnapshots/up.go
+++ b/pkg/postgres/migrations/202501301505_operatorSetStrategyRegistrationSnapshots/up.go
@@ -1,0 +1,32 @@
+package _202501301505_operatorSetStrategyRegistrationSnapshots
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS operator_set_strategy_registration_snapshots (
+			strategy varchar not null,
+			avs varchar not null,
+			operator_set_id bigint not null,
+			snapshot date not null
+		)`,
+	}
+	for _, query := range queries {
+		if _, err := db.Exec(query); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202501301505_operatorSetStrategyRegistrationSnapshots"
+}

--- a/pkg/postgres/migrations/202501301505_operatorSetStrategyRegistrationSnapshots/up.go
+++ b/pkg/postgres/migrations/202501301505_operatorSetStrategyRegistrationSnapshots/up.go
@@ -16,7 +16,8 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 			strategy varchar not null,
 			avs varchar not null,
 			operator_set_id bigint not null,
-			snapshot date not null
+			snapshot date not null,
+			UNIQUE (strategy, avs, operator_set_id, snapshot)
 		)`,
 	}
 	for _, query := range queries {

--- a/pkg/postgres/migrations/202501301945_operatorDirectedOperatorSetRewards/up.go
+++ b/pkg/postgres/migrations/202501301945_operatorDirectedOperatorSetRewards/up.go
@@ -1,0 +1,45 @@
+package _202501301945_operatorDirectedOperatorSetRewards
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`CREATE TABLE IF NOT EXISTS operator_directed_operator_set_rewards (
+			avs varchar not null,
+			operator_set_id bigint not null,
+			reward_hash varchar not null,
+			token varchar not null,
+			operator varchar not null,
+			operator_index integer not null,
+			amount numeric not null,
+			strategy varchar not null,
+			strategy_index integer not null,
+			multiplier numeric(78) not null,
+			start_timestamp timestamp(6) not null,
+			end_timestamp timestamp(6) not null,
+			duration bigint not null,
+			block_number bigint not null,
+			block_time timestamp without time zone not null,
+			block_date date not null
+		)`,
+	}
+
+	for _, query := range queries {
+		if err := grm.Exec(query).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202501301945_operatorDirectedOperatorSetRewards"
+}

--- a/pkg/postgres/migrations/202501301945_operatorDirectedOperatorSetRewards/up.go
+++ b/pkg/postgres/migrations/202501301945_operatorDirectedOperatorSetRewards/up.go
@@ -28,7 +28,9 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 			duration bigint not null,
 			block_number bigint not null,
 			block_time timestamp without time zone not null,
-			block_date date not null
+			block_date date not null,
+			UNIQUE (avs, operator_set_id, reward_hash, operator_index, strategy_index),
+			CONSTRAINT operator_directed_operator_set_rewards_block_number_fkey FOREIGN KEY (block_number) REFERENCES blocks(number) ON DELETE CASCADE
 		)`,
 	}
 

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -3,8 +3,9 @@ package migrations
 import (
 	"database/sql"
 	"fmt"
-	_202501241111_addIndexesForRpcFunctions "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501241111_addIndexesForRpcFunctions"
 	"time"
+
+	_202501241111_addIndexesForRpcFunctions "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501241111_addIndexesForRpcFunctions"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	_202409061249_bootstrapDb "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202409061249_bootstrapDb"
@@ -54,6 +55,10 @@ import (
 	_202501241533_operatorSetSplits "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501241533_operatorSetSplits"
 	_202501271727_operatorSetOperatorRegistrations "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501271727_operatorSetOperatorRegistrations"
 	_202501281806_operatorSetStrategyRegistrations "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501281806_operatorSetStrategyRegistrations"
+	_202501301458_operatorSetSplitSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501301458_operatorSetSplitSnapshots"
+	_202501301502_operatorSetOperatorRegistrationSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501301502_operatorSetOperatorRegistrationSnapshots"
+	_202501301505_operatorSetStrategyRegistrationSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501301505_operatorSetStrategyRegistrationSnapshots"
+	_202501301945_operatorDirectedOperatorSetRewards "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501301945_operatorDirectedOperatorSetRewards"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -144,6 +149,10 @@ func (m *Migrator) MigrateAll() error {
 		&_202501241533_operatorSetSplits.Migration{},
 		&_202501271727_operatorSetOperatorRegistrations.Migration{},
 		&_202501281806_operatorSetStrategyRegistrations.Migration{},
+		&_202501301458_operatorSetSplitSnapshots.Migration{},
+		&_202501301502_operatorSetOperatorRegistrationSnapshots.Migration{},
+		&_202501301505_operatorSetStrategyRegistrationSnapshots.Migration{},
+		&_202501301945_operatorDirectedOperatorSetRewards.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/rewards/11_goldActiveODOperatorSetRewards.go
+++ b/pkg/rewards/11_goldActiveODOperatorSetRewards.go
@@ -1,0 +1,219 @@
+package rewards
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+var _11_goldActiveODOperatorSetRewardsQuery = `
+CREATE TABLE {{.destTableName}} AS
+WITH 
+-- Step 1: Modify active rewards and compute tokens per day
+active_rewards_modified AS (
+    SELECT 
+        *,
+        CAST(@cutoffDate AS TIMESTAMP(6)) AS global_end_inclusive -- Inclusive means we DO USE this day as a snapshot
+    FROM operator_directed_operator_set_rewards
+    WHERE end_timestamp >= TIMESTAMP '{{.rewardsStart}}'
+      AND start_timestamp <= TIMESTAMP '{{.cutoffDate}}'
+      AND block_time <= TIMESTAMP '{{.cutoffDate}}' -- Always ensure we're not using future data. Should never happen since we're never backfilling, but here for safety and consistency.
+),
+
+-- Step 2: Cut each reward's start and end windows to handle the global range
+active_rewards_updated_end_timestamps AS (
+    SELECT
+        avs,
+        operator_set_id,
+        operator,
+        /**
+         * Cut the start and end windows to handle
+         * A. Retroactive rewards that came recently whose start date is less than start_timestamp
+         * B. Don't make any rewards past end_timestamp for this run
+         */
+        start_timestamp AS reward_start_exclusive,
+        LEAST(global_end_inclusive, end_timestamp) AS reward_end_inclusive,
+        amount,
+        token,
+        multiplier,
+        strategy,
+        reward_hash,
+        duration,
+        global_end_inclusive,
+        block_date AS reward_submission_date
+    FROM active_rewards_modified
+),
+
+-- Step 3: For each reward hash, find the latest snapshot
+active_rewards_updated_start_timestamps AS (
+    SELECT
+        ap.avs,
+        ap.operator_set_id,
+        ap.operator,
+        COALESCE(MAX(g.snapshot), ap.reward_start_exclusive) AS reward_start_exclusive,
+        ap.reward_end_inclusive,
+        ap.token,
+        -- We use floor to ensure we are always underestimating total tokens per day
+        FLOOR(ap.amount) AS amount_decimal,
+        ap.multiplier,
+        ap.strategy,
+        ap.reward_hash,
+        ap.duration,
+        ap.global_end_inclusive,
+        ap.reward_submission_date
+    FROM active_rewards_updated_end_timestamps ap
+    LEFT JOIN gold_table g 
+        ON g.reward_hash = ap.reward_hash
+    GROUP BY 
+        ap.avs, 
+        ap.operator_set_id,
+        ap.operator, 
+        ap.reward_end_inclusive, 
+        ap.token, 
+        ap.amount,
+        ap.multiplier, 
+        ap.strategy, 
+        ap.reward_hash, 
+        ap.duration,
+        ap.global_end_inclusive, 
+        ap.reward_start_exclusive, 
+        ap.reward_submission_date
+),
+
+-- Step 4: Filter out invalid reward ranges
+active_reward_ranges AS (
+    /** Take out (reward_start_exclusive, reward_end_inclusive) windows where
+	* 1. reward_start_exclusive >= reward_end_inclusive: The reward period is done or we will handle on a subsequent run
+	*/
+    SELECT * 
+    FROM active_rewards_updated_start_timestamps
+    WHERE reward_start_exclusive < reward_end_inclusive
+),
+
+-- Step 5: Explode out the ranges for a day per inclusive date
+exploded_active_range_rewards AS (
+    SELECT
+        *
+    FROM active_reward_ranges
+    CROSS JOIN generate_series(
+        DATE(reward_start_exclusive), 
+        DATE(reward_end_inclusive), 
+        INTERVAL '1' DAY
+    ) AS day
+),
+
+-- Step 6: Prepare cleaned active rewards
+active_rewards_cleaned AS (
+    SELECT
+        avs,
+        operator_set_id,
+        operator,
+        CAST(day AS DATE) AS snapshot,
+        token,
+        amount_decimal,
+        multiplier,
+        strategy,
+        duration,
+        reward_hash,
+        reward_submission_date
+    FROM exploded_active_range_rewards
+    -- Remove snapshots on the start day
+    WHERE day != reward_start_exclusive
+),
+
+-- Step 7: Dedupe the active rewards by (avs, operator_set_id, snapshot, operator, reward_hash)
+active_rewards_reduced_deduped AS (
+    SELECT DISTINCT avs, operator_set_id, snapshot, operator, reward_hash
+    FROM active_rewards_cleaned
+),
+
+-- Step 8: Divide by the number of snapshots that the operator was registered to an operator set for
+op_set_op_num_registered_snapshots AS (
+    SELECT
+        ar.reward_hash,
+        ar.operator,
+        COUNT(*) AS num_registered_snapshots
+    FROM active_rewards_reduced_deduped ar
+    JOIN operator_set_operator_registration_snapshots osor
+    ON
+        ar.avs = osor.avs
+        AND ar.operator_set_id = osor.operator_set_id
+        AND ar.snapshot = osor.snapshot 
+        AND ar.operator = osor.operator
+    GROUP BY ar.reward_hash, ar.operator        
+),
+
+-- Step 9: Divide amount to pay by the number of snapshots that the operator was registered
+active_rewards_with_registered_snapshots AS (
+    SELECT
+        arc.*,
+        COALESCE(nrs.num_registered_snapshots, 0) as num_registered_snapshots
+    FROM active_rewards_cleaned arc
+    LEFT JOIN op_set_op_num_registered_snapshots nrs
+    ON
+        arc.reward_hash = nrs.reward_hash
+        AND arc.operator = nrs.operator
+),
+
+-- Step 10: Divide amount to pay by the number of snapshots that the operator was registered
+active_rewards_final AS (
+    SELECT
+        ar.*,
+        CASE
+            -- If the operator was not registered for any snapshots, just get regular tokens per day to refund the AVS
+            WHEN ar.num_registered_snapshots = 0 THEN floor(ar.amount_decimal / (duration / 86400))
+            ELSE floor(ar.amount_decimal / ar.num_registered_snapshots)
+        END AS tokens_per_registered_snapshot_decimal
+    FROM active_rewards_with_registered_snapshots ar
+)
+
+SELECT * FROM active_rewards_final
+`
+
+// Generate11GoldActiveODOperatorSetRewards generates active operator-directed rewards for the gold_11_active_od_operator_set_rewards table
+//
+// @param snapshotDate: The upper bound of when to calculate rewards to
+// @param startDate: The lower bound of when to calculate rewards from. If we're running rewards for the first time,
+// this will be "1970-01-01". If this is a subsequent run, this will be the last snapshot date.
+func (r *RewardsCalculator) GenerateGold11ActiveODOperatorSetRewards(snapshotDate string) error {
+	rewardsV2_1Enabled, err := r.globalConfig.IsRewardsV2_1EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_1Enabled {
+		r.logger.Sugar().Infow("Rewards v2.1 is not enabled for this cutoff date, skipping Generate11GoldActiveODOperatorSetRewards")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards]
+
+	rewardsStart := "1970-01-01 00:00:00" // This will always start as this date and get's updated later in the query
+
+	r.logger.Sugar().Infow("Generating active rewards",
+		zap.String("rewardsStart", rewardsStart),
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_11_goldActiveODOperatorSetRewardsQuery, map[string]interface{}{
+		"destTableName": destTableName,
+		"rewardsStart":  rewardsStart,
+		"cutoffDate":    snapshotDate,
+	})
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := r.grm.Exec(query,
+		sql.Named("cutoffDate", snapshotDate),
+	)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to generate active od operator set rewards", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/12_goldOperatorODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/12_goldOperatorODOperatorSetRewardAmounts.go
@@ -1,0 +1,104 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _12_goldOperatorODOperatorSetRewardAmountsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- Step 1: Get the rows where operators have registered for the operator set
+WITH reward_snapshot_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot AS snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs AS avs,
+        ap.operator_set_id AS operator_set_id,
+        ap.operator AS operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    JOIN operator_set_operator_registration_snapshots osor
+        ON ap.avs = osor.avs 
+       AND ap.operator_set_id = osor.operator_set_id
+       AND ap.snapshot = osor.snapshot 
+       AND ap.operator = osor.operator
+),
+
+-- Step 2: Dedupe the operator tokens across strategies for each (operator, reward hash, snapshot)
+-- Since the above result is a flattened operator-directed reward submission across strategies.
+distinct_operators AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            -- We can use an arbitrary order here since the avs_tokens is the same for each (operator, strategy, hash, snapshot)
+            -- We use strategy ASC for better debuggability
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM reward_snapshot_operators
+    ) t
+    -- Keep only the first row for each (operator, reward hash, snapshot)
+    WHERE rn = 1
+),
+
+-- Step 3: Calculate the tokens for each operator with dynamic split logic
+-- If no split is found, default to 1000 (10%)
+operator_splits AS (
+    SELECT 
+        dop.*,
+        COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL) AS split_pct,
+        FLOOR(dop.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS operator_tokens
+    FROM distinct_operators dop
+    LEFT JOIN operator_set_split_snapshots oss
+        ON dop.operator = oss.operator 
+       AND dop.avs = oss.avs
+       AND dop.operator_set_id = oss.operator_set_id 
+       AND dop.snapshot = oss.snapshot
+    LEFT JOIN default_operator_split_snapshots dos ON (dop.snapshot = dos.snapshot)
+)
+
+-- Step 4: Output the final table with operator splits
+SELECT * FROM operator_splits
+`
+
+func (rc *RewardsCalculator) GenerateGold12OperatorODOperatorSetRewardAmountsTable(snapshotDate string) error {
+	rewardsV2_1Enabled, err := rc.globalConfig.IsRewardsV2_1EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_1Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.1 is not enabled for this cutoff date, skipping GenerateGold12OperatorODOperatorSetRewardAmountsTable")
+		return nil
+	}
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts]
+
+	rc.logger.Sugar().Infow("Generating Operator OD operator set reward amounts",
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_12_goldOperatorODOperatorSetRewardAmountsQuery, map[string]interface{}{
+		"destTableName":        destTableName,
+		"activeODRewardsTable": allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to create gold_operator_od_operator_set_reward_amounts", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/13_goldStakerODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/13_goldStakerODOperatorSetRewardAmounts.go
@@ -1,0 +1,167 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _13_goldStakerODOperatorSetRewardAmountsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- Step 1: Get the rows where operators have registered for the operator set
+WITH reward_snapshot_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot AS snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs AS avs,
+        ap.operator_set_id AS operator_set_id,
+        ap.operator AS operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    JOIN operator_set_operator_registration_snapshots osor
+        ON ap.avs = osor.avs 
+       AND ap.operator_set_id = osor.operator_set_id
+       AND ap.snapshot = osor.snapshot 
+       AND ap.operator = osor.operator
+),
+
+-- Get the rows where strategies have registered for the operator set
+operator_set_strategy_registrations AS (
+    SELECT
+        rso.*
+    FROM reward_snapshot_operators rso
+    JOIN operator_set_strategy_registration_snapshots ossr
+        ON rso.avs = ossr.avs 
+       AND rso.operator_set_id = ossr.operator_set_id
+       AND rso.snapshot = ossr.snapshot
+       AND rso.strategy = ossr.strategy
+),
+
+-- Calculate the total staker split for each operator reward with dynamic split logic
+-- If no split is found, default to 1000 (10%)
+staker_splits AS (
+    SELECT 
+        ossr.*,
+        ossr.tokens_per_registered_snapshot_decimal - FLOOR(ossr.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS staker_split
+    FROM operator_set_strategy_registrations ossr
+    LEFT JOIN operator_set_split_snapshots oss
+        ON ossr.operator = oss.operator 
+       AND ossr.avs = oss.avs 
+       AND ossr.operator_set_id = oss.operator_set_id
+       AND ossr.snapshot = oss.snapshot
+    LEFT JOIN default_operator_split_snapshots dos ON (ossr.snapshot = dos.snapshot)
+),
+
+-- Get the stakers that were delegated to the operator for the snapshot
+staker_delegated_operators AS (
+    SELECT
+        ors.*,
+        sds.staker
+    FROM staker_splits ors
+    JOIN staker_delegation_snapshots sds
+        ON ors.operator = sds.operator 
+       AND ors.snapshot = sds.snapshot
+),
+
+-- Get the shares for stakers delegated to the operator
+staker_strategy_shares AS (
+    SELECT
+        sdo.*,
+        sss.shares
+    FROM staker_delegated_operators sdo
+    JOIN staker_share_snapshots sss
+        ON sdo.staker = sss.staker 
+       AND sdo.snapshot = sss.snapshot 
+       AND sdo.strategy = sss.strategy
+    -- Filter out negative shares and zero multiplier to avoid division by zero
+    WHERE sss.shares > 0 AND sdo.multiplier != 0
+),
+
+-- Calculate the weight of each staker
+staker_weights AS (
+    SELECT 
+        *,
+        SUM(multiplier * shares) OVER (PARTITION BY staker, reward_hash, snapshot) AS staker_weight
+    FROM staker_strategy_shares
+),
+-- Get distinct stakers since their weights are already calculated
+distinct_stakers AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            -- We can use an arbitrary order here since the staker_weight is the same for each (staker, strategy, hash, snapshot)
+            -- We use strategy ASC for better debuggability
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, staker 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM staker_weights
+    ) t
+    WHERE rn = 1
+    ORDER BY reward_hash, snapshot, staker
+),
+-- Calculate the sum of all staker weights for each reward and snapshot
+staker_weight_sum AS (
+    SELECT 
+        *,
+        SUM(staker_weight) OVER (PARTITION BY reward_hash, operator, snapshot) AS total_weight
+    FROM distinct_stakers
+),
+-- Calculate staker proportion of tokens for each reward and snapshot
+staker_proportion AS (
+    SELECT 
+        *,
+        FLOOR((staker_weight / total_weight) * 1000000000000000) / 1000000000000000 AS staker_proportion
+    FROM staker_weight_sum
+),
+-- Calculate the staker reward amounts
+staker_reward_amounts AS (
+    SELECT 
+        *,
+        FLOOR(staker_proportion * staker_split) AS staker_tokens
+    FROM staker_proportion
+)
+-- Output the final table
+SELECT * FROM staker_reward_amounts
+`
+
+func (rc *RewardsCalculator) GenerateGold13StakerODOperatorSetRewardAmountsTable(snapshotDate string) error {
+	rewardsV2_1Enabled, err := rc.globalConfig.IsRewardsV2_1EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_1Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.1 is not enabled for this cutoff date, skipping GenerateGold13StakerODOperatorSetRewardAmountsTable")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts]
+
+	rc.logger.Sugar().Infow("Generating Staker OD operator set reward amounts",
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_13_goldStakerODOperatorSetRewardAmountsQuery, map[string]interface{}{
+		"destTableName":        destTableName,
+		"activeODRewardsTable": allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to create gold_staker_od_operator_set_reward_amounts", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
@@ -1,0 +1,99 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _14_goldAvsODOperatorSetRewardAmountsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- Step 1: Get the rows where operators have not registered for the AVS or if the AVS does not exist
+WITH reward_snapshot_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot AS snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs AS avs,
+        ap.operator_set_id AS operator_set_id,
+        ap.operator AS operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    WHERE
+        ap.num_registered_snapshots = 0
+),
+
+-- Step 2: Dedupe the operator tokens across strategies for each (operator, reward hash, snapshot)
+-- Since the above result is a flattened operator-directed reward submission across strategies
+distinct_operators AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            -- We can use an arbitrary order here since the avs_tokens is the same for each (operator, strategy, hash, snapshot)
+            -- We use strategy ASC for better debuggability
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM reward_snapshot_operators
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 3: Sum the operator tokens for each (reward hash, snapshot)
+-- Since we want to refund the sum of those operator amounts to the AVS in that reward submission for that snapshot
+operator_token_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_operators
+)
+
+-- Step 4: Output the final table
+SELECT * FROM operator_token_sums
+`
+
+func (rc *RewardsCalculator) GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate string) error {
+	rewardsV2_1Enabled, err := rc.globalConfig.IsRewardsV2_1EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_1Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.1 is not enabled for this cutoff date, skipping GenerateGold14AvsODOperatorSetRewardAmountsTable")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts]
+
+	rc.logger.Sugar().Infow("Generating Avs OD operator set reward amounts",
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_14_goldAvsODOperatorSetRewardAmountsQuery, map[string]interface{}{
+		"destTableName":        destTableName,
+		"activeODRewardsTable": allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to create gold_avs_od_operator_set_reward_amounts", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/15_goldStaging.go
+++ b/pkg/rewards/15_goldStaging.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const _11_goldStagingQuery = `
+const _15_goldStagingQuery = `
 create table {{.destTableName}} as
 WITH staker_rewards AS (
   -- We can select DISTINCT here because the staker's tokens are the same for each strategy in the reward hash
@@ -44,7 +44,7 @@ rewards_for_all_earners_stakers AS (
     snapshot,
     reward_hash,
     token,
-    staker_tokens as amounts
+    staker_tokens as amount
   FROM {{.rfaeStakerTable}}
 ),
 rewards_for_all_earners_operators AS (
@@ -88,6 +88,38 @@ avs_od_rewards AS (
   FROM {{.avsODRewardAmountsTable}}
 ),
 {{ end }}
+{{ if .enableRewardsV2_1 }}
+operator_od_operator_set_rewards AS (
+  SELECT DISTINCT
+    -- We can select DISTINCT here because the operator's tokens are the same for each strategy in the reward hash
+    operator as earner,
+    snapshot,
+    reward_hash,
+    token,
+    operator_tokens as amount
+  FROM {{.operatorODOperatorSetRewardAmountsTable}}
+),
+staker_od_operator_set_rewards AS (
+  SELECT DISTINCT
+    -- We can select DISTINCT here because the staker's tokens are the same for each strategy in the reward hash
+    staker as earner,
+    snapshot,
+    reward_hash,
+    token,
+    staker_tokens as amount
+  FROM {{.stakerODOperatorSetRewardAmountsTable}}
+),
+avs_od_operator_set_rewards AS (
+  SELECT DISTINCT
+    -- We can select DISTINCT here because the avs's tokens are the same for each strategy in the reward hash
+    avs as earner,
+    snapshot,
+    reward_hash,
+    token,
+    avs_tokens as amount
+  FROM {{.avsODOperatorSetRewardAmountsTable}}
+),
+{{ end }}
 combined_rewards AS (
   SELECT * FROM operator_rewards
   UNION ALL
@@ -105,6 +137,14 @@ combined_rewards AS (
   SELECT * FROM staker_od_rewards
   UNION ALL
   SELECT * FROM avs_od_rewards
+{{ end }}
+{{ if .enableRewardsV2_1 }}
+  UNION ALL
+  SELECT * FROM operator_od_operator_set_rewards
+  UNION ALL
+  SELECT * FROM staker_od_operator_set_rewards
+  UNION ALL
+  SELECT * FROM avs_od_operator_set_rewards
 {{ end }}
 ),
 -- Dedupe earners, primarily operators who are also their own staker.
@@ -126,9 +166,9 @@ SELECT *
 FROM deduped_earners
 `
 
-func (rc *RewardsCalculator) GenerateGold11StagingTable(snapshotDate string) error {
+func (rc *RewardsCalculator) GenerateGold15StagingTable(snapshotDate string) error {
 	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
-	destTableName := allTableNames[rewardsUtils.Table_11_GoldStaging]
+	destTableName := allTableNames[rewardsUtils.Table_15_GoldStaging]
 
 	rc.logger.Sugar().Infow("Generating gold staging",
 		zap.String("cutoffDate", snapshotDate),
@@ -142,17 +182,28 @@ func (rc *RewardsCalculator) GenerateGold11StagingTable(snapshotDate string) err
 	}
 	rc.logger.Sugar().Infow("Is RewardsV2 enabled?", "enabled", isRewardsV2Enabled)
 
-	query, err := rewardsUtils.RenderQueryTemplate(_11_goldStagingQuery, map[string]interface{}{
-		"destTableName":                destTableName,
-		"stakerRewardAmountsTable":     allTableNames[rewardsUtils.Table_2_StakerRewardAmounts],
-		"operatorRewardAmountsTable":   allTableNames[rewardsUtils.Table_3_OperatorRewardAmounts],
-		"rewardsForAllTable":           allTableNames[rewardsUtils.Table_4_RewardsForAll],
-		"rfaeStakerTable":              allTableNames[rewardsUtils.Table_5_RfaeStakers],
-		"rfaeOperatorTable":            allTableNames[rewardsUtils.Table_6_RfaeOperators],
-		"operatorODRewardAmountsTable": allTableNames[rewardsUtils.Table_8_OperatorODRewardAmounts],
-		"stakerODRewardAmountsTable":   allTableNames[rewardsUtils.Table_9_StakerODRewardAmounts],
-		"avsODRewardAmountsTable":      allTableNames[rewardsUtils.Table_10_AvsODRewardAmounts],
-		"enableRewardsV2":              isRewardsV2Enabled,
+	isRewardsV2_1Enabled, err := rc.globalConfig.IsRewardsV2_1EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Infow("Is RewardsV2_1 enabled?", "enabled", isRewardsV2_1Enabled)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_15_goldStagingQuery, map[string]interface{}{
+		"destTableName":                           destTableName,
+		"stakerRewardAmountsTable":                allTableNames[rewardsUtils.Table_2_StakerRewardAmounts],
+		"operatorRewardAmountsTable":              allTableNames[rewardsUtils.Table_3_OperatorRewardAmounts],
+		"rewardsForAllTable":                      allTableNames[rewardsUtils.Table_4_RewardsForAll],
+		"rfaeStakerTable":                         allTableNames[rewardsUtils.Table_5_RfaeStakers],
+		"rfaeOperatorTable":                       allTableNames[rewardsUtils.Table_6_RfaeOperators],
+		"operatorODRewardAmountsTable":            allTableNames[rewardsUtils.Table_8_OperatorODRewardAmounts],
+		"stakerODRewardAmountsTable":              allTableNames[rewardsUtils.Table_9_StakerODRewardAmounts],
+		"avsODRewardAmountsTable":                 allTableNames[rewardsUtils.Table_10_AvsODRewardAmounts],
+		"enableRewardsV2":                         isRewardsV2Enabled,
+		"operatorODOperatorSetRewardAmountsTable": allTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts],
+		"stakerODOperatorSetRewardAmountsTable":   allTableNames[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts],
+		"avsODOperatorSetRewardAmountsTable":      allTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts],
+		"enableRewardsV2_1":                       isRewardsV2_1Enabled,
 	})
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
@@ -188,7 +239,7 @@ func (rc *RewardsCalculator) ListGoldStagingRowsForSnapshot(snapshotDate string)
 		amount
 	FROM {{.goldStagingTable}} WHERE DATE(snapshot) < @cutoffDate`
 	query, err := rewardsUtils.RenderQueryTemplate(query, map[string]interface{}{
-		"goldStagingTable": allTableNames[rewardsUtils.Table_11_GoldStaging],
+		"goldStagingTable": allTableNames[rewardsUtils.Table_15_GoldStaging],
 	})
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)

--- a/pkg/rewards/16_goldFinal.go
+++ b/pkg/rewards/16_goldFinal.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const _12_goldFinalQuery = `
+const _16_goldFinalQuery = `
 insert into gold_table
 SELECT
     earner,
@@ -26,15 +26,15 @@ type GoldRow struct {
 	Amount     string
 }
 
-func (rc *RewardsCalculator) GenerateGold12FinalTable(snapshotDate string) error {
+func (rc *RewardsCalculator) GenerateGold16FinalTable(snapshotDate string) error {
 	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
 
 	rc.logger.Sugar().Infow("Generating gold final table",
 		zap.String("cutoffDate", snapshotDate),
 	)
 
-	query, err := rewardsUtils.RenderQueryTemplate(_12_goldFinalQuery, map[string]interface{}{
-		"goldStagingTable": allTableNames[rewardsUtils.Table_11_GoldStaging],
+	query, err := rewardsUtils.RenderQueryTemplate(_16_goldFinalQuery, map[string]interface{}{
+		"goldStagingTable": allTableNames[rewardsUtils.Table_15_GoldStaging],
 	})
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)

--- a/pkg/rewards/5_goldRfaeStakers.go
+++ b/pkg/rewards/5_goldRfaeStakers.go
@@ -10,11 +10,21 @@ import (
 
 const _5_goldRfaeStakersQuery = `
 create table {{.destTableName}} as
-WITH avs_opted_operators AS (
+WITH combined_operators AS (
   SELECT DISTINCT
     snapshot,
     operator
-  FROM operator_avs_registration_snapshots
+  FROM (
+    -- Always include AVS operators
+    SELECT snapshot, operator FROM operator_avs_registration_snapshots
+    UNION
+    -- Include operator set operators only after Mississippi hard fork
+    SELECT 
+      snapshot, 
+      operator 
+    FROM operator_set_operator_registration_snapshots
+    WHERE snapshot >= @mississippiForkDate
+  ) all_operators
 ),
 -- Get the operators who will earn rewards for the reward submission at the given snapshot
 reward_snapshot_operators as (
@@ -28,10 +38,10 @@ reward_snapshot_operators as (
     ap.multiplier,
     ap.reward_type,
     ap.reward_submission_date,
-    aoo.operator
+    co.operator
   FROM {{.activeRewardsTable}} ap
-  JOIN avs_opted_operators aoo
-  ON ap.snapshot = aoo.snapshot
+  JOIN combined_operators co
+  ON ap.snapshot = co.snapshot
   WHERE ap.reward_type = 'all_earners'
 ),
 -- Get the stakers that were delegated to the operator for the snapshot 
@@ -146,6 +156,7 @@ func (rc *RewardsCalculator) GenerateGold5RfaeStakersTable(snapshotDate string, 
 		zap.String("destTableName", destTableName),
 		zap.String("arnoHardforkDate", forks[config.RewardsFork_Arno]),
 		zap.String("trinityHardforkDate", forks[config.RewardsFork_Trinity]),
+		zap.String("mississippiForkDate", forks[config.RewardsFork_Mississippi]),
 	)
 
 	query, err := rewardsUtils.RenderQueryTemplate(_5_goldRfaeStakersQuery, map[string]interface{}{
@@ -162,6 +173,7 @@ func (rc *RewardsCalculator) GenerateGold5RfaeStakersTable(snapshotDate string, 
 		sql.Named("network", rc.globalConfig.Chain.String()),
 		sql.Named("arnoHardforkDate", forks[config.RewardsFork_Arno]),
 		sql.Named("trinityHardforkDate", forks[config.RewardsFork_Trinity]),
+		sql.Named("mississippiForkDate", forks[config.RewardsFork_Mississippi]),
 	)
 	if res.Error != nil {
 		rc.logger.Sugar().Errorw("Failed to generate gold_rfae_stakers", "error", res.Error)

--- a/pkg/rewards/5_goldRfaeStakers.go
+++ b/pkg/rewards/5_goldRfaeStakers.go
@@ -16,14 +16,19 @@ WITH combined_operators AS (
     operator
   FROM (
     -- Always include AVS operators
-    SELECT snapshot, operator FROM operator_avs_registration_snapshots
+    (
+      SELECT snapshot, operator 
+      FROM operator_avs_registration_snapshots
+    )
     UNION
     -- Include operator set operators only after Mississippi hard fork
-    SELECT 
-      snapshot, 
-      operator 
-    FROM operator_set_operator_registration_snapshots
-    WHERE snapshot >= @mississippiForkDate
+    (
+      SELECT 
+        snapshot, 
+        operator 
+      FROM operator_set_operator_registration_snapshots
+      WHERE snapshot >= @mississippiForkDate
+    )
   ) all_operators
 ),
 -- Get the operators who will earn rewards for the reward submission at the given snapshot

--- a/pkg/rewards/operatorDirectedOperatorSetRewards.go
+++ b/pkg/rewards/operatorDirectedOperatorSetRewards.go
@@ -3,46 +3,26 @@ package rewards
 import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
 
 const operatorDirectedOperatorSetRewardsQuery = `
-	with _operator_directed_operator_set_rewards as (
-		SELECT
-			odosrs.avs,
-			odosrs.operator_set_id,
-			odosrs.reward_hash,
-			odosrs.token,
-			odosrs.operator,
-			odosrs.operator_index,
-			odosrs.amount,
-			odosrs.strategy,
-			odosrs.strategy_index,
-			odosrs.multiplier,
-			odosrs.start_timestamp::TIMESTAMP(6),
-			odosrs.end_timestamp::TIMESTAMP(6),
-			odosrs.duration,
-			odosrs.block_number,
-			b.block_time::TIMESTAMP(6),
-			TO_CHAR(b.block_time, 'YYYY-MM-DD') AS block_date
-		FROM operator_directed_operator_set_reward_submissions AS odosrs
-		JOIN blocks AS b ON (b.number = odosrs.block_number)
-		WHERE b.block_time < TIMESTAMP '{{.cutoffDate}}'
-	)
-	select
-		avs,
-		operator_set_id,
-		reward_hash,
-		token,
-		operator,
-		operator_index,
-		amount,
-		strategy,
-		strategy_index,
-		multiplier,
-		start_timestamp::TIMESTAMP(6),
-		end_timestamp::TIMESTAMP(6),
-		duration,
-		block_number,
-		block_time,
-		block_date
-	from _operator_directed_operator_set_rewards
+SELECT
+	odosrs.avs,
+	odosrs.operator_set_id,
+	odosrs.reward_hash,
+	odosrs.token,
+	odosrs.operator,
+	odosrs.operator_index,
+	odosrs.amount,
+	odosrs.strategy,
+	odosrs.strategy_index,
+	odosrs.multiplier,
+	odosrs.start_timestamp::TIMESTAMP(6),
+	odosrs.end_timestamp::TIMESTAMP(6),
+	odosrs.duration,
+	odosrs.block_number,
+	b.block_time::TIMESTAMP(6),
+	TO_CHAR(b.block_time, 'YYYY-MM-DD') AS block_date
+FROM operator_directed_operator_set_reward_submissions AS odosrs
+JOIN blocks AS b ON (b.number = odosrs.block_number)
+WHERE b.block_time < TIMESTAMP '{{.cutoffDate}}'
 `
 
 func (r *RewardsCalculator) GenerateAndInsertOperatorDirectedOperatorSetRewards(snapshotDate string) error {

--- a/pkg/rewards/operatorDirectedOperatorSetRewards.go
+++ b/pkg/rewards/operatorDirectedOperatorSetRewards.go
@@ -1,0 +1,75 @@
+package rewards
+
+import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+
+const operatorDirectedOperatorSetRewardsQuery = `
+	with _operator_directed_operator_set_rewards as (
+		SELECT
+			odosrs.avs,
+			odosrs.operator_set_id,
+			odosrs.reward_hash,
+			odosrs.token,
+			odosrs.operator,
+			odosrs.operator_index,
+			odosrs.amount,
+			odosrs.strategy,
+			odosrs.strategy_index,
+			odosrs.multiplier,
+			odosrs.start_timestamp::TIMESTAMP(6),
+			odosrs.end_timestamp::TIMESTAMP(6),
+			odosrs.duration,
+			odosrs.block_number,
+			b.block_time::TIMESTAMP(6),
+			TO_CHAR(b.block_time, 'YYYY-MM-DD') AS block_date
+		FROM operator_directed_operator_set_reward_submissions AS odosrs
+		JOIN blocks AS b ON (b.number = odosrs.block_number)
+		WHERE b.block_time < TIMESTAMP '{{.cutoffDate}}'
+	)
+	select
+		avs,
+		operator_set_id,
+		reward_hash,
+		token,
+		operator,
+		operator_index,
+		amount,
+		strategy,
+		strategy_index,
+		multiplier,
+		start_timestamp::TIMESTAMP(6),
+		end_timestamp::TIMESTAMP(6),
+		duration,
+		block_number,
+		block_time,
+		block_date
+	from _operator_directed_operator_set_rewards
+`
+
+func (r *RewardsCalculator) GenerateAndInsertOperatorDirectedOperatorSetRewards(snapshotDate string) error {
+	tableName := "operator_directed_operator_set_rewards"
+
+	query, err := rewardsUtils.RenderQueryTemplate(operatorDirectedOperatorSetRewardsQuery, map[string]interface{}{
+		"cutoffDate": snapshotDate,
+	})
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to render rewards combined query", "error", err)
+		return err
+	}
+
+	err = r.generateAndInsertFromQuery(tableName, query, nil)
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to generate combined rewards", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (rc *RewardsCalculator) ListOperatorDirectedOperatorSetRewards() ([]*OperatorDirectedOperatorSetRewards, error) {
+	var operatorDirectedOperatorSetRewards []*OperatorDirectedOperatorSetRewards
+	res := rc.grm.Model(&OperatorDirectedOperatorSetRewards{}).Find(&operatorDirectedOperatorSetRewards)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to list combined rewards", "error", res.Error)
+		return nil, res.Error
+	}
+	return operatorDirectedOperatorSetRewards, nil
+}

--- a/pkg/rewards/operatorDirectedOperatorSetRewards_test.go
+++ b/pkg/rewards/operatorDirectedOperatorSetRewards_test.go
@@ -1,0 +1,156 @@
+package rewards
+
+import (
+	"testing"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/internal/logger"
+	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/postgres"
+	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+func setupOperatorDirectedOperatorSetRewards() (
+	string,
+	*config.Config,
+	*gorm.DB,
+	*zap.Logger,
+	error,
+) {
+	cfg := tests.GetConfig()
+	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
+
+	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
+
+	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
+	if err != nil {
+		return dbname, nil, nil, nil, err
+	}
+
+	return dbname, cfg, grm, l, nil
+}
+
+func teardownOperatorDirectedOperatorSetRewards(dbname string, cfg *config.Config, db *gorm.DB, l *zap.Logger) {
+	rawDb, _ := db.DB()
+	_ = rawDb.Close()
+
+	pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
+
+	if err := postgres.DeleteTestDatabase(pgConfig, dbname); err != nil {
+		l.Sugar().Errorw("Failed to delete test database", "error", err)
+	}
+}
+
+func hydrateOperatorDirectedOperatorSetRewardSubmissionsTable(grm *gorm.DB, l *zap.Logger) error {
+	query := `
+		INSERT INTO operator_directed_operator_set_reward_submissions (
+			avs, 
+			operator_set_id, 
+			reward_hash,
+			token,
+			operator,
+			operator_index,
+			amount,
+			strategy,
+			strategy_index,
+			multiplier,
+			start_timestamp,
+			end_timestamp,
+			duration,
+			description,
+			block_number,
+			transaction_hash,
+			log_index
+		)
+		VALUES (
+			'0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101',
+			1,
+			'0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9',
+			'0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24',
+			'0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1',
+			0,
+			'30000000000000000000000',
+			'0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c',
+			0,
+			'1000000000000000000',
+			to_timestamp(1725494400),
+			to_timestamp(1725494400 + 2419200),
+			2419200,
+			'test reward submission',
+			1477020,
+			'some hash',
+			12
+		)
+	`
+
+	res := grm.Exec(query)
+	if res.Error != nil {
+		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
+		return res.Error
+	}
+	return nil
+}
+
+func Test_OperatorDirectedOperatorSetRewards(t *testing.T) {
+	if !rewardsTestsEnabled() {
+		t.Skipf("Skipping %s", t.Name())
+		return
+	}
+
+	dbFileName, cfg, grm, l, err := setupOperatorDirectedOperatorSetRewards()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshotDate := "2024-12-09"
+
+	t.Run("Should hydrate blocks and operator_directed_operator_set_reward_submissions tables", func(t *testing.T) {
+		t.Log("Hydrating blocks")
+		totalBlockCount, err := hydrateRewardsV2Blocks(grm, l)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Log("Hydrating operator directed operator set reward submissions")
+		query := "select count(*) from blocks"
+		var count int
+		res := grm.Raw(query).Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, totalBlockCount, count)
+
+		err = hydrateOperatorDirectedOperatorSetRewardSubmissionsTable(grm, l)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		query = "select count(*) from operator_directed_operator_set_reward_submissions"
+		res = grm.Raw(query).Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("Should generate the proper operatorDirectedOperatorSetRewards", func(t *testing.T) {
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		rewards, _ := NewRewardsCalculator(cfg, grm, nil, sog, l)
+
+		err = rewards.GenerateAndInsertOperatorDirectedOperatorSetRewards(snapshotDate)
+		assert.Nil(t, err)
+
+		operatorDirectedOperatorSetRewards, err := rewards.ListOperatorDirectedOperatorSetRewards()
+		assert.Nil(t, err)
+
+		assert.NotNil(t, operatorDirectedOperatorSetRewards)
+
+		t.Logf("Generated %d operatorDirectedOperatorSetRewards", len(operatorDirectedOperatorSetRewards))
+
+		assert.Equal(t, 1, len(operatorDirectedOperatorSetRewards))
+	})
+
+	t.Cleanup(func() {
+		teardownOperatorDirectedOperatorSetRewards(dbFileName, cfg, grm, l)
+	})
+}

--- a/pkg/rewards/operatorDirectedOperatorSetRewards_test.go
+++ b/pkg/rewards/operatorDirectedOperatorSetRewards_test.go
@@ -2,10 +2,12 @@ package rewards
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions"
 	"github.com/Layr-Labs/sidecar/pkg/postgres"
 	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
 	"github.com/stretchr/testify/assert"
@@ -45,51 +47,33 @@ func teardownOperatorDirectedOperatorSetRewards(dbname string, cfg *config.Confi
 }
 
 func hydrateOperatorDirectedOperatorSetRewardSubmissionsTable(grm *gorm.DB, l *zap.Logger) error {
-	query := `
-		INSERT INTO operator_directed_operator_set_reward_submissions (
-			avs, 
-			operator_set_id, 
-			reward_hash,
-			token,
-			operator,
-			operator_index,
-			amount,
-			strategy,
-			strategy_index,
-			multiplier,
-			start_timestamp,
-			end_timestamp,
-			duration,
-			description,
-			block_number,
-			transaction_hash,
-			log_index
-		)
-		VALUES (
-			'0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101',
-			1,
-			'0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9',
-			'0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24',
-			'0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1',
-			0,
-			'30000000000000000000000',
-			'0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c',
-			0,
-			'1000000000000000000',
-			to_timestamp(1725494400),
-			to_timestamp(1725494400 + 2419200),
-			2419200,
-			'test reward submission',
-			1477020,
-			'some hash',
-			12
-		)
-	`
+	startTime := time.Unix(1725494400, 0)
+	endTime := time.Unix(1725494400+2419200, 0)
 
-	res := grm.Exec(query)
-	if res.Error != nil {
-		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
-		return res.Error
+	reward := operatorDirectedOperatorSetRewardSubmissions.OperatorDirectedOperatorSetRewardSubmission{
+		Avs:             "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101",
+		OperatorSetId:   1,
+		RewardHash:      "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9",
+		Token:           "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24",
+		Operator:        "0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1",
+		OperatorIndex:   0,
+		Amount:          "30000000000000000000000",
+		Strategy:        "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c",
+		StrategyIndex:   0,
+		Multiplier:      "1000000000000000000",
+		StartTimestamp:  &startTime,
+		EndTimestamp:    &endTime,
+		Duration:        2419200,
+		Description:     "test reward submission",
+		BlockNumber:     1477020,
+		TransactionHash: "some hash",
+		LogIndex:        12,
+	}
+
+	result := grm.Create(&reward)
+	if result.Error != nil {
+		l.Sugar().Errorw("Failed to create operator directed operator set reward submission", "error", result.Error)
+		return result.Error
 	}
 	return nil
 }

--- a/pkg/rewards/operatorSetOperatorRegistrationSnapshots.go
+++ b/pkg/rewards/operatorSetOperatorRegistrationSnapshots.go
@@ -1,0 +1,134 @@
+package rewards
+
+import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+
+// Operator Set Operator Registration Windows: Ranges at which an operator has registered for an operator set
+// 1. Marked_statuses: Denote which registration status comes after one another
+// 2. Removed_same_day_deregistrations: Remove a pairs of (registration, deregistration) that happen on the same day
+// 3. Registration_periods: Combine registration together, only select registrations with:
+// a. (Registered, Unregistered)
+// b. (Registered, Null). If null, the end time is the current timestamp
+// 4. Registration_snapshots: Round up each start_time to  0 UTC on NEXT DAY and round down each end_time to 0 UTC on CURRENT DAY
+// 5. Operator_set_operator_registration_windows: Ranges that start and end on same day are invalid
+// Note: We cannot assume that the operator is registered for operator set at end_time because it is
+// Payments calculations should only be done on snapshots from the PREVIOUS DAY. For example say we have the following:
+// <-----0-------1-------2------3------>
+// ^           ^
+// Entry        Exit
+// Since exits (deregistrations) are rounded down, we must only look at the day 2 snapshot on a pipeline run on day 3.
+const operatorSetOperatorRegistrationSnapshotsQuery = `
+WITH state_changes as (
+	select
+		osor.*,
+		b.block_time::timestamp(6) as block_time,
+		to_char(b.block_time, 'YYYY-MM-DD') AS block_date
+	from operator_set_operator_registrations as osor
+	join blocks as b on (b.number = osor.block_number)
+	where b.block_time < TIMESTAMP '{{.cutoffDate}}'
+),
+marked_statuses AS (
+    SELECT
+        operator,
+        avs,
+		operator_set_id,
+        is_active,
+        block_time,
+        block_date,
+        -- Mark the next action as next_block_time
+        LEAD(block_time) OVER (PARTITION BY operator, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS next_block_time,
+        -- The below lead/lag combinations are only used in the next CTE
+        -- Get the next row's registered status and block_date
+        LEAD(is_active) OVER (PARTITION BY operator, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS next_is_active,
+        LEAD(block_date) OVER (PARTITION BY operator, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS next_block_date,
+        -- Get the previous row's registered status and block_date
+        LAG(is_active) OVER (PARTITION BY operator, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS prev_is_active,
+        LAG(block_date) OVER (PARTITION BY operator, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS prev_block_date
+    FROM state_changes
+),
+-- Ignore a (registration,deregistration) pairs that happen on the exact same date
+ removed_same_day_deregistrations AS (
+	 SELECT * from marked_statuses
+	 WHERE NOT (
+		 -- Remove the registration part
+		 (is_active = TRUE AND
+		  COALESCE(next_is_active = FALSE, false) AND -- default to false if null
+		  COALESCE(block_date = next_block_date, false)) OR
+			 -- Remove the deregistration part
+		 (is_active = FALSE AND
+		  COALESCE(prev_is_active = TRUE, false) and
+		  COALESCE(block_date = prev_block_date, false)
+			 )
+		 )
+ ),
+-- Combine corresponding registrations into a single record
+-- start_time is the beginning of the record
+ registration_periods AS (
+	SELECT
+		operator,
+		avs,
+		operator_set_id,
+		block_time AS start_time,
+		-- Mark the next_block_time as the end_time for the range
+		-- Use coalesce because if the next_block_time for a registration is not closed, then we use cutoff_date
+		COALESCE(next_block_time, '{{.cutoffDate}}')::timestamp AS end_time,
+		is_active
+	FROM removed_same_day_deregistrations
+	WHERE is_active = TRUE
+ ),
+-- Round UP each start_time and round DOWN each end_time
+registration_windows_extra as (
+	SELECT
+		operator,
+		avs,
+		operator_set_id,
+		date_trunc('day', start_time) + interval '1' day as start_time,
+		-- End time is end time non inclusive becuase the strategy is not registered on the operator set at the end time OR it is current timestamp rounded up
+		date_trunc('day', end_time) as end_time
+	FROM registration_periods
+),
+-- Ignore start_time and end_time that last less than a day
+operator_set_operator_registration_windows as (
+	 SELECT * from registration_windows_extra
+	 WHERE start_time != end_time
+),
+cleaned_records AS (
+	SELECT * FROM operator_set_operator_registration_windows
+	WHERE start_time < end_time
+)
+SELECT
+	operator,
+	avs,
+	operator_set_id,
+	d AS snapshot
+FROM cleaned_records
+CROSS JOIN generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS d
+`
+
+func (r *RewardsCalculator) GenerateAndInsertOperatorSetOperatorRegistrationSnapshots(snapshotDate string) error {
+	tableName := "operator_set_operator_registration_snapshots"
+
+	query, err := rewardsUtils.RenderQueryTemplate(operatorSetOperatorRegistrationSnapshotsQuery, map[string]interface{}{
+		"cutoffDate": snapshotDate,
+	})
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to render operator set operator registration snapshots query", "error", err)
+		return err
+	}
+
+	err = r.generateAndInsertFromQuery(tableName, query, nil)
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_set_operator_registration_snapshots", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (rc *RewardsCalculator) ListOperatorSetOperatorRegistrationSnapshots() ([]*OperatorSetOperatorRegistrationSnapshots, error) {
+	var operatorSetOperatorRegistrationSnapshots []*OperatorSetOperatorRegistrationSnapshots
+	res := rc.grm.Model(&OperatorSetOperatorRegistrationSnapshots{}).Find(&operatorSetOperatorRegistrationSnapshots)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to list operator set operator registration snapshots", "error", res.Error)
+		return nil, res.Error
+	}
+	return operatorSetOperatorRegistrationSnapshots, nil
+}

--- a/pkg/rewards/operatorSetOperatorRegistrationSnapshots_test.go
+++ b/pkg/rewards/operatorSetOperatorRegistrationSnapshots_test.go
@@ -1,0 +1,128 @@
+package rewards
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/internal/logger"
+	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/postgres"
+	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+func setupOperatorSetOperatorRegistrationSnapshot() (
+	string,
+	*config.Config,
+	*gorm.DB,
+	*zap.Logger,
+	error,
+) {
+	testContext := getRewardsTestContext()
+	cfg := tests.GetConfig()
+	switch testContext {
+	case "testnet":
+		cfg.Chain = config.Chain_Holesky
+	case "testnet-reduced":
+		cfg.Chain = config.Chain_Holesky
+	case "mainnet-reduced":
+		cfg.Chain = config.Chain_Mainnet
+	default:
+		return "", nil, nil, nil, fmt.Errorf("Unknown test context")
+	}
+
+	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
+
+	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
+
+	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
+	if err != nil {
+		return dbname, nil, nil, nil, err
+	}
+
+	return dbname, cfg, grm, l, nil
+}
+
+func teardownOperatorSetOperatorRegistrationSnapshot(dbname string, cfg *config.Config, db *gorm.DB, l *zap.Logger) {
+	rawDb, _ := db.DB()
+	_ = rawDb.Close()
+
+	pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
+
+	if err := postgres.DeleteTestDatabase(pgConfig, dbname); err != nil {
+		l.Sugar().Errorw("Failed to delete test database", "error", err)
+	}
+}
+
+func hydrateOperatorSetOperatorRegistrationsTable(grm *gorm.DB, l *zap.Logger) error {
+	query := `
+		INSERT INTO operator_set_operator_registrations (operator, avs, operator_set_id, is_active, block_number, transaction_hash, log_index)
+		VALUES ('0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101', '0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1', 1, true, 1477020, '0xccc83cdfa365bacff5e4099b9931bccaec1c0b0cf37cd324c92c27b5cb5387d1', 545)
+	`
+
+	res := grm.Exec(query)
+	if res.Error != nil {
+		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
+		return res.Error
+	}
+	return nil
+}
+
+func Test_OperatorSetOperatorRegistrationSnapshots(t *testing.T) {
+	if !rewardsTestsEnabled() {
+		t.Skipf("Skipping %s", t.Name())
+		return
+	}
+
+	// projectRoot := getProjectRootPath()
+	dbFileName, cfg, grm, l, err := setupOperatorSetOperatorRegistrationSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// testContext := getRewardsTestContext()
+
+	snapshotDate := "2024-12-09"
+
+	t.Run("Should hydrate dependency tables", func(t *testing.T) {
+		t.Log("Hydrating blocks")
+
+		_, err := hydrateRewardsV2Blocks(grm, l)
+		assert.Nil(t, err)
+
+		t.Log("Hydrating operator set operator registrations")
+		err = hydrateOperatorSetOperatorRegistrationsTable(grm, l)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		query := `select count(*) from operator_set_operator_registrations`
+		var count int
+		res := grm.Raw(query).Scan(&count)
+
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("Should generate the proper operatorSetOperatorRegistrationSnapshots", func(t *testing.T) {
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		rewards, _ := NewRewardsCalculator(cfg, grm, nil, sog, l)
+
+		err := rewards.GenerateAndInsertOperatorSetOperatorRegistrationSnapshots(snapshotDate)
+		assert.Nil(t, err)
+
+		snapshots, err := rewards.ListOperatorSetOperatorRegistrationSnapshots()
+		assert.Nil(t, err)
+
+		t.Logf("Found %d snapshots", len(snapshots))
+
+		assert.Equal(t, 218, len(snapshots))
+	})
+
+	t.Cleanup(func() {
+		teardownOperatorSetOperatorRegistrationSnapshot(dbFileName, cfg, grm, l)
+	})
+}

--- a/pkg/rewards/operatorSetOperatorRegistrationSnapshots_test.go
+++ b/pkg/rewards/operatorSetOperatorRegistrationSnapshots_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/eigenState/operatorSetOperatorRegistrations"
 	"github.com/Layr-Labs/sidecar/pkg/postgres"
 	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
 	"github.com/stretchr/testify/assert"
@@ -58,15 +59,20 @@ func teardownOperatorSetOperatorRegistrationSnapshot(dbname string, cfg *config.
 }
 
 func hydrateOperatorSetOperatorRegistrationsTable(grm *gorm.DB, l *zap.Logger) error {
-	query := `
-		INSERT INTO operator_set_operator_registrations (operator, avs, operator_set_id, is_active, block_number, transaction_hash, log_index)
-		VALUES ('0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101', '0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1', 1, true, 1477020, '0xccc83cdfa365bacff5e4099b9931bccaec1c0b0cf37cd324c92c27b5cb5387d1', 545)
-	`
+	registration := operatorSetOperatorRegistrations.OperatorSetOperatorRegistration{
+		Operator:        "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101",
+		Avs:             "0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1",
+		OperatorSetId:   1,
+		IsActive:        true,
+		BlockNumber:     1477020,
+		TransactionHash: "0xccc83cdfa365bacff5e4099b9931bccaec1c0b0cf37cd324c92c27b5cb5387d1",
+		LogIndex:        545,
+	}
 
-	res := grm.Exec(query)
-	if res.Error != nil {
-		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
-		return res.Error
+	result := grm.Create(&registration)
+	if result.Error != nil {
+		l.Sugar().Errorw("Failed to create operator set operator registration", "error", result.Error)
+		return result.Error
 	}
 	return nil
 }

--- a/pkg/rewards/operatorSetSplitSnapshots.go
+++ b/pkg/rewards/operatorSetSplitSnapshots.go
@@ -1,0 +1,98 @@
+package rewards
+
+import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+
+const operatorSetSplitSnapshotQuery = `
+WITH operator_set_splits_with_block_info as (
+	select
+		oss.operator,
+		oss.avs,
+		oss.operator_set_id,
+		oss.activated_at::timestamp(6) as activated_at,
+		oss.new_operator_set_split_bips as split,
+		oss.block_number,
+		oss.log_index,
+		b.block_time::timestamp(6) as block_time
+	from operator_set_splits as oss
+	join blocks as b on (b.number = oss.block_number)
+	where activated_at < TIMESTAMP '{{.cutoffDate}}'
+),
+-- Rank the records for each combination of (operator, avs, operator_set_id, activation date) by activation time, block time and log index
+ranked_operator_set_split_records as (
+	SELECT
+	    *,
+		ROW_NUMBER() OVER (PARTITION BY operator, avs, operator_set_id, cast(activated_at AS DATE) ORDER BY activated_at DESC, block_time DESC, log_index DESC) AS rn
+	FROM operator_set_splits_with_block_info
+),
+-- Get the latest record for each day & round up to the snapshot day
+snapshotted_records as (
+ SELECT
+	 operator,
+	 avs,
+	 operator_set_id,
+	 split,
+	 block_time,
+	 date_trunc('day', activated_at) + INTERVAL '1' day AS snapshot_time
+ from ranked_operator_set_split_records
+ where rn = 1
+),
+-- Get the range for each (operator, avs, operator_set_id) grouping
+operator_set_split_windows as (
+ SELECT
+	 operator, avs, operator_set_id, split, snapshot_time as start_time,
+	 CASE
+		 -- If the range does not have the end, use the current timestamp truncated to 0 UTC
+		 WHEN LEAD(snapshot_time) OVER (PARTITION BY operator, avs, operator_set_id ORDER BY snapshot_time) is null THEN date_trunc('day', TIMESTAMP '{{.cutoffDate}}')
+		 ELSE LEAD(snapshot_time) OVER (PARTITION BY operator, avs, operator_set_id ORDER BY snapshot_time)
+		 END AS end_time
+ FROM snapshotted_records
+),
+-- Clean up any records where start_time >= end_time
+cleaned_records as (
+  SELECT * FROM operator_set_split_windows
+  WHERE start_time < end_time
+),
+-- Generate a snapshot for each day in the range
+final_results as (
+	SELECT
+		operator,
+		avs,
+		operator_set_id,
+		split,
+		d AS snapshot
+	FROM
+		cleaned_records
+			CROSS JOIN
+		generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS d
+)
+select * from final_results
+`
+
+func (r *RewardsCalculator) GenerateAndInsertOperatorSetSplitSnapshots(snapshotDate string) error {
+	tableName := "operator_set_split_snapshots"
+
+	query, err := rewardsUtils.RenderQueryTemplate(operatorSetSplitSnapshotQuery, map[string]interface{}{
+		"cutoffDate": snapshotDate,
+	})
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	err = r.generateAndInsertFromQuery(tableName, query, nil)
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_set_split_snapshots", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (r *RewardsCalculator) ListOperatorSetSplitSnapshots() ([]*OperatorSetSplitSnapshots, error) {
+	var snapshots []*OperatorSetSplitSnapshots
+	res := r.grm.Model(&OperatorSetSplitSnapshots{}).Find(&snapshots)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to list operator set split snapshots", "error", res.Error)
+		return nil, res.Error
+	}
+	return snapshots, nil
+}

--- a/pkg/rewards/operatorSetSplitSnapshots_test.go
+++ b/pkg/rewards/operatorSetSplitSnapshots_test.go
@@ -1,0 +1,128 @@
+package rewards
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/internal/logger"
+	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/postgres"
+	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+func setupOperatorSetSplitWindows() (
+	string,
+	*config.Config,
+	*gorm.DB,
+	*zap.Logger,
+	error,
+) {
+	testContext := getRewardsTestContext()
+	cfg := tests.GetConfig()
+	switch testContext {
+	case "testnet":
+		cfg.Chain = config.Chain_Holesky
+	case "testnet-reduced":
+		cfg.Chain = config.Chain_Holesky
+	case "mainnet-reduced":
+		cfg.Chain = config.Chain_Mainnet
+	default:
+		return "", nil, nil, nil, fmt.Errorf("Unknown test context")
+	}
+
+	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
+
+	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
+
+	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
+	if err != nil {
+		return dbname, nil, nil, nil, err
+	}
+
+	return dbname, cfg, grm, l, nil
+}
+
+func teardownOperatorSetSplitWindows(dbname string, cfg *config.Config, db *gorm.DB, l *zap.Logger) {
+	rawDb, _ := db.DB()
+	_ = rawDb.Close()
+
+	pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
+
+	if err := postgres.DeleteTestDatabase(pgConfig, dbname); err != nil {
+		l.Sugar().Errorw("Failed to delete test database", "error", err)
+	}
+}
+
+func hydrateOperatorSetSplits(grm *gorm.DB, l *zap.Logger) error {
+	query := `
+		INSERT INTO operator_set_splits (operator, avs, operator_set_id, activated_at, old_operator_set_split_bips, new_operator_set_split_bips, block_number, transaction_hash, log_index)
+		VALUES ('0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101', '0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1', 1, '2024-12-05 12:00:00.000000', 1000, 500, 1477020, '0xccc83cdfa365bacff5e4099b9931bccaec1c0b0cf37cd324c92c27b5cb5387d1', 545)
+	`
+
+	res := grm.Exec(query)
+	if res.Error != nil {
+		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
+		return res.Error
+	}
+	return nil
+}
+
+func Test_OperatorSetSplitSnapshots(t *testing.T) {
+	if !rewardsTestsEnabled() {
+		t.Skipf("Skipping %s", t.Name())
+		return
+	}
+
+	// projectRoot := getProjectRootPath()
+	dbFileName, cfg, grm, l, err := setupOperatorSetSplitWindows()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// testContext := getRewardsTestContext()
+
+	snapshotDate := "2024-12-09"
+
+	t.Run("Should hydrate dependency tables", func(t *testing.T) {
+		t.Log("Hydrating blocks")
+
+		_, err := hydrateRewardsV2Blocks(grm, l)
+		assert.Nil(t, err)
+
+		t.Log("Hydrating restaked strategies")
+		err = hydrateOperatorSetSplits(grm, l)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		query := `select count(*) from operator_set_splits`
+		var count int
+		res := grm.Raw(query).Scan(&count)
+
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("Should calculate correct operatorSetSplit windows", func(t *testing.T) {
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		rewards, _ := NewRewardsCalculator(cfg, grm, nil, sog, l)
+
+		t.Log("Generating snapshots")
+		err := rewards.GenerateAndInsertOperatorSetSplitSnapshots(snapshotDate)
+		assert.Nil(t, err)
+
+		windows, err := rewards.ListOperatorSetSplitSnapshots()
+		assert.Nil(t, err)
+
+		t.Logf("Found %d windows", len(windows))
+
+		assert.Equal(t, 3, len(windows))
+	})
+	t.Cleanup(func() {
+		teardownOperatorSetSplitWindows(dbFileName, cfg, grm, l)
+	})
+}

--- a/pkg/rewards/operatorSetStrategyRegistrationSnapshots.go
+++ b/pkg/rewards/operatorSetStrategyRegistrationSnapshots.go
@@ -1,0 +1,134 @@
+package rewards
+
+import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+
+// Operator Set Strategy Registration Windows: Ranges at which a strategy has registered for an operator set
+// 1. Marked_statuses: Denote which registration status comes after one another
+// 2. Removed_same_day_deregistrations: Remove a pairs of (registration, deregistration) that happen on the same day
+// 3. Registration_periods: Combine registration together, only select registrations with:
+// a. (Registered, Unregistered)
+// b. (Registered, Null). If null, the end time is the current timestamp
+// 4. Registration_snapshots: Round up each start_time to  0 UTC on NEXT DAY and round down each end_time to 0 UTC on CURRENT DAY
+// 5. Operator_set_strategy_registration_windows: Ranges that start and end on same day are invalid
+// Note: We cannot assume that the strategy is registered for operator set at end_time because it is
+// Payments calculations should only be done on snapshots from the PREVIOUS DAY. For example say we have the following:
+// <-----0-------1-------2------3------>
+// ^           ^
+// Entry        Exit
+// Since exits (deregistrations) are rounded down, we must only look at the day 2 snapshot on a pipeline run on day 3.
+const operatorSetStrategyRegistrationSnapshotsQuery = `
+WITH state_changes as (
+	select
+		ossr.*,
+		b.block_time::timestamp(6) as block_time,
+		to_char(b.block_time, 'YYYY-MM-DD') AS block_date
+	from operator_set_strategy_registrations as ossr
+	join blocks as b on (b.number = ossr.block_number)
+	where b.block_time < TIMESTAMP '{{.cutoffDate}}'
+),
+marked_statuses AS (
+    SELECT
+        strategy,
+        avs,
+		operator_set_id,
+        is_active,
+        block_time,
+        block_date,
+        -- Mark the next action as next_block_time
+        LEAD(block_time) OVER (PARTITION BY strategy, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS next_block_time,
+        -- The below lead/lag combinations are only used in the next CTE
+        -- Get the next row's registered status and block_date
+        LEAD(is_active) OVER (PARTITION BY strategy, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS next_is_active,
+        LEAD(block_date) OVER (PARTITION BY strategy, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS next_block_date,
+        -- Get the previous row's registered status and block_date
+        LAG(is_active) OVER (PARTITION BY strategy, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS prev_is_active,
+        LAG(block_date) OVER (PARTITION BY strategy, avs, operator_set_id ORDER BY block_time ASC, log_index ASC) AS prev_block_date
+    FROM state_changes
+),
+-- Ignore a (registration,deregistration) pairs that happen on the exact same date
+ removed_same_day_deregistrations AS (
+	 SELECT * from marked_statuses
+	 WHERE NOT (
+		 -- Remove the registration part
+		 (is_active = TRUE AND
+		  COALESCE(next_is_active = FALSE, false) AND -- default to false if null
+		  COALESCE(block_date = next_block_date, false)) OR
+			 -- Remove the deregistration part
+		 (is_active = FALSE AND
+		  COALESCE(prev_is_active = TRUE, false) and
+		  COALESCE(block_date = prev_block_date, false)
+			 )
+		 )
+ ),
+-- Combine corresponding registrations into a single record
+-- start_time is the beginning of the record
+ registration_periods AS (
+	SELECT
+		strategy,
+		avs,
+		operator_set_id,
+		block_time AS start_time,
+		-- Mark the next_block_time as the end_time for the range
+		-- Use coalesce because if the next_block_time for a registration is not closed, then we use cutoff_date
+		COALESCE(next_block_time, '{{.cutoffDate}}')::timestamp AS end_time,
+		is_active
+	FROM removed_same_day_deregistrations
+	WHERE is_active = TRUE
+ ),
+-- Round UP each start_time and round DOWN each end_time
+registration_windows_extra as (
+	SELECT
+		strategy,
+		avs,
+		operator_set_id,
+		date_trunc('day', start_time) + interval '1' day as start_time,
+		-- End time is end time non inclusive becuase the strategy is not registered on the operator set at the end time OR it is current timestamp rounded up
+		date_trunc('day', end_time) as end_time
+	FROM registration_periods
+),
+-- Ignore start_time and end_time that last less than a day
+operator_set_strategy_registration_windows as (
+	 SELECT * from registration_windows_extra
+	 WHERE start_time != end_time
+),
+cleaned_records AS (
+	SELECT * FROM operator_set_strategy_registration_windows
+	WHERE start_time < end_time
+)
+SELECT
+	strategy,
+	avs,
+	operator_set_id,
+	d AS snapshot
+FROM cleaned_records
+CROSS JOIN generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS d
+`
+
+func (r *RewardsCalculator) GenerateAndInsertOperatorSetStrategyRegistrationSnapshots(snapshotDate string) error {
+	tableName := "operator_set_strategy_registration_snapshots"
+
+	query, err := rewardsUtils.RenderQueryTemplate(operatorSetStrategyRegistrationSnapshotsQuery, map[string]interface{}{
+		"cutoffDate": snapshotDate,
+	})
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to render operator set operator registration snapshots query", "error", err)
+		return err
+	}
+
+	err = r.generateAndInsertFromQuery(tableName, query, nil)
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_set_strategy_registration_snapshots", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (rc *RewardsCalculator) ListOperatorSetStrategyRegistrationSnapshots() ([]*OperatorSetStrategyRegistrationSnapshots, error) {
+	var operatorSetStrategyRegistrationSnapshots []*OperatorSetStrategyRegistrationSnapshots
+	res := rc.grm.Model(&OperatorSetStrategyRegistrationSnapshots{}).Find(&operatorSetStrategyRegistrationSnapshots)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to list operator set strategy registration snapshots", "error", res.Error)
+		return nil, res.Error
+	}
+	return operatorSetStrategyRegistrationSnapshots, nil
+}

--- a/pkg/rewards/operatorSetStrategyRegistrationSnapshots_test.go
+++ b/pkg/rewards/operatorSetStrategyRegistrationSnapshots_test.go
@@ -119,7 +119,7 @@ func Test_OperatorSetStrategyRegistrationSnapshots(t *testing.T) {
 
 		t.Logf("Found %d snapshots", len(snapshots))
 
-		assert.Equal(t, 218, len(snapshots))
+		assert.Equal(t, 219, len(snapshots))
 	})
 
 	t.Cleanup(func() {

--- a/pkg/rewards/operatorSetStrategyRegistrationSnapshots_test.go
+++ b/pkg/rewards/operatorSetStrategyRegistrationSnapshots_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/eigenState/operatorSetStrategyRegistrations"
 	"github.com/Layr-Labs/sidecar/pkg/postgres"
 	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
 	"github.com/stretchr/testify/assert"
@@ -58,15 +59,20 @@ func teardownOperatorSetStrategyRegistrationSnapshot(dbname string, cfg *config.
 }
 
 func hydrateOperatorSetStrategyRegistrationsTable(grm *gorm.DB, l *zap.Logger) error {
-	query := `
-		INSERT INTO operator_set_strategy_registrations (strategy, avs, operator_set_id, is_active, block_number, transaction_hash, log_index)
-		VALUES ('0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101', '0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1', 1, true, 1477020, '0xccc83cdfa365bacff5e4099b9931bccaec1c0b0cf37cd324c92c27b5cb5387d1', 545)
-	`
+	registration := operatorSetStrategyRegistrations.OperatorSetStrategyRegistration{
+		Strategy:        "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101",
+		Avs:             "0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1",
+		OperatorSetId:   1,
+		IsActive:        true,
+		BlockNumber:     1477020,
+		TransactionHash: "0xccc83cdfa365bacff5e4099b9931bccaec1c0b0cf37cd324c92c27b5cb5387d1",
+		LogIndex:        545,
+	}
 
-	res := grm.Exec(query)
-	if res.Error != nil {
-		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
-		return res.Error
+	result := grm.Create(&registration)
+	if result.Error != nil {
+		l.Sugar().Errorw("Failed to create operator set strategy registration", "error", result.Error)
+		return result.Error
 	}
 	return nil
 }

--- a/pkg/rewards/operatorSetStrategyRegistrationSnapshots_test.go
+++ b/pkg/rewards/operatorSetStrategyRegistrationSnapshots_test.go
@@ -1,0 +1,128 @@
+package rewards
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/internal/logger"
+	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/postgres"
+	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+func setupOperatorSetStrategyRegistrationSnapshot() (
+	string,
+	*config.Config,
+	*gorm.DB,
+	*zap.Logger,
+	error,
+) {
+	testContext := getRewardsTestContext()
+	cfg := tests.GetConfig()
+	switch testContext {
+	case "testnet":
+		cfg.Chain = config.Chain_Holesky
+	case "testnet-reduced":
+		cfg.Chain = config.Chain_Holesky
+	case "mainnet-reduced":
+		cfg.Chain = config.Chain_Mainnet
+	default:
+		return "", nil, nil, nil, fmt.Errorf("Unknown test context")
+	}
+
+	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
+
+	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
+
+	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
+	if err != nil {
+		return dbname, nil, nil, nil, err
+	}
+
+	return dbname, cfg, grm, l, nil
+}
+
+func teardownOperatorSetStrategyRegistrationSnapshot(dbname string, cfg *config.Config, db *gorm.DB, l *zap.Logger) {
+	rawDb, _ := db.DB()
+	_ = rawDb.Close()
+
+	pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
+
+	if err := postgres.DeleteTestDatabase(pgConfig, dbname); err != nil {
+		l.Sugar().Errorw("Failed to delete test database", "error", err)
+	}
+}
+
+func hydrateOperatorSetStrategyRegistrationsTable(grm *gorm.DB, l *zap.Logger) error {
+	query := `
+		INSERT INTO operator_set_strategy_registrations (strategy, avs, operator_set_id, is_active, block_number, transaction_hash, log_index)
+		VALUES ('0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101', '0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1', 1, true, 1477020, '0xccc83cdfa365bacff5e4099b9931bccaec1c0b0cf37cd324c92c27b5cb5387d1', 545)
+	`
+
+	res := grm.Exec(query)
+	if res.Error != nil {
+		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
+		return res.Error
+	}
+	return nil
+}
+
+func Test_OperatorSetStrategyRegistrationSnapshots(t *testing.T) {
+	if !rewardsTestsEnabled() {
+		t.Skipf("Skipping %s", t.Name())
+		return
+	}
+
+	// projectRoot := getProjectRootPath()
+	dbFileName, cfg, grm, l, err := setupOperatorSetStrategyRegistrationSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// testContext := getRewardsTestContext()
+
+	snapshotDate := "2024-12-09"
+
+	t.Run("Should hydrate dependency tables", func(t *testing.T) {
+		t.Log("Hydrating blocks")
+
+		_, err := hydrateRewardsV2Blocks(grm, l)
+		assert.Nil(t, err)
+
+		t.Log("Hydrating operator set strategy registrations")
+		err = hydrateOperatorSetStrategyRegistrationsTable(grm, l)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		query := `select count(*) from operator_set_strategy_registrations`
+		var count int
+		res := grm.Raw(query).Scan(&count)
+
+		assert.Nil(t, res.Error)
+
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("Should generate the proper operatorSetStrategyRegistrationSnapshots", func(t *testing.T) {
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		rewards, _ := NewRewardsCalculator(cfg, grm, nil, sog, l)
+
+		err := rewards.GenerateAndInsertOperatorSetStrategyRegistrationSnapshots(snapshotDate)
+		assert.Nil(t, err)
+
+		snapshots, err := rewards.ListOperatorSetStrategyRegistrationSnapshots()
+		assert.Nil(t, err)
+
+		t.Logf("Found %d snapshots", len(snapshots))
+
+		assert.Equal(t, 218, len(snapshots))
+	})
+
+	t.Cleanup(func() {
+		teardownOperatorSetStrategyRegistrationSnapshot(dbFileName, cfg, grm, l)
+	})
+}

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -4,13 +4,16 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/Layr-Labs/sidecar/pkg/rewards/rewardsTypes"
 	"time"
+
+	"github.com/Layr-Labs/sidecar/pkg/rewards/rewardsTypes"
 
 	"sync/atomic"
 
 	"slices"
 	"strings"
+
+	"strconv"
 
 	"github.com/Layr-Labs/eigenlayer-rewards-proofs/pkg/distribution"
 	"github.com/Layr-Labs/sidecar/internal/config"
@@ -23,7 +26,6 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"strconv"
 )
 
 type RewardsCalculator struct {
@@ -225,7 +227,7 @@ func (rc *RewardsCalculator) MerkelizeRewardsForSnapshot(snapshotDate string) (
 }
 
 func (rc *RewardsCalculator) GetMaxSnapshotDateForCutoffDate(cutoffDate string) (string, error) {
-	goldStagingTableName := rewardsUtils.GetGoldTableNames(cutoffDate)[rewardsUtils.Table_11_GoldStaging]
+	goldStagingTableName := rewardsUtils.GetGoldTableNames(cutoffDate)[rewardsUtils.Table_15_GoldStaging]
 
 	var maxSnapshotStr string
 	query := fmt.Sprintf(`select to_char(max(snapshot), 'YYYY-MM-DD') as snapshot from %s`, goldStagingTableName)
@@ -633,6 +635,33 @@ func (rc *RewardsCalculator) generateSnapshotData(snapshotDate string) error {
 	}
 	rc.logger.Sugar().Debugw("Generated default operator split snapshots")
 
+	// ------------------------------------------------------------------------
+	// Rewards V2.1 snapshots
+	// ------------------------------------------------------------------------
+	if err = rc.GenerateAndInsertOperatorDirectedOperatorSetRewards(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate operator directed operator set rewards", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Debugw("Generated operator directed operator set rewards")
+
+	if err = rc.GenerateAndInsertOperatorSetSplitSnapshots(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate operator set split snapshots", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Debugw("Generated operator set split snapshots")
+
+	if err = rc.GenerateAndInsertOperatorSetOperatorRegistrationSnapshots(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate operator set operator registration snapshots", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Debugw("Generated operator set operator registration snapshots")
+
+	if err = rc.GenerateAndInsertOperatorSetStrategyRegistrationSnapshots(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate operator set strategy registration snapshots", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Debugw("Generated operator set strategy registration snapshots")
+
 	return nil
 }
 
@@ -691,12 +720,32 @@ func (rc *RewardsCalculator) generateGoldTables(snapshotDate string) error {
 		return err
 	}
 
-	if err := rc.GenerateGold11StagingTable(snapshotDate); err != nil {
+	if err := rc.GenerateGold11ActiveODOperatorSetRewards(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate active od operator set rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold12OperatorODOperatorSetRewardAmountsTable(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate operator od operator set rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold13StakerODOperatorSetRewardAmountsTable(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate staker od operator set rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate avs od operator set rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold15StagingTable(snapshotDate); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate gold staging", "error", err)
 		return err
 	}
 
-	if err := rc.GenerateGold12FinalTable(snapshotDate); err != nil {
+	if err := rc.GenerateGold16FinalTable(snapshotDate); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate final table", "error", err)
 		return err
 	}

--- a/pkg/rewards/rewardsV2_1_test.go
+++ b/pkg/rewards/rewardsV2_1_test.go
@@ -1,183 +1,28 @@
 package rewards
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/Layr-Labs/sidecar/internal/config"
-	"github.com/Layr-Labs/sidecar/internal/logger"
-	"github.com/Layr-Labs/sidecar/internal/tests"
-	"github.com/Layr-Labs/sidecar/pkg/postgres"
 	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
 	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
-	postgres2 "github.com/Layr-Labs/sidecar/pkg/storage/postgres"
-	"github.com/Layr-Labs/sidecar/pkg/utils"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-	"gorm.io/gorm"
 )
 
-// const TOTAL_BLOCK_COUNT = 1229187
-
-func rewardsTestsEnabled() bool {
-	return os.Getenv("TEST_REWARDS") == "true"
-}
-
-func getRewardsTestContext() string {
-	ctx := os.Getenv("REWARDS_TEST_CONTEXT")
-	if ctx == "" {
-		return "testnet"
-	}
-	return ctx
-}
-
-func getProjectRootPath() string {
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	p, err := filepath.Abs(fmt.Sprintf("%s/../..", wd))
-	if err != nil {
-		panic(err)
-	}
-	return p
-}
-
-func getSnapshotDate() (string, error) {
-	context := getRewardsTestContext()
-
-	switch context {
-	case "testnet":
-		return "2024-09-01", nil
-	case "testnet-reduced":
-		return "2024-07-25", nil
-	case "mainnet-reduced":
-		return "2024-08-12", nil
-	case "preprod-rewardsV2":
-		return "2024-12-09", nil
-	}
-	return "", fmt.Errorf("Unknown context: %s", context)
-}
-
-func hydrateAllBlocksTable(grm *gorm.DB, l *zap.Logger) (int, error) {
-	projectRoot := getProjectRootPath()
-	contents, err := tests.GetAllBlocksSqlFile(projectRoot)
-
-	if err != nil {
-		return 0, err
-	}
-
-	count := len(strings.Split(strings.Trim(contents, "\n"), "\n")) - 1
-
-	res := grm.Exec(contents)
-	if res.Error != nil {
-		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
-		return count, res.Error
-	}
-	return count, nil
-}
-
-func hydrateRewardsV2Blocks(grm *gorm.DB, l *zap.Logger) (int, error) {
-	projectRoot := getProjectRootPath()
-	contents, err := tests.GetRewardsV2Blocks(projectRoot)
-
-	if err != nil {
-		return 0, err
-	}
-
-	count := len(strings.Split(strings.Trim(contents, "\n"), "\n")) - 1
-
-	res := grm.Exec(contents)
-	if res.Error != nil {
-		l.Sugar().Errorw("Failed to execute sql", "error", zap.Error(res.Error))
-		return count, res.Error
-	}
-	return count, nil
-}
-
-func getRowCountForTable(grm *gorm.DB, tableName string) (int, error) {
-	query := fmt.Sprintf("select count(*) as cnt from %s", tableName)
-	var count int
-	res := grm.Raw(query).Scan(&count)
-
-	if res.Error != nil {
-		return 0, res.Error
-	}
-	return count, nil
-}
-
-func setupRewards() (
-	string,
-	*config.Config,
-	*gorm.DB,
-	*zap.Logger,
-	error,
-) {
-	cfg := tests.GetConfig()
-	cfg.Rewards.GenerateStakerOperatorsTable = true
-	cfg.Rewards.ValidateRewardsRoot = true
-	cfg.Chain = config.Chain_Mainnet
-
-	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
-
-	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
-
-	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
-	if err != nil {
-		return dbname, nil, nil, nil, err
-	}
-
-	return dbname, cfg, grm, l, nil
-}
-
-func setupRewardsV2() (
-	string,
-	*config.Config,
-	*gorm.DB,
-	*zap.Logger,
-	error,
-) {
-	cfg := tests.GetConfig()
-	cfg.Rewards.GenerateStakerOperatorsTable = true
-	cfg.Rewards.ValidateRewardsRoot = true
-	cfg.Chain = config.Chain_Preprod
-
-	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
-
-	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
-
-	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
-	if err != nil {
-		return dbname, nil, nil, nil, err
-	}
-
-	return dbname, cfg, grm, l, nil
-}
-
-func Test_Rewards(t *testing.T) {
+func Test_RewardsV2_1(t *testing.T) {
 	if !rewardsTestsEnabled() {
 		t.Skipf("Skipping %s", t.Name())
 		return
 	}
 
-	dbFileName, cfg, grm, l, err := setupRewards()
+	dbFileName, cfg, grm, l, err := setupRewardsV2()
 	fmt.Printf("Using db file: %+v\n", dbFileName)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	projectRoot := getProjectRootPath()
-
-	// snapshotDate, err := getSnapshotDate()
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
 
 	sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
 
@@ -194,7 +39,7 @@ func Test_Rewards(t *testing.T) {
 		testStart := time.Now()
 
 		// Setup all tables and source data
-		_, err = hydrateAllBlocksTable(grm, l)
+		_, err = hydrateRewardsV2Blocks(grm, l)
 		assert.Nil(t, err)
 
 		err = hydrateOperatorAvsStateChangesTable(grm, l)
@@ -215,13 +60,33 @@ func Test_Rewards(t *testing.T) {
 		err = hydrateRewardSubmissionsTable(grm, l)
 		assert.Nil(t, err)
 
+		// RewardsV2 tables
+		err = hydrateOperatorAvsSplits(grm, l)
+		assert.Nil(t, err)
+
+		err = hydrateOperatorPISplits(grm, l)
+		assert.Nil(t, err)
+
+		err = hydrateOperatorDirectedRewardSubmissionsTable(grm, l)
+		assert.Nil(t, err)
+
+		// RewardsV2_1 tables
+		err = hydrateOperatorSetOperatorRegistrationsTable(grm, l)
+		assert.Nil(t, err)
+
+		err = hydrateOperatorSetStrategyRegistrationsTable(grm, l)
+		assert.Nil(t, err)
+
+		err = hydrateOperatorSetSplits(grm, l)
+		assert.Nil(t, err)
+
+		err = hydrateOperatorDirectedOperatorSetRewardSubmissionsTable(grm, l)
+		assert.Nil(t, err)
+
 		t.Log("Hydrated tables")
 
 		snapshotDates := []string{
-			"2024-08-02",
-			// "2024-08-11",
-			// "2024-08-12",
-			// "2024-08-19",
+			"2025-02-04",
 		}
 
 		fmt.Printf("Hydration duration: %v\n", time.Since(testStart))
@@ -297,7 +162,6 @@ func Test_Rewards(t *testing.T) {
 			// ------------------------------------------------------------------------
 			// Rewards V2
 			// ------------------------------------------------------------------------
-
 			rewardsV2Enabled, err := cfg.IsRewardsV2EnabledForCutoffDate(snapshotDate)
 			assert.Nil(t, err)
 
@@ -407,129 +271,25 @@ func Test_Rewards(t *testing.T) {
 			assert.Nil(t, err)
 
 			t.Logf("Gold staging rows for snapshot %s: %d", snapshotDate, len(goldRows))
-
-			fmt.Printf("Total duration for rewards compute %s: %v\n", snapshotDate, time.Since(snapshotStartTime))
-			testStart = time.Now()
-
-			expectedRows, err := tests.GetGoldExpectedResults(projectRoot, snapshotDate)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			assert.Equal(t, len(expectedRows), len(goldRows))
-			t.Logf("Expected rows: %d, Gold staging rows: %d", len(expectedRows), len(goldRows))
-
-			expectedRowsMap := make(map[string]*tests.GoldStagingExpectedResult)
-
-			for _, row := range expectedRows {
-				key := fmt.Sprintf("%s_%s_%s_%s", row.Earner, row.Snapshot, row.RewardHash, row.Token)
-				if _, ok := expectedRowsMap[key]; !ok {
-					expectedRowsMap[key] = row
-				} else {
-					t.Logf("Duplicate expected row found: %+v", row)
-				}
-			}
-
-			missingRows := 0
-			invalidAmounts := 0
 			for i, row := range goldRows {
-				key := fmt.Sprintf("%s_%s_%s_%s", row.Earner, row.Snapshot.Format(time.DateOnly), row.RewardHash, row.Token)
-				foundRow, ok := expectedRowsMap[key]
-				if !ok {
-					missingRows++
-					if missingRows < 100 {
-						fmt.Printf("[%d] Row not found in expected results: %+v\n", i, row)
-					}
-					continue
+				if strings.EqualFold(row.RewardHash, strings.ToLower("0xB38AB57E8E858F197C07D0CDF61F34EB07C3D0FC58390417DDAD0BF528681909")) &&
+					strings.EqualFold(row.Earner, strings.ToLower("0xaFF71569D30ED876987088a62E0EA881EBc761E6")) {
+					t.Logf("%d: %s %s %s %s %s", i, row.Earner, row.Snapshot.String(), row.RewardHash, row.Token, row.Amount)
 				}
-				if foundRow.Amount != row.Amount {
-					invalidAmounts++
-					if invalidAmounts < 100 {
-						fmt.Printf("[%d] Amount mismatch: expected '%s', got '%s' for row: %+v\n", i, foundRow.Amount, row.Amount, row)
-					}
-				}
-			}
-			assert.Zero(t, missingRows)
-			if missingRows > 0 {
-				t.Fatalf("Missing rows: %d", missingRows)
-			}
-
-			assert.Zero(t, invalidAmounts)
-			if invalidAmounts > 0 {
-				t.Fatalf("Invalid amounts: %d", invalidAmounts)
+				// t.Logf("%d: %s %s %s %s %s", i, row.Earner, row.Snapshot.String(), row.RewardHash, row.Token, row.Amount)
 			}
 
 			t.Logf("Generating staker operators table")
 			err = rc.sog.GenerateStakerOperatorsTable(snapshotDate)
 			assert.Nil(t, err)
 
-			accountTree, _, _, err := rc.MerkelizeRewardsForSnapshot(snapshotDate)
-			assert.Nil(t, err)
-
-			root := utils.ConvertBytesToString(accountTree.Root())
-			t.Logf("Root: %s", root)
+			fmt.Printf("Total duration for rewards compute %s: %v\n", snapshotDate, time.Since(snapshotStartTime))
+			testStart = time.Now()
 		}
 
 		fmt.Printf("Done!\n\n")
 		t.Cleanup(func() {
 			// teardownRewards(dbFileName, cfg, grm, l)
 		})
-	})
-}
-
-func Test_RewardsCalculatorLock(t *testing.T) {
-	if !rewardsTestsEnabled() {
-		t.Skipf("Skipping %s", t.Name())
-		return
-	}
-
-	dbFileName, cfg, grm, l, err := setupRewards()
-	fmt.Printf("Using db file: %+v\n", dbFileName)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	bs := postgres2.NewPostgresBlockStore(grm, l, cfg)
-
-	sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
-	rc, err := NewRewardsCalculator(cfg, grm, bs, sog, l)
-	assert.Nil(t, err)
-
-	// Setup all tables and source data
-	_, err = hydrateAllBlocksTable(grm, l)
-	assert.Nil(t, err)
-
-	err = hydrateOperatorAvsStateChangesTable(grm, l)
-	assert.Nil(t, err)
-
-	err = hydrateOperatorAvsRestakedStrategies(grm, l)
-	assert.Nil(t, err)
-
-	err = hydrateOperatorShareDeltas(grm, l)
-	assert.Nil(t, err)
-
-	err = hydrateStakerDelegations(grm, l)
-	assert.Nil(t, err)
-
-	err = hydrateStakerShareDeltas(grm, l)
-	assert.Nil(t, err)
-
-	err = hydrateRewardSubmissionsTable(grm, l)
-	assert.Nil(t, err)
-
-	t.Log("Hydrated tables")
-
-	// --------
-
-	go func() {
-		_ = rc.CalculateRewardsForSnapshotDate("2024-08-02")
-	}()
-	time.Sleep(1 * time.Second)
-	t.Logf("Attempting to calculate second rewards for snapshot date: 2024-08-02")
-	err = rc.calculateRewardsForSnapshotDate("2024-08-02")
-	assert.True(t, errors.Is(err, &ErrRewardsCalculationInProgress{}))
-
-	t.Cleanup(func() {
-		postgres.TeardownTestDatabase(dbFileName, cfg, grm, l)
 	})
 }

--- a/pkg/rewards/rewardsV2_test.go
+++ b/pkg/rewards/rewardsV2_test.go
@@ -192,16 +192,63 @@ func Test_RewardsV2(t *testing.T) {
 			}
 			testStart = time.Now()
 
-			fmt.Printf("Running gold_11_staging\n")
-			err = rc.GenerateGold11StagingTable(snapshotDate)
+			// ------------------------------------------------------------------------
+			// Rewards V2.1
+			// ------------------------------------------------------------------------
+
+			rewardsV2_1Enabled, err := cfg.IsRewardsV2_1EnabledForCutoffDate(snapshotDate)
 			assert.Nil(t, err)
-			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_11_GoldStaging])
+
+			fmt.Printf("Running gold_11_active_od_operator_set_rewards\n")
+			err = rc.GenerateGold11ActiveODOperatorSetRewards(snapshotDate)
 			assert.Nil(t, err)
-			fmt.Printf("\tRows in gold_11_staging: %v - [time: %v]\n", rows, time.Since(testStart))
+			if rewardsV2_1Enabled {
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards])
+				assert.Nil(t, err)
+				fmt.Printf("\tRows in gold_11_active_od_operator_set_rewards: %v - [time: %v]\n", rows, time.Since(testStart))
+			}
 			testStart = time.Now()
 
-			fmt.Printf("Running gold_12_final_table\n")
-			err = rc.GenerateGold12FinalTable(snapshotDate)
+			fmt.Printf("Running gold_12_operator_od_operator_set_rewards\n")
+			err = rc.GenerateGold12OperatorODOperatorSetRewardAmountsTable(snapshotDate)
+			assert.Nil(t, err)
+			if rewardsV2_1Enabled {
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts])
+				assert.Nil(t, err)
+				fmt.Printf("\tRows in gold_12_operator_od_operator_set_rewards: %v - [time: %v]\n", rows, time.Since(testStart))
+			}
+			testStart = time.Now()
+
+			fmt.Printf("Running gold_13_staker_od_operator_set_rewards\n")
+			err = rc.GenerateGold13StakerODOperatorSetRewardAmountsTable(snapshotDate)
+			assert.Nil(t, err)
+			if rewardsV2_1Enabled {
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts])
+				assert.Nil(t, err)
+				fmt.Printf("\tRows in gold_13_staker_od_operator_set_rewards: %v - [time: %v]\n", rows, time.Since(testStart))
+			}
+			testStart = time.Now()
+
+			fmt.Printf("Running gold_14_avs_od_operator_set_rewards\n")
+			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate)
+			assert.Nil(t, err)
+			if rewardsV2_1Enabled {
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts])
+				assert.Nil(t, err)
+				fmt.Printf("\tRows in gold_14_avs_od_operator_set_rewards: %v - [time: %v]\n", rows, time.Since(testStart))
+			}
+			testStart = time.Now()
+
+			fmt.Printf("Running gold_15_staging\n")
+			err = rc.GenerateGold15StagingTable(snapshotDate)
+			assert.Nil(t, err)
+			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_15_GoldStaging])
+			assert.Nil(t, err)
+			fmt.Printf("\tRows in gold_15_staging: %v - [time: %v]\n", rows, time.Since(testStart))
+			testStart = time.Now()
+
+			fmt.Printf("Running gold_final_table\n")
+			err = rc.GenerateGold16FinalTable(snapshotDate)
 			assert.Nil(t, err)
 			rows, err = getRowCountForTable(grm, "gold_table")
 			assert.Nil(t, err)

--- a/pkg/rewards/stakerOperators/10_stakerODOperatorSetStrategyPayouts.go
+++ b/pkg/rewards/stakerOperators/10_stakerODOperatorSetStrategyPayouts.go
@@ -1,0 +1,71 @@
+package stakerOperators
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+)
+
+const _10_stakerODOperatorSetStrategyPayoutQuery = `
+create table {{.destTableName}} as
+select
+    staker,
+    operator,
+    avs,
+	operator_set_id,
+    token,
+    strategy,
+    multiplier,
+    shares,
+    staker_tokens,
+    reward_hash,
+    snapshot
+from {{.stakerODOperatorSetRewardAmountsTable}}
+`
+
+func (sog *StakerOperatorsGenerator) GenerateAndInsert10StakerODOperatorSetStrategyPayouts(cutoffDate string) error {
+	rewardsV2_1Enabled, err := sog.globalConfig.IsRewardsV2_1EnabledForCutoffDate(cutoffDate)
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_1Enabled {
+		sog.logger.Sugar().Infow("Skipping 10_stakerODOperatorSetStrategyPayouts generation as rewards v2.1 is not enabled")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(cutoffDate)
+	destTableName := allTableNames[rewardsUtils.Sot_10_StakerODOperatorSetStrategyPayouts]
+
+	sog.logger.Sugar().Infow("Generating and inserting 10_stakerODOperatorSetStrategyPayouts",
+		"cutoffDate", cutoffDate,
+	)
+
+	if err := rewardsUtils.DropTableIfExists(sog.db, destTableName, sog.logger); err != nil {
+		sog.logger.Sugar().Errorw("Failed to drop table", "error", err)
+		return err
+	}
+
+	rewardsTables, err := sog.FindRewardsTableNamesForSearchPattersn(map[string]string{
+		rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts: rewardsUtils.GoldTableNameSearchPattern[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts],
+	}, cutoffDate)
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to find staker operator table names", "error", err)
+		return err
+	}
+
+	query, err := rewardsUtils.RenderQueryTemplate(_10_stakerODOperatorSetStrategyPayoutQuery, map[string]interface{}{
+		"destTableName":                         destTableName,
+		"stakerODOperatorSetRewardAmountsTable": rewardsTables[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts],
+	})
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to render 10_stakerODOperatorSetStrategyPayouts query", "error", err)
+		return err
+	}
+
+	res := sog.db.Exec(query)
+
+	if res.Error != nil {
+		sog.logger.Sugar().Errorw("Failed to generate 10_stakerODOperatorSetStrategyPayouts", "error", res.Error)
+		return err
+	}
+	return nil
+}

--- a/pkg/rewards/stakerOperators/11_avsODOperatorSetStrategyPayouts.go
+++ b/pkg/rewards/stakerOperators/11_avsODOperatorSetStrategyPayouts.go
@@ -1,0 +1,67 @@
+package stakerOperators
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+)
+
+const _11_avsODOperatorSetStrategyPayoutQuery = `
+create table {{.destTableName}} as
+select
+	reward_hash,
+	snapshot,
+	token,
+	avs,
+	operator_set_id,
+	operator,
+	avs_tokens
+from {{.avsODOperatorSetRewardAmountsTable}}
+`
+
+func (sog *StakerOperatorsGenerator) GenerateAndInsert11AvsODOperatorSetStrategyPayouts(cutoffDate string) error {
+	rewardsV2_1Enabled, err := sog.globalConfig.IsRewardsV2_1EnabledForCutoffDate(cutoffDate)
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_1Enabled {
+		sog.logger.Sugar().Infow("Skipping 11_avsODOperatorSetStrategyPayouts generation as rewards v2.1 is not enabled")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(cutoffDate)
+	destTableName := allTableNames[rewardsUtils.Sot_11_AvsODOperatorSetStrategyPayouts]
+
+	sog.logger.Sugar().Infow("Generating and inserting 11_avsODOperatorSetStrategyPayouts",
+		"cutoffDate", cutoffDate,
+	)
+
+	if err := rewardsUtils.DropTableIfExists(sog.db, destTableName, sog.logger); err != nil {
+		sog.logger.Sugar().Errorw("Failed to drop table", "error", err)
+		return err
+	}
+
+	rewardsTables, err := sog.FindRewardsTableNamesForSearchPattersn(map[string]string{
+		rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts: rewardsUtils.GoldTableNameSearchPattern[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts],
+	}, cutoffDate)
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to find staker operator table names", "error", err)
+		return err
+	}
+
+	query, err := rewardsUtils.RenderQueryTemplate(_11_avsODOperatorSetStrategyPayoutQuery, map[string]interface{}{
+		"destTableName":                      destTableName,
+		"avsODOperatorSetRewardAmountsTable": rewardsTables[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts],
+	})
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to render 11_avsODOperatorSetStrategyPayouts query", "error", err)
+		return err
+	}
+
+	res := sog.db.Exec(query)
+
+	if res.Error != nil {
+		sog.logger.Sugar().Errorw("Failed to generate 11_avsODOperatorSetStrategyPayouts", "error", res.Error)
+		return err
+	}
+	return nil
+}

--- a/pkg/rewards/stakerOperators/13_stakerOperator.go
+++ b/pkg/rewards/stakerOperators/13_stakerOperator.go
@@ -1,12 +1,13 @@
 package stakerOperators
 
 import (
+	"time"
+
 	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
 	"go.uber.org/zap"
-	"time"
 )
 
-const _7_stakerOperator = `
+const _13_stakerOperator = `
 insert into {{.destTableName}} (
 	earner,
 	operator,
@@ -50,30 +51,30 @@ type StakerOperator struct {
 	Snapshot   time.Time
 }
 
-func (sog *StakerOperatorsGenerator) GenerateAndInsert10StakerOperator(cutoffDate string) error {
-	sog.logger.Sugar().Infow("Generating and inserting 10_stakerOperator",
+func (sog *StakerOperatorsGenerator) GenerateAndInsert13StakerOperator(cutoffDate string) error {
+	sog.logger.Sugar().Infow("Generating and inserting 13_stakerOperator",
 		zap.String("cutoffDate", cutoffDate),
 	)
 	allTableNames := rewardsUtils.GetGoldTableNames(cutoffDate)
-	destTableName := rewardsUtils.Sot_10_StakerOperatorTable
+	destTableName := rewardsUtils.Sot_13_StakerOperatorTable
 
-	sog.logger.Sugar().Infow("Generating 10_stakerOperator",
+	sog.logger.Sugar().Infow("Generating 13_stakerOperator",
 		zap.String("destTableName", destTableName),
 		zap.String("cutoffDate", cutoffDate),
 	)
 
-	query, err := rewardsUtils.RenderQueryTemplate(_7_stakerOperator, map[string]interface{}{
+	query, err := rewardsUtils.RenderQueryTemplate(_13_stakerOperator, map[string]interface{}{
 		"destTableName":         destTableName,
-		"stakerOperatorStaging": allTableNames[rewardsUtils.Sot_9_StakerOperatorStaging],
+		"stakerOperatorStaging": allTableNames[rewardsUtils.Sot_12_StakerOperatorStaging],
 	})
 	if err != nil {
-		sog.logger.Sugar().Errorw("Failed to render 10_stakerOperator query", "error", err)
+		sog.logger.Sugar().Errorw("Failed to render 13_stakerOperator query", "error", err)
 		return err
 	}
 
 	res := sog.db.Exec(query)
 	if res.Error != nil {
-		sog.logger.Sugar().Errorw("Failed to generate 10_stakerOperator",
+		sog.logger.Sugar().Errorw("Failed to generate 13_stakerOperator",
 			zap.String("cutoffDate", cutoffDate),
 			zap.Error(res.Error),
 		)
@@ -82,11 +83,11 @@ func (sog *StakerOperatorsGenerator) GenerateAndInsert10StakerOperator(cutoffDat
 	return nil
 }
 
-func (sog *StakerOperatorsGenerator) List7StakerOperator() ([]*StakerOperator, error) {
+func (sog *StakerOperatorsGenerator) List13StakerOperator() ([]*StakerOperator, error) {
 	var rewards []*StakerOperator
 	res := sog.db.Model(&StakerOperator{}).Find(&rewards)
 	if res.Error != nil {
-		sog.logger.Sugar().Errorw("Failed to list 7_stakerOperator", "error", res.Error)
+		sog.logger.Sugar().Errorw("Failed to list 13_stakerOperator", "error", res.Error)
 		return nil, res.Error
 	}
 	return rewards, nil

--- a/pkg/rewards/stakerOperators/9_operatorODOperatorSetStrategyPayouts.go
+++ b/pkg/rewards/stakerOperators/9_operatorODOperatorSetStrategyPayouts.go
@@ -1,0 +1,71 @@
+package stakerOperators
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+)
+
+const _9_operatorODOperatorSetStrategyPayoutQuery = `
+create table {{.destTableName}} as
+select
+	operator,
+	reward_hash,
+	snapshot,
+	token,
+	avs,
+	operator_set_id,
+	strategy,
+	multiplier,
+	reward_submission_date,
+	split_pct,
+	operator_tokens
+from {{.operatorODOperatorSetRewardAmountsTable}}
+`
+
+func (sog *StakerOperatorsGenerator) GenerateAndInsert9OperatorODOperatorSetStrategyPayouts(cutoffDate string) error {
+	rewardsV2_1Enabled, err := sog.globalConfig.IsRewardsV2_1EnabledForCutoffDate(cutoffDate)
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to check if rewards v2.1 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_1Enabled {
+		sog.logger.Sugar().Infow("Skipping 9_operatorODOperatorSetStrategyPayouts generation as rewards v2.1 is not enabled")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(cutoffDate)
+	destTableName := allTableNames[rewardsUtils.Sot_9_OperatorODOperatorSetStrategyPayouts]
+
+	sog.logger.Sugar().Infow("Generating and inserting 9_operatorODOperatorSetStrategyPayouts",
+		"cutoffDate", cutoffDate,
+	)
+
+	if err := rewardsUtils.DropTableIfExists(sog.db, destTableName, sog.logger); err != nil {
+		sog.logger.Sugar().Errorw("Failed to drop table", "error", err)
+		return err
+	}
+
+	rewardsTables, err := sog.FindRewardsTableNamesForSearchPattersn(map[string]string{
+		rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts: rewardsUtils.GoldTableNameSearchPattern[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts],
+	}, cutoffDate)
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to find staker operator table names", "error", err)
+		return err
+	}
+
+	query, err := rewardsUtils.RenderQueryTemplate(_9_operatorODOperatorSetStrategyPayoutQuery, map[string]interface{}{
+		"destTableName": destTableName,
+		"operatorODOperatorSetRewardAmountsTable": rewardsTables[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts],
+	})
+	if err != nil {
+		sog.logger.Sugar().Errorw("Failed to render 9_operatorODOperatorSetStrategyPayouts query", "error", err)
+		return err
+	}
+
+	res := sog.db.Exec(query)
+
+	if res.Error != nil {
+		sog.logger.Sugar().Errorw("Failed to generate 9_operatorODOperatorSetStrategyPayouts", "error", res.Error)
+		return err
+	}
+	return nil
+}

--- a/pkg/rewards/stakerOperators/stakerOperator.go
+++ b/pkg/rewards/stakerOperators/stakerOperator.go
@@ -103,16 +103,40 @@ func (sog *StakerOperatorsGenerator) GenerateStakerOperatorsTable(cutoffDate str
 		return err
 	}
 
-	if err := sog.GenerateAndInsert9StakerOperatorStaging(cutoffDate); err != nil {
-		sog.logger.Sugar().Errorw("Failed to generate and insert 6 staker strategy rewards",
+	if err := sog.GenerateAndInsert9OperatorODOperatorSetStrategyPayouts(cutoffDate); err != nil {
+		sog.logger.Sugar().Errorw("Failed to generate and insert 9 operator OD operator set strategy rewards",
 			zap.String("cutoffDate", cutoffDate),
 			zap.Error(err),
 		)
 		return err
 	}
 
-	if err := sog.GenerateAndInsert10StakerOperator(cutoffDate); err != nil {
-		sog.logger.Sugar().Errorw("Failed to generate and insert 7 staker strategy rewards",
+	if err := sog.GenerateAndInsert10StakerODOperatorSetStrategyPayouts(cutoffDate); err != nil {
+		sog.logger.Sugar().Errorw("Failed to generate and insert 10 staker OD operator set strategy rewards",
+			zap.String("cutoffDate", cutoffDate),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	if err := sog.GenerateAndInsert11AvsODOperatorSetStrategyPayouts(cutoffDate); err != nil {
+		sog.logger.Sugar().Errorw("Failed to generate and insert 11 AVS OD operator set strategy rewards",
+			zap.String("cutoffDate", cutoffDate),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	if err := sog.GenerateAndInsert12StakerOperatorStaging(cutoffDate); err != nil {
+		sog.logger.Sugar().Errorw("Failed to generate and insert 12 staker operator staging",
+			zap.String("cutoffDate", cutoffDate),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	if err := sog.GenerateAndInsert13StakerOperator(cutoffDate); err != nil {
+		sog.logger.Sugar().Errorw("Failed to generate and insert 13 staker operator",
 			zap.String("cutoffDate", cutoffDate),
 			zap.Error(err),
 		)

--- a/pkg/rewards/tables.go
+++ b/pkg/rewards/tables.go
@@ -112,3 +112,44 @@ type OperatorDirectedRewards struct {
 	TransactionHash string
 	LogIndex        uint64
 }
+
+type OperatorSetSplitSnapshots struct {
+	Operator      string
+	Avs           string
+	OperatorSetId uint64
+	Split         uint64
+	Snapshot      time.Time
+}
+
+type OperatorSetOperatorRegistrationSnapshots struct {
+	Operator      string
+	Avs           string
+	OperatorSetId uint64
+	Snapshot      time.Time
+}
+
+type OperatorSetStrategyRegistrationSnapshots struct {
+	Strategy      string
+	Avs           string
+	OperatorSetId uint64
+	Snapshot      time.Time
+}
+
+type OperatorDirectedOperatorSetRewards struct {
+	Avs            string
+	OperatorSetId  uint64
+	RewardHash     string
+	Token          string
+	Operator       string
+	OperatorIndex  uint64
+	Amount         string
+	Strategy       string
+	StrategyIndex  uint64
+	Multiplier     string
+	StartTimestamp time.Time
+	EndTimestamp   time.Time
+	Duration       uint64
+	BlockNumber    uint64
+	BlockTime      time.Time
+	BlockDate      string
+}

--- a/pkg/rewardsUtils/rewardsUtils.go
+++ b/pkg/rewardsUtils/rewardsUtils.go
@@ -30,16 +30,19 @@ var (
 	Table_15_GoldStaging                        = "gold_15_staging"
 	Table_16_GoldTable                          = "gold_table"
 
-	Sot_1_StakerStrategyPayouts       = "sot_1_staker_strategy_payouts"
-	Sot_2_OperatorStrategyPayouts     = "sot_2_operator_strategy_payouts"
-	Sot_3_RewardsForAllStrategyPayout = "sot_3_rewards_for_all_strategy_payout"
-	Sot_4_RfaeStakers                 = "sot_4_rfae_stakers"
-	Sot_5_RfaeOperators               = "sot_5_rfae_operators"
-	Sot_6_OperatorODStrategyPayouts   = "sot_6_operator_od_strategy_payouts"
-	Sot_7_StakerODStrategyPayouts     = "sot_7_staker_od_strategy_payouts"
-	Sot_8_AvsODStrategyPayouts        = "sot_8_avs_od_strategy_payouts"
-	Sot_9_StakerOperatorStaging       = "sot_9_staker_operator_staging"
-	Sot_10_StakerOperatorTable        = "staker_operator"
+	Sot_1_StakerStrategyPayouts                = "sot_1_staker_strategy_payouts"
+	Sot_2_OperatorStrategyPayouts              = "sot_2_operator_strategy_payouts"
+	Sot_3_RewardsForAllStrategyPayout          = "sot_3_rewards_for_all_strategy_payout"
+	Sot_4_RfaeStakers                          = "sot_4_rfae_stakers"
+	Sot_5_RfaeOperators                        = "sot_5_rfae_operators"
+	Sot_6_OperatorODStrategyPayouts            = "sot_6_operator_od_strategy_payouts"
+	Sot_7_StakerODStrategyPayouts              = "sot_7_staker_od_strategy_payouts"
+	Sot_8_AvsODStrategyPayouts                 = "sot_8_avs_od_strategy_payouts"
+	Sot_9_OperatorODOperatorSetStrategyPayouts = "sot_9_operator_od_operator_set_strategy_payouts"
+	Sot_10_StakerODOperatorSetStrategyPayouts  = "sot_10_staker_od_operator_set_strategy_payouts"
+	Sot_11_AvsODOperatorSetStrategyPayouts     = "sot_11_avs_od_operator_set_strategy_payouts"
+	Sot_12_StakerOperatorStaging               = "sot_12_staker_operator_staging"
+	Sot_13_StakerOperatorTable                 = "staker_operator"
 )
 
 var goldTableBaseNames = map[string]string{
@@ -60,15 +63,19 @@ var goldTableBaseNames = map[string]string{
 	Table_15_GoldStaging:                        Table_15_GoldStaging,
 	Table_16_GoldTable:                          Table_16_GoldTable,
 
-	Sot_1_StakerStrategyPayouts:       Sot_1_StakerStrategyPayouts,
-	Sot_2_OperatorStrategyPayouts:     Sot_2_OperatorStrategyPayouts,
-	Sot_3_RewardsForAllStrategyPayout: Sot_3_RewardsForAllStrategyPayout,
-	Sot_4_RfaeStakers:                 Sot_4_RfaeStakers,
-	Sot_5_RfaeOperators:               Sot_5_RfaeOperators,
-	Sot_6_OperatorODStrategyPayouts:   Sot_6_OperatorODStrategyPayouts,
-	Sot_7_StakerODStrategyPayouts:     Sot_7_StakerODStrategyPayouts,
-	Sot_8_AvsODStrategyPayouts:        Sot_8_AvsODStrategyPayouts,
-	Sot_9_StakerOperatorStaging:       Sot_9_StakerOperatorStaging,
+	Sot_1_StakerStrategyPayouts:                Sot_1_StakerStrategyPayouts,
+	Sot_2_OperatorStrategyPayouts:              Sot_2_OperatorStrategyPayouts,
+	Sot_3_RewardsForAllStrategyPayout:          Sot_3_RewardsForAllStrategyPayout,
+	Sot_4_RfaeStakers:                          Sot_4_RfaeStakers,
+	Sot_5_RfaeOperators:                        Sot_5_RfaeOperators,
+	Sot_6_OperatorODStrategyPayouts:            Sot_6_OperatorODStrategyPayouts,
+	Sot_7_StakerODStrategyPayouts:              Sot_7_StakerODStrategyPayouts,
+	Sot_8_AvsODStrategyPayouts:                 Sot_8_AvsODStrategyPayouts,
+	Sot_9_OperatorODOperatorSetStrategyPayouts: Sot_9_OperatorODOperatorSetStrategyPayouts,
+	Sot_10_StakerODOperatorSetStrategyPayouts:  Sot_10_StakerODOperatorSetStrategyPayouts,
+	Sot_11_AvsODOperatorSetStrategyPayouts:     Sot_11_AvsODOperatorSetStrategyPayouts,
+	Sot_12_StakerOperatorStaging:               Sot_12_StakerOperatorStaging,
+	Sot_13_StakerOperatorTable:                 Sot_13_StakerOperatorTable,
 }
 
 var GoldTableNameSearchPattern = map[string]string{
@@ -88,15 +95,18 @@ var GoldTableNameSearchPattern = map[string]string{
 	Table_14_AvsODOperatorSetRewardAmounts:      "gold_%_avs_od_operator_set_reward_amounts",
 	Table_15_GoldStaging:                        "gold_%_staging",
 
-	Sot_1_StakerStrategyPayouts:       "sot_%_staker_strategy_payouts",
-	Sot_2_OperatorStrategyPayouts:     "sot_%_operator_strategy_payouts",
-	Sot_3_RewardsForAllStrategyPayout: "sot_%_rewards_for_all_strategy_payout",
-	Sot_4_RfaeStakers:                 "sot_%_rfae_stakers",
-	Sot_5_RfaeOperators:               "sot_%_rfae_operators",
-	Sot_6_OperatorODStrategyPayouts:   "sot_%_operator_od_strategy_payouts",
-	Sot_7_StakerODStrategyPayouts:     "sot_%_staker_od_strategy_payouts",
-	Sot_8_AvsODStrategyPayouts:        "sot_%_avs_od_strategy_payouts",
-	Sot_9_StakerOperatorStaging:       "sot_%_staker_operator_staging",
+	Sot_1_StakerStrategyPayouts:                "sot_%_staker_strategy_payouts",
+	Sot_2_OperatorStrategyPayouts:              "sot_%_operator_strategy_payouts",
+	Sot_3_RewardsForAllStrategyPayout:          "sot_%_rewards_for_all_strategy_payout",
+	Sot_4_RfaeStakers:                          "sot_%_rfae_stakers",
+	Sot_5_RfaeOperators:                        "sot_%_rfae_operators",
+	Sot_6_OperatorODStrategyPayouts:            "sot_%_operator_od_strategy_payouts",
+	Sot_7_StakerODStrategyPayouts:              "sot_%_staker_od_strategy_payouts",
+	Sot_8_AvsODStrategyPayouts:                 "sot_%_avs_od_strategy_payouts",
+	Sot_9_OperatorODOperatorSetStrategyPayouts: "sot_%_operator_od_operator_set_strategy_payouts",
+	Sot_10_StakerODOperatorSetStrategyPayouts:  "sot_%_staker_od_operator_set_strategy_payouts",
+	Sot_11_AvsODOperatorSetStrategyPayouts:     "sot_%_avs_od_operator_set_strategy_payouts",
+	Sot_12_StakerOperatorStaging:               "sot_%_staker_operator_staging",
 }
 
 func GetGoldTableNames(snapshotDate string) map[string]string {

--- a/pkg/rewardsUtils/rewardsUtils.go
+++ b/pkg/rewardsUtils/rewardsUtils.go
@@ -13,18 +13,22 @@ import (
 )
 
 var (
-	Table_1_ActiveRewards           = "gold_1_active_rewards"
-	Table_2_StakerRewardAmounts     = "gold_2_staker_reward_amounts"
-	Table_3_OperatorRewardAmounts   = "gold_3_operator_reward_amounts"
-	Table_4_RewardsForAll           = "gold_4_rewards_for_all"
-	Table_5_RfaeStakers             = "gold_5_rfae_stakers"
-	Table_6_RfaeOperators           = "gold_6_rfae_operators"
-	Table_7_ActiveODRewards         = "gold_7_active_od_rewards"
-	Table_8_OperatorODRewardAmounts = "gold_8_operator_od_reward_amounts"
-	Table_9_StakerODRewardAmounts   = "gold_9_staker_od_reward_amounts"
-	Table_10_AvsODRewardAmounts     = "gold_10_avs_od_reward_amounts"
-	Table_11_GoldStaging            = "gold_11_staging"
-	Table_12_GoldTable              = "gold_table"
+	Table_1_ActiveRewards                       = "gold_1_active_rewards"
+	Table_2_StakerRewardAmounts                 = "gold_2_staker_reward_amounts"
+	Table_3_OperatorRewardAmounts               = "gold_3_operator_reward_amounts"
+	Table_4_RewardsForAll                       = "gold_4_rewards_for_all"
+	Table_5_RfaeStakers                         = "gold_5_rfae_stakers"
+	Table_6_RfaeOperators                       = "gold_6_rfae_operators"
+	Table_7_ActiveODRewards                     = "gold_7_active_od_rewards"
+	Table_8_OperatorODRewardAmounts             = "gold_8_operator_od_reward_amounts"
+	Table_9_StakerODRewardAmounts               = "gold_9_staker_od_reward_amounts"
+	Table_10_AvsODRewardAmounts                 = "gold_10_avs_od_reward_amounts"
+	Table_11_ActiveODOperatorSetRewards         = "gold_11_active_od_operator_set_rewards"
+	Table_12_OperatorODOperatorSetRewardAmounts = "gold_12_operator_od_operator_set_reward_amounts"
+	Table_13_StakerODOperatorSetRewardAmounts   = "gold_13_staker_od_operator_set_reward_amounts"
+	Table_14_AvsODOperatorSetRewardAmounts      = "gold_14_avs_od_operator_set_reward_amounts"
+	Table_15_GoldStaging                        = "gold_15_staging"
+	Table_16_GoldTable                          = "gold_table"
 
 	Sot_1_StakerStrategyPayouts       = "sot_1_staker_strategy_payouts"
 	Sot_2_OperatorStrategyPayouts     = "sot_2_operator_strategy_payouts"
@@ -39,18 +43,22 @@ var (
 )
 
 var goldTableBaseNames = map[string]string{
-	Table_1_ActiveRewards:           Table_1_ActiveRewards,
-	Table_2_StakerRewardAmounts:     Table_2_StakerRewardAmounts,
-	Table_3_OperatorRewardAmounts:   Table_3_OperatorRewardAmounts,
-	Table_4_RewardsForAll:           Table_4_RewardsForAll,
-	Table_5_RfaeStakers:             Table_5_RfaeStakers,
-	Table_6_RfaeOperators:           Table_6_RfaeOperators,
-	Table_7_ActiveODRewards:         Table_7_ActiveODRewards,
-	Table_8_OperatorODRewardAmounts: Table_8_OperatorODRewardAmounts,
-	Table_9_StakerODRewardAmounts:   Table_9_StakerODRewardAmounts,
-	Table_10_AvsODRewardAmounts:     Table_10_AvsODRewardAmounts,
-	Table_11_GoldStaging:            Table_11_GoldStaging,
-	Table_12_GoldTable:              Table_12_GoldTable,
+	Table_1_ActiveRewards:                       Table_1_ActiveRewards,
+	Table_2_StakerRewardAmounts:                 Table_2_StakerRewardAmounts,
+	Table_3_OperatorRewardAmounts:               Table_3_OperatorRewardAmounts,
+	Table_4_RewardsForAll:                       Table_4_RewardsForAll,
+	Table_5_RfaeStakers:                         Table_5_RfaeStakers,
+	Table_6_RfaeOperators:                       Table_6_RfaeOperators,
+	Table_7_ActiveODRewards:                     Table_7_ActiveODRewards,
+	Table_8_OperatorODRewardAmounts:             Table_8_OperatorODRewardAmounts,
+	Table_9_StakerODRewardAmounts:               Table_9_StakerODRewardAmounts,
+	Table_10_AvsODRewardAmounts:                 Table_10_AvsODRewardAmounts,
+	Table_11_ActiveODOperatorSetRewards:         Table_11_ActiveODOperatorSetRewards,
+	Table_12_OperatorODOperatorSetRewardAmounts: Table_12_OperatorODOperatorSetRewardAmounts,
+	Table_13_StakerODOperatorSetRewardAmounts:   Table_13_StakerODOperatorSetRewardAmounts,
+	Table_14_AvsODOperatorSetRewardAmounts:      Table_14_AvsODOperatorSetRewardAmounts,
+	Table_15_GoldStaging:                        Table_15_GoldStaging,
+	Table_16_GoldTable:                          Table_16_GoldTable,
 
 	Sot_1_StakerStrategyPayouts:       Sot_1_StakerStrategyPayouts,
 	Sot_2_OperatorStrategyPayouts:     Sot_2_OperatorStrategyPayouts,
@@ -64,17 +72,21 @@ var goldTableBaseNames = map[string]string{
 }
 
 var GoldTableNameSearchPattern = map[string]string{
-	Table_1_ActiveRewards:           "gold_%_active_rewards",
-	Table_2_StakerRewardAmounts:     "gold_%_staker_reward_amounts",
-	Table_3_OperatorRewardAmounts:   "gold_%_operator_reward_amounts",
-	Table_4_RewardsForAll:           "gold_%_rewards_for_all",
-	Table_5_RfaeStakers:             "gold_%_rfae_stakers",
-	Table_6_RfaeOperators:           "gold_%_rfae_operators",
-	Table_7_ActiveODRewards:         "gold_%_active_od_rewards",
-	Table_8_OperatorODRewardAmounts: "gold_%_operator_od_reward_amounts",
-	Table_9_StakerODRewardAmounts:   "gold_%_staker_od_reward_amounts",
-	Table_10_AvsODRewardAmounts:     "gold_%_avs_od_reward_amounts",
-	Table_11_GoldStaging:            "gold_%_staging",
+	Table_1_ActiveRewards:                       "gold_%_active_rewards",
+	Table_2_StakerRewardAmounts:                 "gold_%_staker_reward_amounts",
+	Table_3_OperatorRewardAmounts:               "gold_%_operator_reward_amounts",
+	Table_4_RewardsForAll:                       "gold_%_rewards_for_all",
+	Table_5_RfaeStakers:                         "gold_%_rfae_stakers",
+	Table_6_RfaeOperators:                       "gold_%_rfae_operators",
+	Table_7_ActiveODRewards:                     "gold_%_active_od_rewards",
+	Table_8_OperatorODRewardAmounts:             "gold_%_operator_od_reward_amounts",
+	Table_9_StakerODRewardAmounts:               "gold_%_staker_od_reward_amounts",
+	Table_10_AvsODRewardAmounts:                 "gold_%_avs_od_reward_amounts",
+	Table_11_ActiveODOperatorSetRewards:         "gold_%_active_od_operator_set_rewards",
+	Table_12_OperatorODOperatorSetRewardAmounts: "gold_%_operator_od_operator_set_reward_amounts",
+	Table_13_StakerODOperatorSetRewardAmounts:   "gold_%_staker_od_operator_set_reward_amounts",
+	Table_14_AvsODOperatorSetRewardAmounts:      "gold_%_avs_od_operator_set_reward_amounts",
+	Table_15_GoldStaging:                        "gold_%_staging",
 
 	Sot_1_StakerStrategyPayouts:       "sot_%_staker_strategy_payouts",
 	Sot_2_OperatorStrategyPayouts:     "sot_%_operator_strategy_payouts",


### PR DESCRIPTION
# Motivation
We need to support Rewards v2.1 calculation. 

This PR builds on top of https://github.com/Layr-Labs/sidecar/pull/197 which supported the Eigen state models for `OperatorDirectedOperatorSetRewardSubmissions`, `OperatorSetSplits`, `OperatorSetOperatorRegistrations`, `OperatorSetStrategyRegistrations`.

# Modifications
* Snapshot generation for: `OperatorDirectedOperatorSetRewardSubmissions`, `OperatorSetSplits`, `OperatorSetOperatorRegistrations`, `OperatorSetStrategyRegistrations`.
* Refactoring Staging and Final numbering from 11 and 12 to 15 and 16.
* Mississippi hard fork for Rewards v2.1.
* New Operator Directed Operator Set rewards calculation to be triggered after Mississippi hard fork.
* Updated Rewards For All Earners (Programmatic Incentives) calculation to include operators registered to operator sets after Mississippi hard fork.
* Staker-operator calculation for Rewards v2.1. 

# Results
Rewards v2.1 calculation.

# Tests
Existing Rewards tests passing.

<img width="660" alt="Screenshot 2025-01-31 at 1 33 38 PM" src="https://github.com/user-attachments/assets/876c2d7c-be22-48b6-a046-55ead8a12530" />

