### PR TITLE
fix: ignore reward submissions with a duration of 0

### DIFF
--- a/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
+++ b/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
@@ -142,6 +142,15 @@ func (odrs *OperatorDirectedRewardSubmissionsModel) handleOperatorDirectedReward
 	}
 	outputRewardData := outputData.OperatorDirectedRewardsSubmission
 
+	if outputRewardData.Duration == 0 {
+		odrs.logger.Sugar().Infow("Skipping operator directed reward submission with zero duration",
+			zap.Uint64("blockNumber", log.BlockNumber),
+			zap.String("transactionHash", log.TransactionHash),
+			zap.Uint64("logIndex", log.LogIndex),
+		)
+		return []*OperatorDirectedRewardSubmission{}, nil
+	}
+
 	rewardSubmissions := make([]*OperatorDirectedRewardSubmission, 0)
 
 	for i, strategyAndMultiplier := range outputRewardData.StrategiesAndMultipliers {

--- a/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions_test.go
+++ b/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions_test.go
@@ -171,6 +171,41 @@ func Test_OperatorDirectedRewardSubmissions(t *testing.T) {
 		})
 	})
 
+	t.Run("Ensure an operator directed reward submission with a duration of 0 is not saved", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(l, grm)
+		model, err := NewOperatorDirectedRewardSubmissionsModel(esm, grm, l, cfg)
+
+		blockNumber := uint64(102)
+
+		if err := createBlock(model, blockNumber); err != nil {
+			t.Fatal(err)
+		}
+
+		log := &storage.TransactionLog{
+			TransactionHash:  "some hash",
+			TransactionIndex: big.NewInt(100).Uint64(),
+			BlockNumber:      blockNumber,
+			Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
+			Arguments:        `[{"Name": "caller", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "avs", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "operatorDirectedRewardsSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": false}, {"Name": "rewardsSubmission", "Type": "((address,uint96)[],address,(address,uint256)[],uint32,uint32,string)", "Value": null, "Indexed": false}]`,
+			EventName:        "OperatorDirectedAVSRewardsSubmissionCreated",
+			LogIndex:         big.NewInt(12).Uint64(),
+			OutputData:       `{"submissionNonce": 0, "operatorDirectedRewardsSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "operatorRewards": [{"operator": "0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1", "amount": 30000000000000000000000}, {"operator": "0xF50Cba7a66b5E615587157e43286DaA7aF94009e", "amount": 40000000000000000000000}], "duration": 0, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}, {"strategy": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc", "multiplier": 2000000000000000000}], "description": "test reward submission"}}`,
+		}
+
+		err = model.SetupStateForBlock(blockNumber)
+		assert.Nil(t, err)
+
+		isInteresting := model.IsInterestingLog(log)
+		assert.True(t, isInteresting)
+
+		change, err := model.HandleStateChange(log)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+
+		typedChanges := change.([]*OperatorDirectedRewardSubmission)
+		assert.Equal(t, 0, len(typedChanges))
+	})
+
 	t.Cleanup(func() {
 		postgres.TeardownTestDatabase(dbName, cfg, grm, l)
 	})

--- a/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions_test.go
+++ b/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions_test.go
@@ -174,6 +174,7 @@ func Test_OperatorDirectedRewardSubmissions(t *testing.T) {
 	t.Run("Ensure an operator directed reward submission with a duration of 0 is not saved", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(l, grm)
 		model, err := NewOperatorDirectedRewardSubmissionsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
 
 		blockNumber := uint64(102)
 

--- a/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
+++ b/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
@@ -127,6 +127,15 @@ func (rs *RewardSubmissionsModel) handleRewardSubmissionCreatedEvent(log *storag
 		actualOuputData = outputData.RewardsSubmission
 	}
 
+	if actualOuputData.Duration == 0 {
+		rs.logger.Sugar().Debugw("Skipping reward submission with zero duration",
+			zap.Uint64("blockNumber", log.BlockNumber),
+			zap.String("transactionHash", log.TransactionHash),
+			zap.Uint64("logIndex", log.LogIndex),
+		)
+		return []*RewardSubmission{}, nil
+	}
+
 	rewardSubmissions := make([]*RewardSubmission, 0)
 
 	for i, strategyAndMultiplier := range actualOuputData.StrategiesAndMultipliers {


### PR DESCRIPTION
Found during the rewards v2.1 audit, this prevents a potential division by 0 case since non-zero durations are not enforced by the RewardsCoordinator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added additional EigenState model tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
