### PR TITLE
fix: return correct columns for claimable rewards result

### DIFF
--- a/pkg/service/rewardsDataService/rewards.go
+++ b/pkg/service/rewardsDataService/rewards.go
@@ -274,11 +274,8 @@ func (rds *RewardsDataService) GetClaimableRewardsForEarner(
 			group by earner, token
 		)
 		select
-			et.earner,
 			et.token,
-			et.amount::numeric as earned_amount,
-			coalesce(ct.amount, 0)::numeric as claimed_amount,
-			(coalesce(et.amount, 0) - coalesce(ct.amount, 0))::numeric as claimable
+			(coalesce(et.amount, 0) - coalesce(ct.amount, 0))::numeric as amount
 		from earner_tokens as et
 		left join claimed_tokens as ct on (
 			ct.token = et.token


### PR DESCRIPTION
## Description

`GetClaimableRewardsForEarner` was scanning the wrong columns into the result struct resulting in a `0` value getting returned. This fixes `GetClaimableRewardsForEarner` to select the expected columns (`token` and `amount`) for the returned struct type.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests and manual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
