### PR TITLE
fix: register MetaState models so they process logs

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/eventBus"
 	"github.com/Layr-Labs/sidecar/pkg/fetcher"
 	"github.com/Layr-Labs/sidecar/pkg/indexer"
+	"github.com/Layr-Labs/sidecar/pkg/metaState"
 	"github.com/Layr-Labs/sidecar/pkg/metaState/metaStateManager"
 	"github.com/Layr-Labs/sidecar/pkg/pipeline"
 	"github.com/Layr-Labs/sidecar/pkg/postgres"
@@ -88,10 +89,13 @@ var runDatabaseCmd = &cobra.Command{
 		}
 
 		sm := stateManager.NewEigenStateManager(l, grm)
-		msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
-
 		if err := eigenState.LoadEigenStateModels(sm, grm, l, cfg); err != nil {
 			l.Sugar().Fatalw("Failed to load eigen state models", zap.Error(err))
+		}
+
+		msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
+		if err := metaState.LoadMetaStateModels(msm, grm, l, cfg); err != nil {
+			l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
 		}
 
 		fetchr := fetcher.NewFetcher(client, cfg, l)

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/eventBus"
 	"github.com/Layr-Labs/sidecar/pkg/fetcher"
 	"github.com/Layr-Labs/sidecar/pkg/indexer"
+	"github.com/Layr-Labs/sidecar/pkg/metaState"
 	"github.com/Layr-Labs/sidecar/pkg/metaState/metaStateManager"
 	"github.com/Layr-Labs/sidecar/pkg/pipeline"
 	"github.com/Layr-Labs/sidecar/pkg/postgres"
@@ -84,10 +85,13 @@ func main() {
 	}
 
 	sm := stateManager.NewEigenStateManager(l, grm)
-	msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
-
 	if err := eigenState.LoadEigenStateModels(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to load eigen state models", zap.Error(err))
+	}
+
+	msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
+	if err := metaState.LoadMetaStateModels(msm, grm, l, cfg); err != nil {
+		l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
 	}
 
 	fetchr := fetcher.NewFetcher(client, cfg, l)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/eventBus"
 	"github.com/Layr-Labs/sidecar/pkg/fetcher"
 	"github.com/Layr-Labs/sidecar/pkg/indexer"
+	"github.com/Layr-Labs/sidecar/pkg/metaState"
 	"github.com/Layr-Labs/sidecar/pkg/metaState/metaStateManager"
 	"github.com/Layr-Labs/sidecar/pkg/pipeline"
 	"github.com/Layr-Labs/sidecar/pkg/postgres"
@@ -103,10 +104,13 @@ var runCmd = &cobra.Command{
 		}
 
 		sm := stateManager.NewEigenStateManager(l, grm)
-		msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
-
 		if err := eigenState.LoadEigenStateModels(sm, grm, l, cfg); err != nil {
 			l.Sugar().Fatalw("Failed to load eigen state models", zap.Error(err))
+		}
+
+		msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
+		if err := metaState.LoadMetaStateModels(msm, grm, l, cfg); err != nil {
+			l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
 		}
 
 		fetchr := fetcher.NewFetcher(client, cfg, l)

--- a/pkg/pipeline/pipelineIntegration_test.go
+++ b/pkg/pipeline/pipelineIntegration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/Layr-Labs/sidecar/pkg/metaState"
 	"log"
 	"testing"
 
@@ -91,11 +92,15 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 
 	sm := stateManager.NewEigenStateManager(l, grm)
-	msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
-
 	if err := eigenState.LoadEigenStateModels(sm, grm, l, cfg); err != nil {
 		l.Sugar().Fatalw("Failed to load eigen state models", zap.Error(err))
 	}
+
+	msm := metaStateManager.NewMetaStateManager(grm, l, cfg)
+	if err := metaState.LoadMetaStateModels(msm, grm, l, cfg); err != nil {
+		l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
+	}
+
 	sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
 	rc, _ := rewards.NewRewardsCalculator(cfg, grm, mds, sog, sdc, l)
 

--- a/pkg/postgres/migrations/202502211539_hydrateClaimedRewards/up.go
+++ b/pkg/postgres/migrations/202502211539_hydrateClaimedRewards/up.go
@@ -1,0 +1,42 @@
+package _202502211539_hydrateClaimedRewards
+
+import (
+	"database/sql"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	query := `
+		insert into rewards_claimed (root, token, claimed_amount, earner, claimer, recipient, transaction_hash, block_number, log_index)
+		select
+			concat('0x', (
+			  SELECT lower(string_agg(lpad(to_hex(elem::int), 2, '0'), ''))
+			  FROM jsonb_array_elements_text(tl.output_data->'root') AS elem
+			)) AS root,
+			lower(tl.output_data->>'token'::text) as token,
+			cast(tl.output_data->>'claimedAmount' as numeric) as claimed_amount,
+			lower(tl.arguments #>> '{1, Value}') as earner,
+			lower(tl.arguments #>> '{2, Value}') as claimer,
+			lower(coalesce(tl.arguments #>> '{3, Value}', '')) as recipient,
+			tl.transaction_hash,
+			tl.block_number,
+			tl.log_index
+		from transaction_logs as tl
+		where
+			tl.address = @rewardsCoordinatorAddress
+			and tl.event_name = 'RewardsClaimed'
+		order by tl.block_number asc
+		on conflict do nothing
+	`
+	contractAddresses := cfg.GetContractsMapForChain()
+	res := grm.Exec(query, sql.Named("rewardsCoordinatorAddress", contractAddresses.RewardsCoordinator))
+	return res.Error
+}
+
+func (m *Migration) GetName() string {
+	return "202502211539_hydrateClaimedRewards"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	_202501241111_addIndexesForRpcFunctions "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501241111_addIndexesForRpcFunctions"
 	_202502100846_goldTableRewardHashIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502100846_goldTableRewardHashIndex"
+	_202502211539_hydrateClaimedRewards "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502211539_hydrateClaimedRewards"
 	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
@@ -138,6 +139,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202501071401_defaultOperatorSplitSnapshots.Migration{},
 		&_202501241111_addIndexesForRpcFunctions.Migration{},
 		&_202502100846_goldTableRewardHashIndex.Migration{},
+		&_202502211539_hydrateClaimedRewards.Migration{},
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Description

A bug was reported that ClaimedRewards rows seemed missing. After investigating and observing that the parsed transaction logs were present, it was discovered that the MetaState model wasnt registered to process log events.

This PR registers the MetaState models and adds a migration to process any logs that have been missed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
