### PR TITLE
fix: set default manifest url, fix json unmarshalling, update docs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ func init() {
 
 	restoreSnapshotCmd.PersistentFlags().String(config.SnapshotInputFile, "", "(deprecated, use --input) Path to the snapshot file")
 	restoreSnapshotCmd.PersistentFlags().String(config.SnapshotInput, "", "Path to the snapshot file")
-	restoreSnapshotCmd.PersistentFlags().String(config.SnapshotManifestUrl, "", "URL to the snapshot manifest file")
+	restoreSnapshotCmd.PersistentFlags().String(config.SnapshotManifestUrl, "https://sidecar.eigenlayer.xyz/snapshots/manifest.json", "URL to the snapshot manifest file")
 	restoreSnapshotCmd.PersistentFlags().Bool(config.SnapshotVerifyHash, true, "Verify the hash of the snapshot file")
 	restoreSnapshotCmd.PersistentFlags().Bool(config.SnapshotVerifySignature, false, "Verify the signature of the snapshot file")
 	restoreSnapshotCmd.PersistentFlags().String(config.SnapshotKind, "full", "The kind of snapshot to restore (slim, full, or archive)")

--- a/docs/src/content/docs/running/getting-started.mdx
+++ b/docs/src/content/docs/running/getting-started.mdx
@@ -23,90 +23,51 @@ import { Steps } from '@astrojs/starlight/components';
 <Steps>
 1. Download the Sidecar binary
 
-    ```bash
-    VERSION="v2.0.0"
-    curl -s -L https://github.com/Layr-Labs/sidecar/releases/download/v2.0.0/sidecar-darwin-amd64-v2.0.0.tar.gz | tar xvz -C /usr/local/bin
-    ```
+	```bash
+	VERSION="v2.4.0"
+	curl -s -L "https://github.com/Layr-Labs/sidecar/releases/download/${VERSION}/sidecar-darwin-amd64-${VERSION}.tar.gz" | tar xvz -C /usr/local/bin
+	```
 
 2. Create a database for your sidecar
 
-    Assuming that you have PostgreSQL installed locally, or access to a remote PostgreSQL instance, you can create a database for your sidecar:
+	Assuming that you have PostgreSQL installed locally, or access to a remote PostgreSQL instance, you can create a database for your sidecar:
 
-    ```bash
-    psql --host <host> --port 5432 --user <username> --password
+	```bash
+	psql --host <host> --port 5432 --user <username> --password
 
-    CREATE DATABASE sidecar;
-    ```
+	CREATE DATABASE sidecar;
+	```
 
-    Please see the ["Advanced PostgreSQL Config"](running/advanced-postgres) for more information on setting up your PostgreSQL database.
+	Please see the ["Advanced PostgreSQL Config"](running/advanced-postgres) for more information on setting up your PostgreSQL database.
 
-    #### Using a snapshot
+	#### Using a snapshot
 
-    If you are launching a Sidecar for Holesky, you will need to use a snapshot to intialize your database. Detailed directions can be found on the ["restore from snapshot"](running/snapshots) page.
+	If you are launching a Sidecar for Holesky, you will need to use a snapshot to intialize your database. Detailed directions can be found on the ["restore from snapshot"](running/snapshots) page.
 
-    ```bash
-    curl -LO https://eigenlayer-sidecar.s3.us-east-1.amazonaws.com/snapshots/testnet-holesky/sidecar-testnet-holesky_v3.0.0-rc.1_public_20250122.dump
+	```bash
+	curl -LO https://eigenlayer-sidecar.s3.us-east-1.amazonaws.com/snapshots/testnet-holesky/sidecar-testnet-holesky_v3.0.0-rc.1_public_20250122.dump
 
-    /usr/local/bin/sidecar restore-snapshot \
-      --input_file=sidecar-testnet-holesky_v3.0.0-rc.1_public_20250122.dump \
-      --database.host=<postgres host> \
-      --database.user=<postgres user> \
-      --database.password=<postgres password> \
-      --database.port=5432 \
-      --database.db_name=sidecar \
-      --database.schema_name=public
+	sidecar restore-snapshot \                                                                                                                                                                                                                                                         (sm-fixManifest✱)
+		--ethereum.rpc-url="<rpc url>" \
+		--chain="mainnet" \
+		--database.host="<hostname>" \
+		--database.port="5432" \
+		--database.user="<username>" \
+		--database.password="<password>" \
+		--database.db_name="<database name>" \
+		--kind="full"
     ```
 
 3. Launch your Sidecar
 
-    ```bash
-    /usr/local/bin/sidecar
-        --ethereum.rpc-url="http://<your-ethereum-rpc-url>" \
-        --chain="mainnet" \
-        --database.host="<postgres host>" \
-        --database.port="5432" \
-        --database.user="<postgres user>" \
-        --database.password="<postgres password>" \
-        --database.db_name="sidecar"
-    ```
-
+	```bash
+	/usr/local/bin/sidecar
+		--ethereum.rpc-url="http://<your-ethereum-rpc-url>" \
+		--chain="mainnet" \
+		--database.host="<postgres host>" \
+		--database.port="5432" \
+		--database.user="<postgres user>" \
+		--database.password="<postgres password>" \
+		--database.db_name="sidecar"
+	```
 </Steps>
-
-
-### Sidecar runtime flags
-
-```bash
-sidecar --help
-
-Run the sidecar
-
-Usage:
-  sidecar run [flags]
-
-Flags:
-  -h, --help   help for run
-
-Global Flags:
-  -c, --chain string                              The chain to use (mainnet, holesky, preprod (default "mainnet")
-      --database.db_name string                   PostgreSQL database name (default "sidecar")
-      --database.host string                      PostgreSQL host (default "localhost")
-      --database.password string                  PostgreSQL password
-      --database.port int                         PostgreSQL port (default 5432)
-      --database.schema_name string               PostgreSQL schema name (default "public")
-      --database.user string                      PostgreSQL username (default "sidecar")
-      --datadog.statsd.enabled                    e.g. "true" or "false"
-      --datadog.statsd.url string                 e.g. "localhost:8125"
-      --debug                                     "true" or "false"
-      --ethereum.chunked_batch_call_size int      The number of calls to make in parallel when using the chunked batch call method (default 10)
-      --ethereum.contract_call_batch_size int     The number of contract calls to batch together when fetching data from the Ethereum node (default 25)
-      --ethereum.native_batch_call_size int       The number of calls to batch together when using the native eth_call method (default 500)
-      --ethereum.rpc-url string                   e.g. "http://<hostname>:8545"
-      --ethereum.use_native_batch_call            Use the native eth_call method for batch calls (default true)
-      --prometheus.enabled                        e.g. "true" or "false"
-      --prometheus.port int                       The port to run the prometheus server on (default 2112)
-      --rewards.generate_staker_operators_table   Generate staker operators table while indexing
-      --rewards.validate_rewards_root             Validate rewards roots while indexing (default true)
-      --rpc.grpc-port int                         gRPC port (default 7100)
-      --rpc.http-port int                         http rpc port (default 7101)
-
-```

--- a/docs/src/content/docs/running/snapshots.md
+++ b/docs/src/content/docs/running/snapshots.md
@@ -5,23 +5,45 @@ description: How to use a snapshot to start or restore your Sidecar
 
 Snapshots are a quicker way to sync to tip and get started.
 
-See [Snapshots Docs](old-docs/snapshots_docs.md) for instructions on creating and restoring snapshots
+## Available snapshots
 
-## Snapshot Sources
+All available snapshots can be found at [https://sidecar.eigenlayer.xyz/snapshots](https://sidecar.eigenlayer.xyz/snapshots).
 
-* Mainnet Ethereum (not yet available)
-* Testnet Holesky ([2025-01-22](https://eigenlayer-sidecar.s3.us-east-1.amazonaws.com/snapshots/testnet-holesky/sidecar-testnet-holesky_v3.0.0-rc.1_public_20250122.dump))
+## Snapshot types
 
-## Example boot from testnet snapshot
+* **Slim:** Only includes indexed chain data and EigenState. Slim snapshots are roughly 30% of the size of full snapshots and can generate the rewards data found in full snapshots.
+* **Full:** Includes all rewards data but _not_ the generated `staker-operator` data for attributable rewards. 
+* **Archive:** (Not yet available) Includes all rewards data and the generated `staker-operator` data for attributable rewards.
+
+## Restoring from a snapshot
+
+### Using the hosted manifest
+
 ```bash
-curl -LO https://eigenlayer-sidecar.s3.us-east-1.amazonaws.com/snapshots/testnet-holesky/sidecar-testnet-holesky_v3.0.0-rc.1_public_20250122.dump
+sidecar restore-snapshot \                                                                                                                                                                                                                                                         (sm-fixManifest✱) 
+    --ethereum.rpc-url="<rpc url>" \
+    --chain="mainnet" \
+    --database.host="<hostname>" \
+    --database.port="5432" \
+    --database.user="<username>" \
+    --database.password="<password>" \
+    --database.db_name="<database name>" \
+    --kind="full"
+```
 
-./bin/sidecar restore-snapshot \
-  --input_file=sidecar-testnet-holesky_v3.0.0-rc.1_public_20250122.dump \
-  --database.host=localhost \
-  --database.user=sidecar \
-  --database.password=... \
-  --database.port=5432 \
-  --database.db_name=sidecar \
-  --database.schema_name=public 
+### Providing a file directly
+
+Input files can be either a local file or a URL.
+
+```bash
+sidecar restore-snapshot \
+  --ethereum.rpc-url="<rpc url>" \
+    --chain="mainnet" \
+    --database.host="<hostname>" \
+    --database.port="5432" \
+    --database.user="<username>" \
+    --database.password="<password>" \
+    --database.db_name="<database name>" \
+  --input="https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.4.0_public_20250227160000.dump" \
+  --verify-hash=false # unless you have a corresponding sha256sum hash 
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,6 +221,8 @@ func NewConfig() *Config {
 			InputFile:       StringWithDefaults(viper.GetString(normalizeFlagName(SnapshotInput)), viper.GetString(normalizeFlagName(SnapshotInputFile))),
 			VerifyHash:      viper.GetBool(normalizeFlagName(SnapshotVerifyHash)),
 			VerifySignature: viper.GetBool(normalizeFlagName(SnapshotVerifySignature)),
+			ManifestUrl:     viper.GetString(normalizeFlagName(SnapshotManifestUrl)),
+			Kind:            StringWithDefault(viper.GetString(normalizeFlagName(SnapshotKind)), "full"),
 		},
 
 		RpcConfig: RpcConfig{

--- a/pkg/snapshot/snapshotManifest/metadata.go
+++ b/pkg/snapshot/snapshotManifest/metadata.go
@@ -78,7 +78,7 @@ func (sm *SnapshotManifest) FindSnapshot(chain string, sidecarVersion string, sc
 func NewSnapshotManifestFromJson(data []byte) (*SnapshotManifest, error) {
 	var manifest *SnapshotManifest
 
-	if err := json.Unmarshal(data, manifest); err != nil {
+	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, err
 	}
 	return manifest, nil

--- a/pkg/snapshot/snapshotManifest/metadata_test.go
+++ b/pkg/snapshot/snapshotManifest/metadata_test.go
@@ -18,3 +18,506 @@ func Test_CreatedAtTimeParsing(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, snapshot.CreatedAt.Format(time.RFC3339), "2025-08-10T15:00:00Z")
 }
+
+func Test_UnmarshalJsonToManifest(t *testing.T) {
+	inputJson := `
+		{
+	"metadata": {
+		"version": "v1.0.0"
+	},
+	"snapshots": [
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T15:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227153000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T14:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227143001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T13:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227133001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T12:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227123000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T12:00:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.4.0_public_20250227120001.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T11:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227113000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T10:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227103000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T09:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227093000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T08:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227083000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T08:00:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.4.0_public_20250227080000.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T07:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227073000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T06:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227063000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T05:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227053000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T04:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227043001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T04:00:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.4.0_public_20250227040001.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T03:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227033000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T02:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227023001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T01:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227013000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T00:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250227003000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-27T00:00:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.4.0_public_20250227000000.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T23:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226233000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T22:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226223001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T21:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226213000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T20:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226203001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T20:00:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.4.0_public_20250226200000.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T19:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226193001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T18:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226183000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T17:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226173000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T16:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226163000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T16:00:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.4.0_public_20250226160000.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T15:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226153000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.4.0",
+			"createdAt": "2025-02-26T14:30:15Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.4.0_public_20250226143015.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T13:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226133000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T12:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226123000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T12:00:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.3.1+6e29089_public_20250226120001.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T11:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226113000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T10:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226103000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T09:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226093000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T08:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226083001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T08:00:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.3.1+6e29089_public_20250226080000.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T07:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226073000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T06:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226063000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T05:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226053000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T04:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226043001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T04:00:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.3.1+6e29089_public_20250226040000.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T03:30:14Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226033014.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T02:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226023001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T01:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226013000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T00:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250226003000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-26T00:00:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_full_v2.3.1+6e29089_public_20250226000000.dump",
+			"schema": "public",
+			"kind": "full",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-25T23:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250225233000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-25T22:30:00Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250225223000.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-25T21:30:01Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250225213001.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		},
+		{
+			"sidecarVersion": "v2.3.1+6e29089",
+			"createdAt": "2025-02-25T21:00:19Z",
+			"chain": "mainnet",
+			"url": "https://sidecar.eigenlayer.xyz/snapshots/mainnet/sidecar_mainnet_slim_v2.3.1+6e29089_public_20250225210019.dump",
+			"schema": "public",
+			"kind": "slim",
+			"signature": ""
+		}
+	]
+}
+	`
+
+	manifest, err := NewSnapshotManifestFromJson([]byte(inputJson))
+	assert.Nil(t, err)
+	assert.Equal(t, manifest.Metadata.Version, "v1.0.0")
+	assert.Equal(t, len(manifest.Snapshots), 54)
+}


### PR DESCRIPTION
## Description

* Fix bug with unmarshalling the manifest json to the destination struct
* Sets the default manifest url to https://sidecar.eigenlayer.xyz/snapshots/manifest.json
* Update the docs to reflect recent changes/improvements with creating and restoring snapshots

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docs (documentation updates)

## How Has This Been Tested?

Added another test to check for correct unmarshalling of json.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
