### PR TITLE
fix: update query to use sql.Named rather than raw template

### DIFF
--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -811,15 +811,17 @@ func (rc *RewardsCalculator) ListDistributionRoots(blockHeight uint64) ([]*Distr
 		from submitted_distribution_roots as sdr
 		left join disabled_distribution_roots as ddr on (sdr.root_index = ddr.root_index)
 	`
+	args := make([]interface{}, 0)
 	if blockHeight > 0 {
 		query += `
-			where sdr.block_number = {{.blockHeight}}
+			where sdr.block_number = @blockHeight
 		`
+		args = append(args, sql.Named("blockHeight", blockHeight))
 	}
 	query += ` order by root_index desc`
 
 	var submittedDistributionRoots []*DistributionRoot
-	res := rc.grm.Raw(query).Scan(&submittedDistributionRoots)
+	res := rc.grm.Raw(query, args...).Scan(&submittedDistributionRoots)
 	if res.Error != nil {
 		rc.logger.Sugar().Errorw("Failed to list submitted distribution roots", "error", res.Error)
 		return nil, res.Error


### PR DESCRIPTION
## Description

Use properly escaped query param for blockHeight rather than template string.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
