### PR TITLE
fix: ignore OperatorDirectedOperatorSetRewardSubmissions with a duration of 0

### DIFF
--- a/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions.go
+++ b/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions.go
@@ -140,6 +140,15 @@ func (od *OperatorDirectedOperatorSetRewardSubmissionsModel) handleOperatorDirec
 	}
 	outputRewardData := outputData.OperatorDirectedRewardsSubmission
 
+	if outputRewardData.Duration == 0 {
+		od.Logger.Sugar().Debugw("Skipping operator directed operator set reward submission with zero duration",
+			zap.String("transactionHash", log.TransactionHash),
+			zap.Uint64("logIndex", log.LogIndex),
+			zap.Uint64("blockNumber", log.BlockNumber),
+		)
+		return []*OperatorDirectedOperatorSetRewardSubmission{}, nil
+	}
+
 	rewardSubmissions := make([]*OperatorDirectedOperatorSetRewardSubmission, 0)
 
 	for i, strategyAndMultiplier := range outputRewardData.StrategiesAndMultipliers {

--- a/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions_test.go
+++ b/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions_test.go
@@ -148,6 +148,37 @@ func Test_OperatorDirectedOperatorSetRewardSubmissions(t *testing.T) {
 			assert.NotNil(t, stateRoot)
 			assert.True(t, len(stateRoot) > 0)
 		})
+		t.Run("Ensure a submission with a duration of 0 is skipped", func(t *testing.T) {
+			blockNumber := uint64(103)
+
+			if err := createBlock(model, blockNumber); err != nil {
+				t.Fatal(err)
+			}
+
+			log := &storage.TransactionLog{
+				TransactionHash:  "some hash",
+				TransactionIndex: big.NewInt(100).Uint64(),
+				BlockNumber:      blockNumber,
+				Address:          cfg.GetContractsMapForChain().RewardsCoordinator,
+				Arguments:        `[{"Name": "caller", "Type": "address", "Value": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "Indexed": true}, {"Name": "operatorDirectedRewardsSubmissionHash", "Type": "bytes32", "Value": "0x7402669fb2c8a0cfe8108acb8a0070257c77ec6906ecb07d97c38e8a5ddc66a9", "Indexed": true}, {"Name": "operatorSet", "Type": "tuple", "Value": {"avs": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "id": 1}, "Indexed": false}, {"Name": "submissionNonce", "Type": "uint256", "Value": 0, "Indexed": false}, {"Name": "operatorDirectedRewardsSubmission", "Type": "((address,uint96)[],address,(address,uint256)[],uint32,uint32,string)", "Value": null, "Indexed": false}]`,
+				EventName:        "OperatorDirectedOperatorSetRewardsSubmissionCreated",
+				LogIndex:         big.NewInt(12).Uint64(),
+				OutputData:       `{"operatorSet": {"avs": "0xd36b6e5eee8311d7bffb2f3bb33301a1ab7de101", "id": 1}, "submissionNonce": 0, "operatorDirectedRewardsSubmission": {"token": "0x0ddd9dc88e638aef6a8e42d0c98aaa6a48a98d24", "operatorRewards": [{"operator": "0x9401E5E6564DB35C0f86573a9828DF69Fc778aF1", "amount": 30000000000000000000000}, {"operator": "0xF50Cba7a66b5E615587157e43286DaA7aF94009e", "amount": 40000000000000000000000}], "duration": 0, "startTimestamp": 1725494400, "strategiesAndMultipliers": [{"strategy": "0x5074dfd18e9498d9e006fb8d4f3fecdc9af90a2c", "multiplier": 1000000000000000000}, {"strategy": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc", "multiplier": 2000000000000000000}], "description": "test reward submission"}}`,
+			}
+
+			err = model.SetupStateForBlock(blockNumber)
+			assert.Nil(t, err)
+
+			isInteresting := model.IsInterestingLog(log)
+			assert.True(t, isInteresting)
+
+			change, err := model.HandleStateChange(log)
+			assert.Nil(t, err)
+			assert.NotNil(t, change)
+
+			typedChange := change.([]*OperatorDirectedOperatorSetRewardSubmission)
+			assert.Equal(t, 0, len(typedChange))
+		})
 	})
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Description

Much like `RewardSubmissions` and `OperatorDirectedRewardSubmissions`, ignore any `OperatorDirectedOperatorSetRewardSubmissions` that have a duration of 0 to avoid a potential division by 0 case

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added appropriate tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
