### PR TITLE
chore: codeql compatible go.mod

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           echo "Building binary for version $VERSION"
-          make release
+          make release-with-docker
           ./scripts/bundleReleases.sh $VERSION
       - name: Create Release
         id: create_release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bookworm AS builder
+FROM golang:1.23.6-bookworm AS builder
 
 ARG TARGETARCH
 
@@ -11,7 +11,7 @@ RUN make deps/go
 
 RUN make build
 
-FROM golang:1.23-bookworm
+FROM golang:1.23.6-bookworm
 
 RUN apt-get update && apt-get install -y ca-certificates postgresql-client
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ release:
 	$(MAKE) build/cmd/sidecar/linux-arm64
 	$(MAKE) build/cmd/sidecar/linux-amd64
 
+.PHONY: release-with-docker
+release-with-docker:
+	docker run -it --rm -v `pwd`:/build golang:1.23.6 /bin/bash -c "cd /build && make release"
+
 .PHONY: build
 build: build/cmd/sidecar
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Layr-Labs/sidecar
 
-go 1.23
+go 1.23.6
+
+toolchain go1.23.6
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/Layr-Labs/sidecar
 
 go 1.23.6
 
-toolchain go1.23.6
-
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-0
 github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQAPooM+8EVqv9w2bL4OytgY=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
-github.com/Layr-Labs/protocol-apis v1.5.1-0.20250210142820-aa0770484197 h1:Ss0wDrH7Z5pbKuYr6IeO6TilfGsgf2oE7CknbG7ohOQ=
-github.com/Layr-Labs/protocol-apis v1.5.1-0.20250210142820-aa0770484197/go.mod h1:prNA2/mLO5vpMZ2q78Nsn0m97wm28uiRnwO+/yOxigk=
 github.com/Layr-Labs/protocol-apis v1.6.0 h1:1TTi4+t8Kq4YKsji7xa3CPGYf4fHXZZbbpt3GYQWZ78=
 github.com/Layr-Labs/protocol-apis v1.6.0/go.mod h1:zCirDItAbrnEv1kV1RTccY7eVSg0+da4/dFCXHyLNZQ=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=


### PR DESCRIPTION
Updating the go.mod file to match the specs needed for codeql build.