### PR TITLE
feat: add `operator_set_id` to staker-operator table

### DIFF
--- a/pkg/postgres/migrations/202502051830_addOperatorSetIdToStakerOperator/up.go
+++ b/pkg/postgres/migrations/202502051830_addOperatorSetIdToStakerOperator/up.go
@@ -14,7 +14,7 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 	queries := []string{
 		`alter table staker_operator add column operator_set_id bigint`,
 		`alter table staker_operator drop constraint uniq_staker_operator`,
-		`alter table staker_operator add constraint uniq_staker_operator unique (earner, operator, snapshot, reward_hash, strategy, reward_type, operator_set_id)`,
+		`alter table staker_operator add constraint uniq_staker_operator unique (earner, operator, snapshot, reward_hash, strategy, reward_type, avs, operator_set_id)`,
 	}
 
 	for _, query := range queries {

--- a/pkg/postgres/migrations/202502051830_addOperatorSetIdToStakerOperator/up.go
+++ b/pkg/postgres/migrations/202502051830_addOperatorSetIdToStakerOperator/up.go
@@ -1,0 +1,30 @@
+package _202502051830_addOperatorSetIdToStakerOperator
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`alter table staker_operator add column operator_set_id bigint`,
+		`alter table staker_operator drop constraint uniq_staker_operator`,
+		`alter table staker_operator add constraint uniq_staker_operator unique (earner, operator, snapshot, reward_hash, strategy, reward_type, operator_set_id)`,
+	}
+
+	for _, query := range queries {
+		if err := grm.Exec(query).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202502051830_addOperatorSetIdToStakerOperator"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -59,6 +59,7 @@ import (
 	_202501301502_operatorSetOperatorRegistrationSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501301502_operatorSetOperatorRegistrationSnapshots"
 	_202501301505_operatorSetStrategyRegistrationSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501301505_operatorSetStrategyRegistrationSnapshots"
 	_202501301945_operatorDirectedOperatorSetRewards "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501301945_operatorDirectedOperatorSetRewards"
+	_202502051830_addOperatorSetIdToStakerOperator "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502051830_addOperatorSetIdToStakerOperator"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -153,6 +154,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202501301502_operatorSetOperatorRegistrationSnapshots.Migration{},
 		&_202501301505_operatorSetStrategyRegistrationSnapshots.Migration{},
 		&_202501301945_operatorDirectedOperatorSetRewards.Migration{},
+		&_202502051830_addOperatorSetIdToStakerOperator.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/rewards/stakerOperators/12_stakerOperatorStaging.go
+++ b/pkg/rewards/stakerOperators/12_stakerOperatorStaging.go
@@ -20,7 +20,8 @@ SELECT
   shares,
   staker_strategy_tokens as amount,
   reward_hash,
-  snapshot
+  snapshot,
+  null as operator_set_id
 FROM {{.sot1StakerStrategyPayouts}}
 
 UNION ALL
@@ -36,7 +37,8 @@ SELECT
   shares,
   operator_strategy_tokens as amount,
   reward_hash,
-  snapshot
+  snapshot,
+  null as operator_set_id
 FROM {{.sot2OperatorStrategyPayouts}}
 
 UNION all
@@ -52,7 +54,8 @@ SELECT
   shares,
   staker_strategy_tokens as amount,
   reward_hash,
-  snapshot
+  snapshot,
+  null as operator_set_id
 FROM {{.sot3RewardsForAllStrategyPayouts}}
 
 UNION ALL
@@ -68,7 +71,8 @@ SELECT
   shares,
   staker_strategy_tokens as amount,
   reward_hash,
-  snapshot
+  snapshot,
+  null as operator_set_id
 FROM {{.sot4RfaeStakerStrategyPayout}}
 
 UNION ALL
@@ -84,7 +88,8 @@ SELECT
   shares,
   operator_strategy_tokens as amount,
   reward_hash,
-  snapshot
+  snapshot,
+  null as operator_set_id
 FROM {{.sot5RfaeOperatorStrategyPayout}}
 
 {{ if .rewardsV2Enabled }}
@@ -102,7 +107,8 @@ SELECT
 	'0' as shares,
 	operator_tokens as amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	null as operator_set_id
 from {{.sot6OperatorODStrategyPayouts}}
 
 UNION ALL
@@ -118,7 +124,8 @@ SELECT
 	shares,
 	staker_tokens as amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	null as operator_set_id
 from {{.sot7StakerODStrategyPayouts}}
 
 UNION ALL
@@ -134,7 +141,8 @@ SELECT
 	'0' as shares,
 	avs_tokens as amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	null as operator_set_id
 from {{.sot8AvsODStrategyPayouts}}
 
 {{ end }}
@@ -154,7 +162,8 @@ SELECT
 	'0' as shares,
 	operator_tokens as amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	operator_set_id
 from {{.sot9OperatorODOperatorSetStrategyPayouts}}
 
 UNION ALL
@@ -170,7 +179,8 @@ SELECT
 	shares,
 	staker_tokens as amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	operator_set_id
 from {{.sot10StakerODOperatorSetStrategyPayouts}}
 
 UNION ALL
@@ -186,7 +196,8 @@ SELECT
 	'0' as shares,
 	avs_tokens as amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	operator_set_id
 from {{.sot11AvsODOperatorSetStrategyPayouts}}
 
 {{ end }}

--- a/pkg/rewards/stakerOperators/12_stakerOperatorStaging.go
+++ b/pkg/rewards/stakerOperators/12_stakerOperatorStaging.go
@@ -21,7 +21,7 @@ SELECT
   staker_strategy_tokens as amount,
   reward_hash,
   snapshot,
-  null as operator_set_id
+  null::bigint as operator_set_id
 FROM {{.sot1StakerStrategyPayouts}}
 
 UNION ALL
@@ -38,7 +38,7 @@ SELECT
   operator_strategy_tokens as amount,
   reward_hash,
   snapshot,
-  null as operator_set_id
+  null::bigint as operator_set_id
 FROM {{.sot2OperatorStrategyPayouts}}
 
 UNION all
@@ -55,7 +55,7 @@ SELECT
   staker_strategy_tokens as amount,
   reward_hash,
   snapshot,
-  null as operator_set_id
+  null::bigint as operator_set_id
 FROM {{.sot3RewardsForAllStrategyPayouts}}
 
 UNION ALL
@@ -72,7 +72,7 @@ SELECT
   staker_strategy_tokens as amount,
   reward_hash,
   snapshot,
-  null as operator_set_id
+  null::bigint as operator_set_id
 FROM {{.sot4RfaeStakerStrategyPayout}}
 
 UNION ALL
@@ -89,7 +89,7 @@ SELECT
   operator_strategy_tokens as amount,
   reward_hash,
   snapshot,
-  null as operator_set_id
+  null::bigint as operator_set_id
 FROM {{.sot5RfaeOperatorStrategyPayout}}
 
 {{ if .rewardsV2Enabled }}
@@ -108,7 +108,7 @@ SELECT
 	operator_tokens as amount,
 	reward_hash,
 	snapshot,
-	null as operator_set_id
+	null::bigint as operator_set_id
 from {{.sot6OperatorODStrategyPayouts}}
 
 UNION ALL
@@ -125,7 +125,7 @@ SELECT
 	staker_tokens as amount,
 	reward_hash,
 	snapshot,
-	null as operator_set_id
+	null::bigint as operator_set_id
 from {{.sot7StakerODStrategyPayouts}}
 
 UNION ALL
@@ -142,7 +142,7 @@ SELECT
 	avs_tokens as amount,
 	reward_hash,
 	snapshot,
-	null as operator_set_id
+	null::bigint as operator_set_id
 from {{.sot8AvsODStrategyPayouts}}
 
 {{ end }}

--- a/pkg/rewards/stakerOperators/13_stakerOperator.go
+++ b/pkg/rewards/stakerOperators/13_stakerOperator.go
@@ -19,7 +19,8 @@ insert into {{.destTableName}} (
 	shares,
 	amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	operator_set_id
 )
 select
 	earner,
@@ -32,7 +33,8 @@ select
 	shares,
 	amount,
 	reward_hash,
-	snapshot
+	snapshot,
+	operator_set_id
 from {{.stakerOperatorStaging}}
 on conflict on constraint uniq_staker_operator do nothing;
 `


### PR DESCRIPTION
# Motivation
Adding `operator_set_id` to staker-operator table for Marketplace APR calculation at the operator set level.

# Tests
<img width="704" alt="Screenshot 2025-02-05 at 7 12 14 PM" src="https://github.com/user-attachments/assets/d3607349-46ce-4174-a9ed-8788aa2def6c" />
