### PR TITLE
fix: handle edgecase where indexer hangs when a block has 0 transactions

### DIFF
--- a/pkg/clients/ethereum/client.go
+++ b/pkg/clients/ethereum/client.go
@@ -347,6 +347,10 @@ func (c *Client) batchCall(ctx context.Context, requests []*RPCRequest) ([]*RPCR
 }
 
 func (c *Client) chunkedNativeBatchCall(ctx context.Context, requests []*RPCRequest) ([]*RPCResponse, error) {
+	if len(requests) == 0 {
+		c.Logger.Sugar().Warnw("No requests to batch call")
+		return make([]*RPCResponse, 0), nil
+	}
 	batches := [][]*RPCRequest{}
 
 	currentIndex := 0
@@ -414,6 +418,10 @@ type BatchedResponse struct {
 //
 // This function allows for better retry and error handling over the batch call method.
 func (c *Client) chunkedBatchCall(ctx context.Context, requests []*RPCRequest) ([]*RPCResponse, error) {
+	if len(requests) == 0 {
+		c.Logger.Sugar().Warnw("No requests to batch call")
+		return make([]*RPCResponse, 0), nil
+	}
 	batches := [][]*IndexedRpcRequestResponse{}
 
 	// all requests in a flat list with their index stored

--- a/pkg/clients/ethereum/client.go
+++ b/pkg/clients/ethereum/client.go
@@ -497,6 +497,10 @@ func (c *Client) chunkedBatchCall(ctx context.Context, requests []*RPCRequest) (
 }
 
 func (c *Client) BatchCall(ctx context.Context, requests []*RPCRequest) ([]*RPCResponse, error) {
+	if len(requests) == 0 {
+		c.Logger.Sugar().Warnw("No requests to batch call")
+		return make([]*RPCResponse, 0), nil
+	}
 	if c.clientConfig.UseNativeBatchCall {
 		return c.chunkedNativeBatchCall(ctx, requests)
 	}

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -64,6 +64,11 @@ func (f *Fetcher) FetchReceiptsForBlock(ctx context.Context, block *ethereum.Eth
 		zap.Int("count", len(txReceiptRequests)),
 		zap.Uint64("blockNumber", blockNumber),
 	)
+	receipts := make(map[string]*ethereum.EthereumTransactionReceipt)
+
+	if len(txReceiptRequests) == 0 {
+		return receipts, nil
+	}
 
 	receiptResponses, err := f.EthClient.BatchCall(ctx, txReceiptRequests)
 	if err != nil {
@@ -80,7 +85,6 @@ func (f *Fetcher) FetchReceiptsForBlock(ctx context.Context, block *ethereum.Eth
 		return nil, errors.New("failed to fetch all transaction receipts")
 	}
 
-	receipts := make(map[string]*ethereum.EthereumTransactionReceipt)
 	for _, response := range receiptResponses {
 		r, err := ethereum.RPCMethod_getTransactionReceipt.ResponseParser(response.Result)
 		if err != nil {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -141,6 +141,10 @@ func (f *Fetcher) FetchBlocks(ctx context.Context, startBlockInclusive uint64, e
 		blockNumbers = append(blockNumbers, i)
 	}
 
+	if len(blockNumbers) == 0 {
+		return []*FetchedBlock{}, nil
+	}
+
 	blockRequests := make([]*ethereum.RPCRequest, 0)
 	for i, n := range blockNumbers {
 		blockRequests = append(blockRequests, ethereum.GetBlockByNumberRequest(n, uint(i)))


### PR DESCRIPTION
## Description

Bug fix for a situation observed on holesky where the indexer would hang when trying to batch fetch 0 transactions. This was only found when using a direct node rather than a service like quiknode since we typically dont use the native batch call structure with quiknode.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit test suite and manually running the sidecar to sync against the block that had 0 transactions on holesky.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
