### PR TITLE
fix: make sure actions run on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
       - '**'
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - '**'
   workflow_dispatch:
 jobs:
   custom-runner-test:


### PR DESCRIPTION
## Description

Fix github actions workflow to ensure they run even on PRs that originate from cloned repos coming back into the main sidecar repo.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
