### PR TITLE
fix: default to latest block in cases where blockHeight is optional

### DIFF
--- a/pkg/service/rewardsDataService/rewards.go
+++ b/pkg/service/rewardsDataService/rewards.go
@@ -243,6 +243,11 @@ func (rds *RewardsDataService) GetClaimableRewardsForEarner(
 	}
 	earner = strings.ToLower(earner)
 
+	blockHeight, err := rds.BaseDataService.GetCurrentBlockHeightIfNotPresent(ctx, blockHeight)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	snapshot, err := rds.findDistributionRootClosestToBlockHeight(blockHeight, true)
 	if err != nil {
 		return nil, nil, err
@@ -532,6 +537,9 @@ func (rds *RewardsDataService) ListAvailableRewardsTokens(ctx context.Context, e
 }
 
 func (rds *RewardsDataService) GetDistributionRootForBlockHeight(ctx context.Context, blockHeight uint64) (*rewards.DistributionRoot, error) {
+	if blockHeight == 0 {
+		return nil, fmt.Errorf("blockHeight is required")
+	}
 	query := `
 		select
 			sdr.*,


### PR DESCRIPTION
## Description

Default to latest block in cases where blockHeight is optional. When a an int filed is omitted in a grpc payload, Go sets it to `0`, which results in the endpoint returning nothing if using a blockHeight in the query.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
