### PR TITLE
feat(sidecar-extensibility): add load-contract cli to side-load any contracts to sidecar

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/Layr-Labs/sidecar/internal/metrics"
@@ -30,9 +32,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
-	"log"
-	"net/http"
-	"time"
 )
 
 var runDatabaseCmd = &cobra.Command{
@@ -63,7 +62,7 @@ var runDatabaseCmd = &cobra.Command{
 
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
-		af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, cfg, []abiSource.AbiSource{})
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -119,7 +118,7 @@ var runDatabaseCmd = &cobra.Command{
 
 		rcq := rewardsCalculatorQueue.NewRewardsCalculatorQueue(rc, l)
 
-		_ = pipeline.NewPipeline(fetchr, idxr, mds, sm, msm, rc, rcq, cfg, sdc, eb, l)
+		_ = pipeline.NewPipeline(fetchr, idxr, mds, contractStore, cm, sm, msm, rc, rcq, cfg, sdc, eb, l)
 
 		l.Sugar().Infow("Done")
 	},

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"time"
+
+	"log"
 
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
@@ -30,7 +30,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/service/rewardsDataService"
 	"github.com/Layr-Labs/sidecar/pkg/sidecar"
 	pgStorage "github.com/Layr-Labs/sidecar/pkg/storage/postgres"
-	"log"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
@@ -60,7 +59,7 @@ func main() {
 
 	client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
-	af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, cfg, []abiSource.AbiSource{})
+	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
 
 	pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -116,7 +115,7 @@ func main() {
 
 	rcq := rewardsCalculatorQueue.NewRewardsCalculatorQueue(rc, l)
 
-	p := pipeline.NewPipeline(fetchr, idxr, mds, sm, msm, rc, rcq, cfg, sdc, eb, l)
+	p := pipeline.NewPipeline(fetchr, idxr, mds, contractStore, cm, sm, msm, rc, rcq, cfg, sdc, eb, l)
 	rps := proofs.NewRewardsProofsStore(rc, l)
 	pds := protocolDataService.NewProtocolDataService(sm, grm, l, cfg)
 	rds := rewardsDataService.NewRewardsDataService(grm, l, cfg, rc)

--- a/cmd/loadContract.go
+++ b/cmd/loadContract.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
+	"github.com/Layr-Labs/sidecar/pkg/abiSource"
+	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
+	"github.com/Layr-Labs/sidecar/pkg/contractStore"
+	"github.com/Layr-Labs/sidecar/pkg/contractStore/postgresContractStore"
+	"github.com/Layr-Labs/sidecar/pkg/postgres"
+	"github.com/Layr-Labs/sidecar/pkg/postgres/helpers"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/internal/logger"
+	"github.com/Layr-Labs/sidecar/pkg/postgres/migrations"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"gorm.io/gorm"
+)
+
+var loadContractCmd = &cobra.Command{
+	Use:   "load-contract [file]",
+	Short: "Load a contract",
+	Long:  `Load a contract from a file or stdin. If a file path is provided as the last argument, it will be used. If no file is provided, it will attempt to read from stdin.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		initLoadContractCmd(cmd)
+		cfg := config.NewConfig()
+
+		ctx := context.Background()
+
+		l, err := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
+		if err != nil {
+			return fmt.Errorf("failed to initialize logger: %w", err)
+		}
+
+		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
+
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+
+		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
+
+		pg, err := postgres.NewPostgres(pgConfig)
+		if err != nil {
+			return fmt.Errorf("failed to setup postgres connection: %w", err)
+		}
+
+		grm, err := postgres.NewGormFromPostgresConnection(pg.Db)
+		if err != nil {
+			return fmt.Errorf("failed to create gorm instance: %w", err)
+		}
+
+		migrator := migrations.NewMigrator(pg.Db, grm, l, cfg)
+		if err = migrator.MigrateAll(); err != nil {
+			return fmt.Errorf("failed to migrate: %w", err)
+		}
+
+		cs := postgresContractStore.NewPostgresContractStore(grm, l, cfg)
+
+		var filename string
+		var useFile bool
+		var useStdin bool
+
+		// Check if a file path is provided as a positional argument
+		if len(args) > 0 {
+			filename = args[0]
+			useFile = true
+		} else if cfg.LoadContractConfig.FromFile != "" {
+			// Check if a file path is provided via the --from-file flag
+			filename = cfg.LoadContractConfig.FromFile
+			useFile = true
+		} else {
+			// Check if we should read from stdin (if stdin is not a terminal)
+			stdinInfo, err := os.Stdin.Stat()
+			if err == nil && (stdinInfo.Mode()&os.ModeCharDevice) == 0 {
+				useStdin = true
+			}
+		}
+
+		// Process based on input source
+		if cfg.LoadContractConfig.Batch {
+			if useFile {
+				// Load contracts from file
+				err := cs.InitializeExternalContracts(filename)
+				if err != nil {
+					return fmt.Errorf("failed to initialize external contracts from file: %w", err)
+				}
+				return nil
+			}
+			if useStdin {
+				// Read directly from stdin
+				err := cs.InitializeExternalContractsFromReader(os.Stdin)
+				if err != nil {
+					return fmt.Errorf("failed to initialize external contracts from stdin: %w", err)
+				}
+				return nil
+			}
+			// If batch mode is enabled but no input source is provided
+			return fmt.Errorf("batch mode requires a file path or stdin input")
+		} else {
+			// If no file or stdin is provided, use the individual contract parameters
+			blockNumber := cfg.LoadContractConfig.BlockNumber
+			address := cfg.LoadContractConfig.Address
+			abi := cfg.LoadContractConfig.Abi
+			bytecodeHash := cfg.LoadContractConfig.BytecodeHash
+			associateToProxy := cfg.LoadContractConfig.AssociateToProxy
+
+			// Validate required parameters
+			if address == "" {
+				return fmt.Errorf("contract address is required in --contract.address")
+			}
+			if abi == "" {
+				return fmt.Errorf("contract ABI is required with the contract address in --contract.abi")
+			}
+			// Fetch bytecode hash if not provided
+			if bytecodeHash == "" {
+				bytecodeHash, err = af.FetchContractBytecodeHash(ctx, address)
+				if err != nil {
+					return fmt.Errorf("failed to fetch contract bytecode hash: %w", err)
+				}
+			}
+
+			// Wrap contract creation and proxy association in a transaction
+			_, err = helpers.WrapTxAndCommit[*contractStore.Contract](func(tx *gorm.DB) (*contractStore.Contract, error) {
+				// Create a temporary contract store with the transaction
+				txContractStore := postgresContractStore.NewPostgresContractStore(tx, l, cfg)
+
+				// Load the contract
+				contract, err := txContractStore.CreateContract(
+					address,
+					abi,
+					true,
+					bytecodeHash,
+					"",
+					true,
+					contractStore.ContractType_External,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load contract: %w", err)
+				}
+
+				// Associate to proxy if specified
+				if associateToProxy != "" {
+					proxyContract, err := txContractStore.GetContractForAddress(associateToProxy)
+					if err != nil {
+						return nil, fmt.Errorf("error checking for proxy contract: %w", err)
+					}
+					if proxyContract == nil {
+						return nil, fmt.Errorf("proxy contract %s not found", associateToProxy)
+					}
+					if blockNumber == 0 {
+						return nil, fmt.Errorf("block number is required to load a proxy contract")
+					}
+					_, err = txContractStore.CreateProxyContract(blockNumber, associateToProxy, address)
+					if err != nil {
+						return nil, fmt.Errorf("failed to load to proxy contract: %w", err)
+					}
+				}
+
+				return contract, nil
+			}, grm, nil)
+
+			if err != nil {
+				return fmt.Errorf("failed to load contract with transaction: %w", err)
+			}
+
+			return nil
+		}
+	},
+}
+
+func initLoadContractCmd(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if err := viper.BindPFlag(config.KebabToSnakeCase(f.Name), f); err != nil {
+			fmt.Printf("Failed to bind flag '%s' - %+v\n", f.Name, err)
+		}
+		if err := viper.BindEnv(f.Name); err != nil {
+			fmt.Printf("Failed to bind env '%s' - %+v\n", f.Name, err)
+		}
+	})
+}

--- a/cmd/operatorRestakedStrategies.go
+++ b/cmd/operatorRestakedStrategies.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/Layr-Labs/sidecar/internal/metrics"
@@ -23,9 +25,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
-	"log"
-	"net/http"
-	"time"
 )
 
 var runOperatorRestakedStrategiesCmd = &cobra.Command{
@@ -50,7 +49,7 @@ var runOperatorRestakedStrategiesCmd = &cobra.Command{
 
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
-		af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, cfg, []abiSource.AbiSource{})
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func init() {
 	rootCmd.AddCommand(createSnapshotCmd)
 	rootCmd.AddCommand(restoreSnapshotCmd)
 	rootCmd.AddCommand(rpcCmd)
+	rootCmd.AddCommand(loadContractCmd)
 
 	// bind any subcommand flags
 	createSnapshotCmd.PersistentFlags().String(config.SnapshotOutputFile, "", "(deprecated, use --output) Path to save the snapshot file")
@@ -82,6 +83,14 @@ func init() {
 	restoreSnapshotCmd.PersistentFlags().String(config.SnapshotKind, "full", "The kind of snapshot to restore (slim, full, or archive)")
 
 	rpcCmd.PersistentFlags().String(config.SidecarPrimaryUrl, "", `RPC url of the "primary" Sidecar instance in an HA environment`)
+
+	loadContractCmd.PersistentFlags().String(config.LoadContractAddress, "", "Contract address to load")
+	loadContractCmd.PersistentFlags().String(config.LoadContractAbi, "", "ABI for the contract")
+	loadContractCmd.PersistentFlags().String(config.LoadContractBytecodeHash, "", "Bytecode hash for the contract")
+	loadContractCmd.PersistentFlags().String(config.LoadContractAssociateToProxy, "", "Contract address to associate to the proxy")
+	loadContractCmd.PersistentFlags().Uint64(config.LoadContractBlockNumber, uint64(0), "Block number for proxy contract deployment")
+	loadContractCmd.PersistentFlags().Bool(config.LoadContractBatch, false, "Batch load contracts from a JSON file")
+	loadContractCmd.PersistentFlags().String(config.LoadContractFromFile, "", "Path to a JSON file containing contract addresses to load")
 
 	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		key := config.KebabToSnakeCase(f.Name)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,16 @@ type SidecarPrimaryConfig struct {
 	IsPrimary bool
 }
 
+type LoadContractConfig struct {
+	Address          string
+	Abi              string
+	BytecodeHash     string
+	AssociateToProxy string
+	BlockNumber      uint64
+	Batch            bool
+	FromFile         string
+}
+
 type IpfsConfig struct {
 	Url string
 }
@@ -137,6 +147,7 @@ type Config struct {
 	DataDogConfig         DataDogConfig
 	PrometheusConfig      PrometheusConfig
 	SidecarPrimaryConfig  SidecarPrimaryConfig
+	LoadContractConfig    LoadContractConfig
 	IpfsConfig            IpfsConfig
 	EtherscanConfig       EtherscanConfig
 }
@@ -200,6 +211,14 @@ var (
 	PrometheusPort    = "prometheus.port"
 
 	SidecarPrimaryUrl = "sidecar-primary.url"
+
+	LoadContractAddress          = "contract.address"
+	LoadContractAbi              = "contract.abi"
+	LoadContractBytecodeHash     = "contract.bytecode-hash"
+	LoadContractAssociateToProxy = "contract.associate-to-proxy"
+	LoadContractBlockNumber      = "contract.block-number"
+	LoadContractBatch            = "contract.batch"
+	LoadContractFromFile         = "contract.from-file"
 
 	IpfsUrl = "ipfs.url"
 
@@ -272,6 +291,16 @@ func NewConfig() *Config {
 
 		SidecarPrimaryConfig: SidecarPrimaryConfig{
 			Url: viper.GetString(normalizeFlagName(SidecarPrimaryUrl)),
+		},
+
+		LoadContractConfig: LoadContractConfig{
+			Address:          viper.GetString(normalizeFlagName(LoadContractAddress)),
+			Abi:              viper.GetString(normalizeFlagName(LoadContractAbi)),
+			BytecodeHash:     viper.GetString(normalizeFlagName(LoadContractBytecodeHash)),
+			AssociateToProxy: viper.GetString(normalizeFlagName(LoadContractAssociateToProxy)),
+			BlockNumber:      viper.GetUint64(normalizeFlagName(LoadContractBlockNumber)),
+			Batch:            viper.GetBool(normalizeFlagName(LoadContractBatch)),
+			FromFile:         viper.GetString(normalizeFlagName(LoadContractFromFile)),
 		},
 
 		IpfsConfig: IpfsConfig{

--- a/pkg/abiSource/ipfs/ipfs.go
+++ b/pkg/abiSource/ipfs/ipfs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/btcsuite/btcutil/base58"
@@ -31,6 +32,12 @@ func NewIpfs(hc *http.Client, l *zap.Logger, cfg *config.Config) *Ipfs {
 		httpClient: hc,
 		logger:     l,
 		config:     cfg,
+	}
+}
+
+func DefaultHttpClient() *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
 	}
 }
 

--- a/pkg/contractManager/contractManager.go
+++ b/pkg/contractManager/contractManager.go
@@ -151,12 +151,22 @@ func (cm *ContractManager) CreateUpgradedProxyContract(
 		return err
 	}
 
-	// Fetch ABIs
-	bytecodeHash, abi, err := cm.AbiFetcher.FetchContractDetails(ctx, proxyContractAddress)
+	// Fetch bytecode hash
+	bytecodeHash, err := cm.AbiFetcher.FetchContractBytecodeHash(ctx, proxyContractAddress)
 	if err != nil {
-		cm.Logger.Sugar().Errorw("Failed to fetch metadata from proxy contract",
+		cm.Logger.Sugar().Errorw("Failed to fetch contract bytecode hash",
 			zap.Error(err),
-			zap.String("proxyContractAddress", proxyContractAddress),
+			zap.String("address", proxyContractAddress),
+		)
+		return err
+	}
+
+	// Fetch ABI
+	abi, err := cm.AbiFetcher.FetchContractAbi(ctx, proxyContractAddress)
+	if err != nil {
+		cm.Logger.Sugar().Errorw("Failed to fetch contract abi",
+			zap.Error(err),
+			zap.String("address", proxyContractAddress),
 		)
 		return err
 	}
@@ -169,14 +179,16 @@ func (cm *ContractManager) CreateUpgradedProxyContract(
 		bytecodeHash,
 		"",
 		true,
+		contractStore.ContractType_External,
 	)
 	if err != nil {
-		cm.Logger.Sugar().Errorw("Failed to create new contract for proxy contract",
+		cm.Logger.Sugar().Errorw("Failed to create upgraded proxy contract",
 			zap.Error(err),
-			zap.String("proxyContractAddress", proxyContractAddress),
+			zap.String("address", proxyContractAddress),
 		)
 		return err
 	}
+
 	cm.Logger.Sugar().Debugf("Created new contract for proxy contract", zap.String("proxyContractAddress", proxyContractAddress))
 
 	return nil

--- a/pkg/contractStore/contractStore.go
+++ b/pkg/contractStore/contractStore.go
@@ -3,6 +3,7 @@ package contractStore
 import (
 	"embed"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 )
@@ -13,20 +14,34 @@ var CoreContracts embed.FS
 type ContractStore interface {
 	GetContractForAddress(address string) (*Contract, error)
 	GetProxyContractForAddress(blockNumber uint64, address string) (*ProxyContract, error)
-	CreateContract(address string, abiJson string, verified bool, bytecodeHash string, matchingContractAddress string, checkedForAbi bool) (*Contract, error)
-	FindOrCreateContract(address string, abiJson string, verified bool, bytecodeHash string, matchingContractAddress string, checkedForAbi bool) (*Contract, bool, error)
+	GetAllProxyAddressesInString() ([]string, error)
+
+	CreateContract(address string, abiJson string, verified bool, bytecodeHash string, matchingContractAddress string, checkedForAbi bool, contractType ContractType) (*Contract, error)
+	FindOrCreateContract(address string, abiJson string, verified bool, bytecodeHash string, matchingContractAddress string, checkedForAbi bool, contractType ContractType) (*Contract, bool, error)
 	CreateProxyContract(blockNumber uint64, contractAddress string, proxyContractAddress string) (*ProxyContract, error)
 	FindOrCreateProxyContract(blockNumber uint64, contractAddress string, proxyContractAddress string) (*ProxyContract, bool, error)
 	GetContractWithProxyContract(address string, atBlockNumber uint64) (*ContractsTree, error)
 	SetContractCheckedForProxy(address string) (*Contract, error)
 
+	InitializeContracts(contractsData *CoreContractsData, contractType ContractType) error
 	InitializeCoreContracts() error
+	InitializeExternalContracts(filename string) error
+	InitializeExternalContractsFromReader(reader io.Reader) error
 }
+
+// Constants.
+type ContractType string
+
+const (
+	ContractType_Core     ContractType = "core"
+	ContractType_External ContractType = "external"
+)
 
 // Tables.
 type Contract struct {
 	ContractAddress         string
 	ContractAbi             string
+	ContractType            ContractType
 	MatchingContractAddress string
 	Verified                bool
 	BytecodeHash            string

--- a/pkg/contractStore/postgresContractStore/postgresContractStore_test.go
+++ b/pkg/contractStore/postgresContractStore/postgresContractStore_test.go
@@ -100,7 +100,7 @@ func Test_PostgresContractStore(t *testing.T) {
 			MatchingContractAddress: "",
 		}
 
-		createdContract, found, err := cs.FindOrCreateContract(contract.ContractAddress, contract.ContractAbi, contract.Verified, contract.BytecodeHash, contract.MatchingContractAddress, false)
+		createdContract, found, err := cs.FindOrCreateContract(contract.ContractAddress, contract.ContractAbi, contract.Verified, contract.BytecodeHash, contract.MatchingContractAddress, false, contractStore.ContractType_Core)
 		assert.Nil(t, err)
 		assert.False(t, found)
 		assert.Equal(t, contract.ContractAddress, createdContract.ContractAddress)
@@ -120,7 +120,7 @@ func Test_PostgresContractStore(t *testing.T) {
 			MatchingContractAddress: "",
 		}
 
-		createdContract, found, err := cs.FindOrCreateContract(contract.ContractAddress, contract.ContractAbi, contract.Verified, contract.BytecodeHash, contract.MatchingContractAddress, false)
+		createdContract, found, err := cs.FindOrCreateContract(contract.ContractAddress, contract.ContractAbi, contract.Verified, contract.BytecodeHash, contract.MatchingContractAddress, false, contractStore.ContractType_Core)
 		assert.Nil(t, err)
 		assert.True(t, found)
 		assert.Equal(t, contract.ContractAddress, createdContract.ContractAddress)
@@ -150,7 +150,7 @@ func Test_PostgresContractStore(t *testing.T) {
 			BytecodeHash:            "0x456",
 			MatchingContractAddress: "",
 		}
-		createdProxy, _, err := cs.FindOrCreateContract(newProxyContract.ContractAddress, newProxyContract.ContractAbi, newProxyContract.Verified, newProxyContract.BytecodeHash, newProxyContract.MatchingContractAddress, false)
+		createdProxy, _, err := cs.FindOrCreateContract(newProxyContract.ContractAddress, newProxyContract.ContractAbi, newProxyContract.Verified, newProxyContract.BytecodeHash, newProxyContract.MatchingContractAddress, false, contractStore.ContractType_Core)
 		assert.Nil(t, err)
 		createdContracts = append(createdContracts, createdProxy)
 
@@ -169,6 +169,12 @@ func Test_PostgresContractStore(t *testing.T) {
 		assert.Equal(t, proxyContract.BlockNumber, proxy.BlockNumber)
 		assert.Equal(t, proxyContract.ContractAddress, proxy.ContractAddress)
 		assert.Equal(t, proxyContract.ProxyContractAddress, proxy.ProxyContractAddress)
+	})
+	t.Run("Get all proxy addresses in string", func(t *testing.T) {
+		addresses, err := cs.GetAllProxyAddressesInString()
+		assert.Nil(t, err)
+		assert.True(t, len(addresses) > 0)
+		assert.Contains(t, addresses, createdContracts[0].ContractAddress)
 	})
 	t.Run("Get contract from address", func(t *testing.T) {
 		address := createdContracts[0].ContractAddress

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -3,6 +3,9 @@ package indexer
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
+
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
 	"github.com/Layr-Labs/sidecar/pkg/contractCaller"
 	"github.com/Layr-Labs/sidecar/pkg/contractManager"
@@ -12,8 +15,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"github.com/Layr-Labs/sidecar/pkg/transactionLogParser"
 	"gorm.io/gorm"
-	"slices"
-	"strings"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"go.uber.org/zap"
@@ -243,7 +244,12 @@ func (idx *Indexer) IsInterestingAddress(addr string) bool {
 	if addr == "" {
 		return false
 	}
-	return slices.Contains(idx.Config.GetInterestingAddressForConfigEnv(), strings.ToLower(addr))
+	addresses, err := idx.ContractStore.GetAllProxyAddressesInString()
+	if err != nil {
+		return false
+	}
+
+	return slices.Contains(addresses, strings.ToLower(addr))
 }
 
 // IsInterestingTransaction determines if a transaction interacts with or creates

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -244,12 +244,17 @@ func (idx *Indexer) IsInterestingAddress(addr string) bool {
 	if addr == "" {
 		return false
 	}
+	addr = strings.ToLower(addr)
+	if slices.Contains(idx.Config.GetInterestingAddressForConfigEnv(), addr) {
+		return true
+	}
+
 	addresses, err := idx.ContractStore.GetAllProxyAddressesInString()
 	if err != nil {
 		return false
 	}
 
-	return slices.Contains(addresses, strings.ToLower(addr))
+	return slices.Contains(addresses, addr)
 }
 
 // IsInterestingTransaction determines if a transaction interacts with or creates

--- a/pkg/indexer/restakedStrategies_test.go
+++ b/pkg/indexer/restakedStrategies_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"testing"
 	"time"
 
@@ -78,7 +77,7 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 	client := ethereum.NewClient(ethConfig, l)
 
-	af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, cfg, []abiSource.AbiSource{})
+	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
 
 	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
 	if err != nil {

--- a/pkg/postgres/migrations/202503051449_addContractTypeColumn/up.go
+++ b/pkg/postgres/migrations/202503051449_addContractTypeColumn/up.go
@@ -1,0 +1,36 @@
+package _202503051449_addContractTypeColumn
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`DO $$ BEGIN
+			CREATE TYPE contract_type AS ENUM ('core', 'external');
+		EXCEPTION
+			WHEN duplicate_object THEN null;
+		END $$;`,
+		`ALTER TABLE contracts ADD COLUMN IF NOT EXISTS contract_type contract_type DEFAULT 'core';`,
+	}
+
+	for _, query := range queries {
+		res := grm.Exec(query)
+		if res.Error != nil {
+			fmt.Printf("Failed to run migration query: %s - %+v\n", query, res.Error)
+			return res.Error
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202503051449_addContractTypeColumn"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -3,12 +3,12 @@ package migrations
 import (
 	"database/sql"
 	"fmt"
+	"time"
+
 	_202501241111_addIndexesForRpcFunctions "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501241111_addIndexesForRpcFunctions"
 	_202502100846_goldTableRewardHashIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502100846_goldTableRewardHashIndex"
-	_202502180836_snapshotUniqueConstraints "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502180836_snapshotUniqueConstraints"
 	_202502211539_hydrateClaimedRewards "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502211539_hydrateClaimedRewards"
 	_202503042014_stakerOperatorIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503042014_stakerOperatorIndex"
-	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	_202409061249_bootstrapDb "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202409061249_bootstrapDb"
@@ -54,6 +54,8 @@ import (
 	_202501061422_defaultOperatorSplits "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501061422_defaultOperatorSplits"
 	_202501071401_defaultOperatorSplitSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501071401_defaultOperatorSplitSnapshots"
 	_202501151039_rewardsClaimed "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501151039_rewardsClaimed"
+	_202502180836_snapshotUniqueConstraints "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502180836_snapshotUniqueConstraints"
+	_202503051449_addContractTypeColumn "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503051449_addContractTypeColumn"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -176,6 +178,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202502211539_hydrateClaimedRewards.Migration{},
 		&_202503042014_stakerOperatorIndex.Migration{},
 		&_202502180836_snapshotUniqueConstraints.Migration{},
+		&_202503051449_addContractTypeColumn.Migration{},
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Description

This PR adds a new cli `load-contract` to allow users to add any contracts to Sidecar. When contracts are added by this command, they will be considered as non-core contracts, a.k.a `external` contracts. External contracts will automatically detect upgradeable contracts.

This is the list of flags associated to `load-contract`:
- `contract.address` (required)
    - `contract.abi` (required with address)
    - `contract.bytecode-hash` (optional)

- `contract.associate-to-proxy` (optional)
    - `contract.block-number` (required with associate-to-proxy)

- `contract.batch` (required to set to true when batch-loading, using file or stdin)
- `contract.from-file` (json file path)

Please refer to some examples below.

Fixes https://github.com/Layr-Labs/sidecar/issues/223

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)

## How Has This Been Tested?
### Load a contract
```
% go build -o sidecar
% ./sidecar load-contract contract.address=0x870679e138bcdf293b7ff14dd44b70fc97e12fc0 --contract.abi='[{"input": []}]' --ethereum.rpc-url="http://72.46.85.253:8545" --chain="mainnet" --database.host=localhost --database.port="5432" --database.user=<add user> --database.password=<add password>  --database.db_name="sidecar"
```
Result:
```
sidecar=# select * from contracts where contract_address='0x870679e138bcdf293b7ff14dd44b70fc97e12fc0';
 id |              contract_address              |  contract_abi   |                          bytecode_hash                           | verified | matching_contract_address | checked_for_proxy | checked_for_abi |        created_at         |        updated_at         |     deleted_at      | contract_type 
----+--------------------------------------------+-----------------+------------------------------------------------------------------+----------+---------------------------+-------------------+-----------------+---------------------------+---------------------------+---------------------+---------------
 28 | 0x870679e138bcdf293b7ff14dd44b70fc97e12fc0 | [{"input": []}] | 6af45b3334e299fa97ea4781109e201a1411aba5131a6f1bc60fdf2011fce868 | t        |                           | f                 | t               | 2025-03-05 15:43:16.67865 | 2025-03-05 15:43:16.67865 | 0001-01-01 00:00:00 | external
(1 row)
```
### Load a proxy contract
```
% go build -o sidecar
% ./sidecar load-contract --contract.address=0xf5fd25a90902c27068cf5ebe53be8da693ac899e --contract.abi='[{"output": []}]' -- --contract.associate-to-proxy=0x870679e138bcdf293b7ff14dd44b70fc97e12fc0 --contract.block-number=19592323 --ethereum.rpc-url="http://72.46.85.253:8545" --chain="mainnet" --database.host=localhost --database.port="5432" --database.user=<add user> --database.password=<add password>  --database.db_name="sidecar"
```

Confirmed the query results:
```
sidecar=# select * from proxy_contracts where contract_address='0x870679e138bcdf293b7ff14dd44b70fc97e12fc0';
 block_number |              contract_address              |           proxy_contract_address           |         created_at         |         updated_at         |     deleted_at      
--------------+--------------------------------------------+--------------------------------------------+----------------------------+----------------------------+---------------------
     19592323 | 0x870679e138bcdf293b7ff14dd44b70fc97e12fc0 | 0xf5fd25a90902c27068cf5ebe53be8da693ac899e | 2025-03-05 15:43:16.744526 | 2025-03-05 15:43:16.744526 | 0001-01-01 00:00:00
(1 row)


sidecar=# select * from contracts where contract_address='0xf5fd25a90902c27068cf5ebe53be8da693ac899e';
 id |              contract_address              |   contract_abi   |                          bytecode_hash                           | verified | matching_contract_address | checked_for_proxy | checked_for_abi |         created_at         |         updated_at         |     deleted_at      | contract_type 
----+--------------------------------------------+------------------+------------------------------------------------------------------+----------+---------------------------+-------------------+-----------------+----------------------------+----------------------------+---------------------+---------------
 29 | 0xf5fd25a90902c27068cf5ebe53be8da693ac899e | [{"output": []}] | f249d9703e9baeeaa2e6b3167d5e71f4cc82127d02b24a955e978f8e3a5beb1b | t        |                           | f                 | t               | 2025-03-05 15:43:16.743142 | 2025-03-05 15:43:16.743142 | 0001-01-01 00:00:00 | external
(1 row)
```

### To batch load contracts
using `test.json`
```
{
	"core_contracts": [
		{
			"contract_address": "0x00a5fd09f6cee6ae9c8b0e5e33287f7c82880505",
			"contract_abi": "[{\"tests\": []}]",
			"bytecode_hash": "abc"
		},
		{
			"contract_address": "0x5d0b9ce2e277daf508528e9f6bf6314e79e4ed2b",
			"contract_abi": "[{\"tests2\": []}]",
			"bytecode_hash": "def"
		}
	],
	"proxy_contracts": [
		{
			"contract_address": "0x00a5fd09f6cee6ae9c8b0e5e33287f7c82880505",
			"proxy_contract_address": "0x5d0b9ce2e277daf508528e9f6bf6314e79e4ed2b",
			"block_number": 19592323
		}
	]
}
```

Command:
```
./sidecar load-contracts --ethereum.rpc-url="http://72.46.85.253:8545" --chain="mainnet" --database.host=localhost --database.port="5432" --database.user=<add user> --database.password=<add password> --database.db_name="sidecar" --contract.from-file=./test.json
```
**OR**
```
cat ./test.json | ./sidecar load-contracts --ethereum.rpc-url="http://72.46.85.253:8545" --chain="mainnet" --database.host=localhost --database.port="5432" --database.user=<add user> --database.password=<add password> --database.db_name="sidecar"
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
