### PR TITLE
refactor: ensure each EigenState model has a proper unique constraint

### DIFF
--- a/pkg/eigenState/avsOperators/avsOperators.go
+++ b/pkg/eigenState/avsOperators/avsOperators.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"slices"
 	"sort"
 	"strings"
@@ -192,7 +191,8 @@ func (a *AvsOperatorsModel) prepareState(blockNumber uint64) ([]*AvsOperatorStat
 	return accumulatedState, nil
 }
 
-func (a *AvsOperatorsModel) writeDeltaRecords(blockNumber uint64) error {
+// CommitFinalState commits the final state for the given block number.
+func (a *AvsOperatorsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	records, ok := a.stateAccumulator[blockNumber]
 	if !ok {
 		msg := "delta accumulator was not initialized"
@@ -200,23 +200,12 @@ func (a *AvsOperatorsModel) writeDeltaRecords(blockNumber uint64) error {
 		return errors.New(msg)
 	}
 
-	if len(records) > 0 {
-		res := a.DB.Model(&AvsOperatorStateChange{}).Clauses(clause.Returning{}).Create(&records)
-		if res.Error != nil {
-			a.logger.Sugar().Errorw("Failed to insert delta records", zap.Error(res.Error))
-			return res.Error
-		}
-	}
-	a.committedState[blockNumber] = records
-	return nil
-}
-
-// CommitFinalState commits the final state for the given block number.
-func (a *AvsOperatorsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
-	if err := a.writeDeltaRecords(blockNumber); err != nil {
+	insertedRecords, err := base.CommitFinalState(records, ignoreInsertConflicts, a.GetTableName(), a.DB)
+	if err != nil {
+		a.logger.Sugar().Errorw("Failed to insert delta records", zap.Error(err))
 		return err
 	}
-
+	a.committedState[blockNumber] = insertedRecords
 	return nil
 }
 
@@ -269,8 +258,12 @@ func (a *AvsOperatorsModel) sortValuesForMerkleTree(deltas []*AvsOperatorStateCh
 	return inputs
 }
 
+func (a *AvsOperatorsModel) GetTableName() string {
+	return "avs_operator_state_changes"
+}
+
 func (a *AvsOperatorsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return a.BaseEigenState.DeleteState("avs_operator_state_changes", startBlockNumber, endBlockNumber, a.DB)
+	return a.BaseEigenState.DeleteState(a.GetTableName(), startBlockNumber, endBlockNumber, a.DB)
 }
 
 func (a *AvsOperatorsModel) ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error) {

--- a/pkg/eigenState/avsOperators/avsOperators.go
+++ b/pkg/eigenState/avsOperators/avsOperators.go
@@ -212,7 +212,7 @@ func (a *AvsOperatorsModel) writeDeltaRecords(blockNumber uint64) error {
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (a *AvsOperatorsModel) CommitFinalState(blockNumber uint64) error {
+func (a *AvsOperatorsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	if err := a.writeDeltaRecords(blockNumber); err != nil {
 		return err
 	}

--- a/pkg/eigenState/avsOperators/avsOperatorsIntegration_test.go
+++ b/pkg/eigenState/avsOperators/avsOperatorsIntegration_test.go
@@ -121,7 +121,7 @@ func Test_AvsOperatorsIntegration(t *testing.T) {
 				}
 			}
 
-			if err := model.CommitFinalState(i); err != nil {
+			if err := model.CommitFinalState(i, false); err != nil {
 				t.Logf("Failed to commit final state for block %d", i)
 				t.Fatal(err)
 			}

--- a/pkg/eigenState/avsOperators/avsOperators_test.go
+++ b/pkg/eigenState/avsOperators/avsOperators_test.go
@@ -123,6 +123,10 @@ func Test_AvsOperatorState(t *testing.T) {
 			err = avsOperatorState.CommitFinalState(log.BlockNumber, false)
 			assert.Nil(t, err)
 
+			committedState, err := avsOperatorState.GetCommittedState(log.BlockNumber)
+			assert.Nil(t, err)
+			assert.Equal(t, len(committedState), 1)
+
 			states := []AvsOperatorStateChange{}
 			statesRes := avsOperatorState.DB.
 				Raw("select * from avs_operator_state_changes where block_number = @blockNumber", sql.Named("blockNumber", log.BlockNumber)).
@@ -279,6 +283,10 @@ func Test_AvsOperatorState(t *testing.T) {
 			if statesRes.Error != nil {
 				t.Fatalf("Failed to fetch avs_operator_state_changes: %v", statesRes.Error)
 			}
+
+			committedState, err := avsOperatorState.GetCommittedState(log.BlockNumber)
+			assert.Nil(t, err)
+			assert.Equal(t, len(committedState), 0)
 
 			assert.Equal(t, 1, len(states))
 		}

--- a/pkg/eigenState/avsOperators/avsOperators_test.go
+++ b/pkg/eigenState/avsOperators/avsOperators_test.go
@@ -166,6 +166,123 @@ func Test_AvsOperatorState(t *testing.T) {
 
 		assert.Equal(t, len(logs), len(inserted))
 	})
+	t.Run("Should build the state, but throw an error when inserting duplicate records", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(nil, l, grm)
+		blocks := []uint64{
+			300,
+			301,
+		}
+
+		logs := []*storage.TransactionLog{
+			{
+				TransactionHash:  "some hash",
+				TransactionIndex: 100,
+				BlockNumber:      blocks[0],
+				Address:          cfg.GetContractsMapForChain().AvsDirectory,
+				Arguments:        `[{"Value": "0xdf25bdcdcdd9a3dd8c9069306c4dba8d90dd8e8e" }, { "Value": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0" }]`,
+				EventName:        "OperatorAVSRegistrationStatusUpdated",
+				LogIndex:         400,
+				OutputData:       `{ "status": 1 }`,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+				DeletedAt:        time.Time{},
+			},
+			{
+				TransactionHash:  "some hash",
+				TransactionIndex: 100,
+				BlockNumber:      blocks[1],
+				Address:          cfg.GetContractsMapForChain().AvsDirectory,
+				Arguments:        `[{"Value": "0xdf25bdcdcdd9a3dd8c9069306c4dba8d90dd8e8e" }, { "Value": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0" }]`,
+				EventName:        "OperatorAVSRegistrationStatusUpdated",
+				LogIndex:         400,
+				OutputData:       `{ "status": 0 }`,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+				DeletedAt:        time.Time{},
+			},
+		}
+
+		avsOperatorState, err := NewAvsOperatorsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		for _, log := range logs {
+			assert.True(t, avsOperatorState.IsInterestingLog(log))
+
+			err = avsOperatorState.SetupStateForBlock(log.BlockNumber)
+			assert.Nil(t, err)
+
+			stateChange, err := avsOperatorState.HandleStateChange(log)
+			assert.Nil(t, err)
+			assert.NotNil(t, stateChange)
+
+			err = avsOperatorState.CommitFinalState(log.BlockNumber, false)
+			assert.NotNil(t, err)
+		}
+	})
+	t.Run("Should build the state, but ignore the conflict for duplicate records", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(nil, l, grm)
+		blocks := []uint64{
+			300,
+			301,
+		}
+
+		logs := []*storage.TransactionLog{
+			{
+				TransactionHash:  "some hash",
+				TransactionIndex: 100,
+				BlockNumber:      blocks[0],
+				Address:          cfg.GetContractsMapForChain().AvsDirectory,
+				Arguments:        `[{"Value": "0xdf25bdcdcdd9a3dd8c9069306c4dba8d90dd8e8e" }, { "Value": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0" }]`,
+				EventName:        "OperatorAVSRegistrationStatusUpdated",
+				LogIndex:         400,
+				OutputData:       `{ "status": 1 }`,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+				DeletedAt:        time.Time{},
+			},
+			{
+				TransactionHash:  "some hash",
+				TransactionIndex: 100,
+				BlockNumber:      blocks[1],
+				Address:          cfg.GetContractsMapForChain().AvsDirectory,
+				Arguments:        `[{"Value": "0xdf25bdcdcdd9a3dd8c9069306c4dba8d90dd8e8e" }, { "Value": "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0" }]`,
+				EventName:        "OperatorAVSRegistrationStatusUpdated",
+				LogIndex:         400,
+				OutputData:       `{ "status": 0 }`,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+				DeletedAt:        time.Time{},
+			},
+		}
+
+		avsOperatorState, err := NewAvsOperatorsModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		for _, log := range logs {
+			assert.True(t, avsOperatorState.IsInterestingLog(log))
+
+			err = avsOperatorState.SetupStateForBlock(log.BlockNumber)
+			assert.Nil(t, err)
+
+			stateChange, err := avsOperatorState.HandleStateChange(log)
+			assert.Nil(t, err)
+			assert.NotNil(t, stateChange)
+
+			err = avsOperatorState.CommitFinalState(log.BlockNumber, true)
+			assert.Nil(t, err)
+
+			var states []*AvsOperatorStateChange
+			statesRes := avsOperatorState.DB.
+				Raw("select * from avs_operator_state_changes where block_number = @blockNumber", sql.Named("blockNumber", log.BlockNumber)).
+				Scan(&states)
+
+			if statesRes.Error != nil {
+				t.Fatalf("Failed to fetch avs_operator_state_changes: %v", statesRes.Error)
+			}
+
+			assert.Equal(t, 1, len(states))
+		}
+	})
 	t.Cleanup(func() {
 		postgres.TeardownTestDatabase(dbName, cfg, grm, l)
 	})

--- a/pkg/eigenState/avsOperators/avsOperators_test.go
+++ b/pkg/eigenState/avsOperators/avsOperators_test.go
@@ -120,7 +120,7 @@ func Test_AvsOperatorState(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotNil(t, stateChange)
 
-			err = avsOperatorState.CommitFinalState(log.BlockNumber)
+			err = avsOperatorState.CommitFinalState(log.BlockNumber, false)
 			assert.Nil(t, err)
 
 			states := []AvsOperatorStateChange{}

--- a/pkg/eigenState/base/baseEigenState.go
+++ b/pkg/eigenState/base/baseEigenState.go
@@ -167,3 +167,5 @@ func CastInterfaceToCommittedState[T any](committedState []interface{}) []*T {
 	}
 	return state
 }
+
+

--- a/pkg/eigenState/base/baseEigenState.go
+++ b/pkg/eigenState/base/baseEigenState.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/Layr-Labs/sidecar/pkg/parser"
 	"github.com/Layr-Labs/sidecar/pkg/storage"
+	"gorm.io/gorm/clause"
 	"slices"
 	"strings"
 
@@ -168,4 +169,30 @@ func CastInterfaceToCommittedState[T any](committedState []interface{}) []*T {
 	return state
 }
 
+func FormatUniqueConstraintName(tableName string) string {
+	return fmt.Sprintf("uniq_%s", tableName)
+}
 
+func CommitFinalState[T any](
+	records []*T,
+	ignoreInsertConflicts bool,
+	tableName string,
+	db *gorm.DB,
+) ([]*T, error) {
+	if len(records) == 0 {
+		return records, nil
+	}
+
+	clauses := []clause.Expression{
+		clause.Returning{},
+	}
+	if ignoreInsertConflicts {
+		clauses = append(clauses, clause.OnConflict{
+			OnConstraint: FormatUniqueConstraintName(tableName),
+			DoNothing:    true,
+		})
+	}
+
+	res := db.Model(&records[0]).Clauses(clauses...).Create(&records)
+	return records, res.Error
+}

--- a/pkg/eigenState/defaultOperatorSplits/defaultOperatorSplits.go
+++ b/pkg/eigenState/defaultOperatorSplits/defaultOperatorSplits.go
@@ -198,7 +198,7 @@ func (dos *DefaultOperatorSplitModel) prepareState(blockNumber uint64) ([]*Defau
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (dos *DefaultOperatorSplitModel) CommitFinalState(blockNumber uint64) error {
+func (dos *DefaultOperatorSplitModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := dos.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/defaultOperatorSplits/defaultOperatorSplits.go
+++ b/pkg/eigenState/defaultOperatorSplits/defaultOperatorSplits.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type DefaultOperatorSplit struct {
@@ -204,16 +203,12 @@ func (dos *DefaultOperatorSplitModel) CommitFinalState(blockNumber uint64, ignor
 		return err
 	}
 
-	if len(recordsToInsert) > 0 {
-		for _, record := range recordsToInsert {
-			res := dos.DB.Model(&DefaultOperatorSplit{}).Clauses(clause.Returning{}).Create(&record)
-			if res.Error != nil {
-				dos.logger.Sugar().Errorw("Failed to insert records", zap.Error(res.Error))
-				return res.Error
-			}
-		}
+	insertedRecords, err := base.CommitFinalState(recordsToInsert, ignoreInsertConflicts, dos.GetTableName(), dos.DB)
+	if err != nil {
+		dos.logger.Sugar().Errorw("Failed to insert records", zap.Error(err))
+		return err
 	}
-	dos.committedState[blockNumber] = recordsToInsert
+	dos.committedState[blockNumber] = insertedRecords
 	return nil
 }
 
@@ -270,8 +265,12 @@ func (dos *DefaultOperatorSplitModel) sortValuesForMerkleTree(splits []*DefaultO
 	return inputs
 }
 
+func (dos *DefaultOperatorSplitModel) GetTableName() string {
+	return "default_operator_splits"
+}
+
 func (dos *DefaultOperatorSplitModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return dos.BaseEigenState.DeleteState("default_operator_splits", startBlockNumber, endBlockNumber, dos.DB)
+	return dos.BaseEigenState.DeleteState(dos.GetTableName(), startBlockNumber, endBlockNumber, dos.DB)
 }
 
 func (dos *DefaultOperatorSplitModel) ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error) {

--- a/pkg/eigenState/defaultOperatorSplits/defaultOperatorSplits_test.go
+++ b/pkg/eigenState/defaultOperatorSplits/defaultOperatorSplits_test.go
@@ -111,7 +111,7 @@ func Test_DefaultOperatorSplit(t *testing.T) {
 			assert.Equal(t, uint64(1000), split.OldDefaultOperatorSplitBips)
 			assert.Equal(t, uint64(2000), split.NewDefaultOperatorSplitBips)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			splits := make([]*DefaultOperatorSplit, 0)

--- a/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots.go
+++ b/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots.go
@@ -166,7 +166,7 @@ func (ddr *DisabledDistributionRootsModel) prepareState(blockNumber uint64) ([]*
 	return preparedState, nil
 }
 
-func (ddr *DisabledDistributionRootsModel) CommitFinalState(blockNumber uint64) error {
+func (ddr *DisabledDistributionRootsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	records, err := ddr.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots.go
+++ b/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"slices"
 	"sort"
 	"strings"
@@ -172,14 +171,12 @@ func (ddr *DisabledDistributionRootsModel) CommitFinalState(blockNumber uint64, 
 		return err
 	}
 
-	if len(records) > 0 {
-		res := ddr.DB.Model(&types.DisabledDistributionRoot{}).Clauses(clause.Returning{}).Create(&records)
-		if res.Error != nil {
-			ddr.logger.Sugar().Errorw("Failed to create new submitted_distribution_roots records", zap.Error(res.Error))
-			return res.Error
-		}
-		ddr.committedState[blockNumber] = records
+	insertedRecords, err := base.CommitFinalState(records, ignoreInsertConflicts, ddr.GetTableName(), ddr.DB)
+	if err != nil {
+		ddr.logger.Sugar().Errorw("Failed to create new submitted_distribution_roots records", zap.Error(err))
+		return err
 	}
+	ddr.committedState[blockNumber] = insertedRecords
 
 	return nil
 }
@@ -232,8 +229,12 @@ func (ddr *DisabledDistributionRootsModel) GenerateStateRoot(blockNumber uint64)
 	return fullTree.Root(), nil
 }
 
+func (ddr *DisabledDistributionRootsModel) GetTableName() string {
+	return "disabled_distribution_roots"
+}
+
 func (ddr *DisabledDistributionRootsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return ddr.BaseEigenState.DeleteState("disabled_distribution_roots", startBlockNumber, endBlockNumber, ddr.DB)
+	return ddr.BaseEigenState.DeleteState(ddr.GetTableName(), startBlockNumber, endBlockNumber, ddr.DB)
 }
 
 func (ddr *DisabledDistributionRootsModel) GetAccumulatedState(blockNumber uint64) []*types.DisabledDistributionRoot {

--- a/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots_test.go
+++ b/pkg/eigenState/disabledDistributionRoots/disabledDistributionRoots_test.go
@@ -97,7 +97,7 @@ func Test_DisabledDistributionRoots(t *testing.T) {
 		assert.Equal(t, uint64(8), typedChange.RootIndex)
 		assert.Equal(t, blockNumber, typedChange.BlockNumber)
 
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `SELECT * FROM disabled_distribution_roots WHERE block_number = ?`

--- a/pkg/eigenState/operatorAVSSplits/operatorAVSSplits.go
+++ b/pkg/eigenState/operatorAVSSplits/operatorAVSSplits.go
@@ -213,7 +213,7 @@ func (oas *OperatorAVSSplitModel) prepareState(blockNumber uint64) ([]*OperatorA
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (oas *OperatorAVSSplitModel) CommitFinalState(blockNumber uint64) error {
+func (oas *OperatorAVSSplitModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := oas.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/operatorAVSSplits/operatorAVSSplits_test.go
+++ b/pkg/eigenState/operatorAVSSplits/operatorAVSSplits_test.go
@@ -115,7 +115,7 @@ func Test_OperatorAVSSplit(t *testing.T) {
 			assert.Equal(t, uint64(1000), split.OldOperatorAVSSplitBips)
 			assert.Equal(t, uint64(2000), split.NewOperatorAVSSplitBips)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			splits := make([]*OperatorAVSSplit, 0)

--- a/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions.go
+++ b/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions.go
@@ -302,7 +302,7 @@ func (od *OperatorDirectedOperatorSetRewardSubmissionsModel) prepareState(blockN
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (od *OperatorDirectedOperatorSetRewardSubmissionsModel) CommitFinalState(blockNumber uint64) error {
+func (od *OperatorDirectedOperatorSetRewardSubmissionsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := od.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions_test.go
+++ b/pkg/eigenState/operatorDirectedOperatorSetRewardSubmissions/operatorDirectedOperatorSetRewardSubmissions_test.go
@@ -132,7 +132,7 @@ func Test_OperatorDirectedOperatorSetRewardSubmissions(t *testing.T) {
 				assert.Equal(t, "test reward submission", submission.Description)
 			}
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			rewards := make([]*OperatorDirectedOperatorSetRewardSubmission, 0)

--- a/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
+++ b/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions.go
@@ -307,7 +307,7 @@ func (odrs *OperatorDirectedRewardSubmissionsModel) prepareState(blockNumber uin
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (odrs *OperatorDirectedRewardSubmissionsModel) CommitFinalState(blockNumber uint64) error {
+func (odrs *OperatorDirectedRewardSubmissionsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := odrs.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions_test.go
+++ b/pkg/eigenState/operatorDirectedRewardSubmissions/operatorDirectedRewardSubmissions_test.go
@@ -145,7 +145,7 @@ func Test_OperatorDirectedRewardSubmissions(t *testing.T) {
 				assert.Equal(t, "test reward submission", submission.Description)
 			}
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			rewards := make([]*OperatorDirectedRewardSubmission, 0)

--- a/pkg/eigenState/operatorPISplits/operatorPISplits.go
+++ b/pkg/eigenState/operatorPISplits/operatorPISplits.go
@@ -211,7 +211,7 @@ func (ops *OperatorPISplitModel) prepareState(blockNumber uint64) ([]*OperatorPI
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (ops *OperatorPISplitModel) CommitFinalState(blockNumber uint64) error {
+func (ops *OperatorPISplitModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := ops.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/operatorPISplits/operatorPISplits.go
+++ b/pkg/eigenState/operatorPISplits/operatorPISplits.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type OperatorPISplit struct {
@@ -217,16 +216,12 @@ func (ops *OperatorPISplitModel) CommitFinalState(blockNumber uint64, ignoreInse
 		return err
 	}
 
-	if len(recordsToInsert) > 0 {
-		for _, record := range recordsToInsert {
-			res := ops.DB.Model(&OperatorPISplit{}).Clauses(clause.Returning{}).Create(&record)
-			if res.Error != nil {
-				ops.logger.Sugar().Errorw("Failed to insert records", zap.Error(res.Error))
-				return res.Error
-			}
-		}
+	insertedRecords, err := base.CommitFinalState(recordsToInsert, ignoreInsertConflicts, ops.GetTableName(), ops.DB)
+	if err != nil {
+		ops.logger.Sugar().Errorw("Failed to commit final state", zap.Error(err))
+		return err
 	}
-	ops.committedState[blockNumber] = recordsToInsert
+	ops.committedState[blockNumber] = insertedRecords
 	return nil
 }
 
@@ -316,8 +311,12 @@ func (ops *OperatorPISplitModel) sortValuesForMerkleTree(splits []*OperatorPISpl
 	return inputs, nil
 }
 
+func (ops *OperatorPISplitModel) GetTableName() string {
+	return "operator_pi_splits"
+}
+
 func (ops *OperatorPISplitModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return ops.BaseEigenState.DeleteState("operator_pi_splits", startBlockNumber, endBlockNumber, ops.DB)
+	return ops.BaseEigenState.DeleteState(ops.GetTableName(), startBlockNumber, endBlockNumber, ops.DB)
 }
 
 func (ops *OperatorPISplitModel) ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error) {

--- a/pkg/eigenState/operatorPISplits/operatorPISplits_test.go
+++ b/pkg/eigenState/operatorPISplits/operatorPISplits_test.go
@@ -114,7 +114,7 @@ func Test_OperatorPISplit(t *testing.T) {
 			assert.Equal(t, uint64(6545), split.NewOperatorPISplitBips)
 			assert.Equal(t, uint64(1000), split.OldOperatorPISplitBips)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			splits := make([]*OperatorPISplit, 0)

--- a/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
+++ b/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type OperatorSetOperatorRegistration struct {
@@ -223,16 +222,12 @@ func (osor *OperatorSetOperatorRegistrationModel) CommitFinalState(blockNumber u
 		return err
 	}
 
-	if len(recordsToInsert) > 0 {
-		for _, record := range recordsToInsert {
-			res := osor.DB.Model(&OperatorSetOperatorRegistration{}).Clauses(clause.Returning{}).Create(&record)
-			if res.Error != nil {
-				osor.logger.Sugar().Errorw("Failed to insert records", zap.Error(res.Error))
-				return res.Error
-			}
-		}
+	insertedRecords, err := base.CommitFinalState(recordsToInsert, ignoreInsertConflicts, osor.GetTableName(), osor.DB)
+	if err != nil {
+		osor.logger.Sugar().Errorw("Failed to commit final state", zap.Error(err))
+		return err
 	}
-	osor.committedState[blockNumber] = recordsToInsert
+	osor.committedState[blockNumber] = insertedRecords
 	return nil
 }
 
@@ -316,8 +311,12 @@ func (osor *OperatorSetOperatorRegistrationModel) sortValuesForMerkleTree(operat
 	return inputs, nil
 }
 
+func (osor *OperatorSetOperatorRegistrationModel) GetTableName() string {
+	return "operator_set_operator_registrations"
+}
+
 func (osor *OperatorSetOperatorRegistrationModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return osor.BaseEigenState.DeleteState("operator_set_operator_registrations", startBlockNumber, endBlockNumber, osor.DB)
+	return osor.BaseEigenState.DeleteState(osor.GetTableName(), startBlockNumber, endBlockNumber, osor.DB)
 }
 
 func (osor *OperatorSetOperatorRegistrationModel) ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error) {

--- a/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
+++ b/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
@@ -217,7 +217,7 @@ func (osor *OperatorSetOperatorRegistrationModel) prepareState(blockNumber uint6
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (osor *OperatorSetOperatorRegistrationModel) CommitFinalState(blockNumber uint64) error {
+func (osor *OperatorSetOperatorRegistrationModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := osor.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations_test.go
+++ b/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations_test.go
@@ -115,7 +115,7 @@ func Test_OperatorSetOperatorRegistration(t *testing.T) {
 			assert.Equal(t, uint64(1), operatorRegistration.OperatorSetId)
 			assert.Equal(t, true, operatorRegistration.IsActive)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			operatorRegistrations := make([]*OperatorSetOperatorRegistration, 0)
@@ -169,7 +169,7 @@ func Test_OperatorSetOperatorRegistration(t *testing.T) {
 			assert.Equal(t, uint64(1), operatorRegistration.OperatorSetId)
 			assert.Equal(t, false, operatorRegistration.IsActive)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			operatorRegistrations := make([]*OperatorSetOperatorRegistration, 0)

--- a/pkg/eigenState/operatorSetSplits/operatorSetSplits.go
+++ b/pkg/eigenState/operatorSetSplits/operatorSetSplits.go
@@ -221,7 +221,7 @@ func (oss *OperatorSetSplitModel) prepareState(blockNumber uint64) ([]*OperatorS
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (oss *OperatorSetSplitModel) CommitFinalState(blockNumber uint64) error {
+func (oss *OperatorSetSplitModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := oss.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/operatorSetSplits/operatorSetSplits.go
+++ b/pkg/eigenState/operatorSetSplits/operatorSetSplits.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type OperatorSetSplit struct {
@@ -227,16 +226,12 @@ func (oss *OperatorSetSplitModel) CommitFinalState(blockNumber uint64, ignoreIns
 		return err
 	}
 
-	if len(recordsToInsert) > 0 {
-		for _, record := range recordsToInsert {
-			res := oss.DB.Model(&OperatorSetSplit{}).Clauses(clause.Returning{}).Create(&record)
-			if res.Error != nil {
-				oss.logger.Sugar().Errorw("Failed to insert records", zap.Error(res.Error))
-				return res.Error
-			}
-		}
+	insertedRecords, err := base.CommitFinalState(recordsToInsert, ignoreInsertConflicts, oss.GetTableName(), oss.DB)
+	if err != nil {
+		oss.logger.Sugar().Errorw("Failed to commit final state", zap.Error(err), zap.Uint64("blockNumber", blockNumber))
+		return err
 	}
-	oss.committedState[blockNumber] = recordsToInsert
+	oss.committedState[blockNumber] = insertedRecords
 	return nil
 }
 
@@ -326,8 +321,12 @@ func (oss *OperatorSetSplitModel) sortValuesForMerkleTree(splits []*OperatorSetS
 	return inputs, nil
 }
 
+func (oss *OperatorSetSplitModel) GetTableName() string {
+	return "operator_set_splits"
+}
+
 func (oss *OperatorSetSplitModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return oss.BaseEigenState.DeleteState("operator_set_splits", startBlockNumber, endBlockNumber, oss.DB)
+	return oss.BaseEigenState.DeleteState(oss.GetTableName(), startBlockNumber, endBlockNumber, oss.DB)
 }
 
 func (oss *OperatorSetSplitModel) ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error) {

--- a/pkg/eigenState/operatorSetSplits/operatorSetSplits_test.go
+++ b/pkg/eigenState/operatorSetSplits/operatorSetSplits_test.go
@@ -102,7 +102,7 @@ func Test_OperatorSetSplit(t *testing.T) {
 			assert.Equal(t, uint64(1000), split.OldOperatorSetSplitBips)
 			assert.Equal(t, uint64(2000), split.NewOperatorSetSplitBips)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			splits := make([]*OperatorSetSplit, 0)

--- a/pkg/eigenState/operatorSetStrategyRegistrations/operatorSetStrategyRegistrations.go
+++ b/pkg/eigenState/operatorSetStrategyRegistrations/operatorSetStrategyRegistrations.go
@@ -213,7 +213,7 @@ func (ossr *OperatorSetStrategyRegistrationModel) prepareState(blockNumber uint6
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (ossr *OperatorSetStrategyRegistrationModel) CommitFinalState(blockNumber uint64) error {
+func (ossr *OperatorSetStrategyRegistrationModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := ossr.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/operatorSetStrategyRegistrations/operatorSetStrategyRegistrations_test.go
+++ b/pkg/eigenState/operatorSetStrategyRegistrations/operatorSetStrategyRegistrations_test.go
@@ -115,7 +115,7 @@ func Test_OperatorSetStrategyRegistration(t *testing.T) {
 			assert.Equal(t, uint64(1), strategyRegistration.OperatorSetId)
 			assert.Equal(t, true, strategyRegistration.IsActive)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			strategyRegistrations := make([]*OperatorSetStrategyRegistration, 0)
@@ -169,7 +169,7 @@ func Test_OperatorSetStrategyRegistration(t *testing.T) {
 			assert.Equal(t, uint64(1), strategyRegistration.OperatorSetId)
 			assert.Equal(t, false, strategyRegistration.IsActive)
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			strategyRegistrations := make([]*OperatorSetStrategyRegistration, 0)

--- a/pkg/eigenState/operatorShares/operatorShares.go
+++ b/pkg/eigenState/operatorShares/operatorShares.go
@@ -243,7 +243,7 @@ func (osm *OperatorSharesModel) writeDeltaRecords(blockNumber uint64) error {
 	return nil
 }
 
-func (osm *OperatorSharesModel) CommitFinalState(blockNumber uint64) error {
+func (osm *OperatorSharesModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	if err := osm.writeDeltaRecords(blockNumber); err != nil {
 		return err
 	}

--- a/pkg/eigenState/operatorShares/operatorShares.go
+++ b/pkg/eigenState/operatorShares/operatorShares.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/types"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type OperatorShareDeltas struct {
@@ -215,7 +214,7 @@ func (osm *OperatorSharesModel) prepareState(blockNumber uint64) ([]*OperatorSha
 	return records, nil
 }
 
-func (osm *OperatorSharesModel) writeDeltaRecords(blockNumber uint64) error {
+func (osm *OperatorSharesModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	deltas := osm.stateAccumulator[blockNumber]
 	if len(deltas) == 0 {
 		return nil
@@ -233,20 +232,12 @@ func (osm *OperatorSharesModel) writeDeltaRecords(blockNumber uint64) error {
 		d.BlockDate = block.BlockTime.Format(time.DateOnly)
 	}
 
-	res = osm.DB.Model(&OperatorShareDeltas{}).Clauses(clause.Returning{}).Create(&deltas)
-	if res.Error != nil {
-		osm.logger.Sugar().Errorw("Failed to create new operator_share_deltas records", zap.Error(res.Error))
-		return res.Error
-	}
-	osm.committedState[blockNumber] = deltas
-
-	return nil
-}
-
-func (osm *OperatorSharesModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
-	if err := osm.writeDeltaRecords(blockNumber); err != nil {
+	insertedRecords, err := base.CommitFinalState(deltas, ignoreInsertConflicts, osm.GetTableName(), osm.DB)
+	if err != nil {
+		osm.logger.Sugar().Errorw("Failed to commit final state", zap.Error(err))
 		return err
 	}
+	osm.committedState[blockNumber] = insertedRecords
 
 	return nil
 }
@@ -299,8 +290,12 @@ func (osm *OperatorSharesModel) sortValuesForMerkleTree(diffs []*OperatorShareDe
 	return inputs
 }
 
+func (osm *OperatorSharesModel) GetTableName() string {
+	return "operator_share_deltas"
+}
+
 func (osm *OperatorSharesModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return osm.BaseEigenState.DeleteState("operator_share_deltas", startBlockNumber, endBlockNumber, osm.DB)
+	return osm.BaseEigenState.DeleteState(osm.GetTableName(), startBlockNumber, endBlockNumber, osm.DB)
 }
 
 func (osm *OperatorSharesModel) ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error) {

--- a/pkg/eigenState/operatorShares/operatorSharesIntegration_test.go
+++ b/pkg/eigenState/operatorShares/operatorSharesIntegration_test.go
@@ -121,7 +121,7 @@ func Test_OperatorSharesIntegration(t *testing.T) {
 				}
 			}
 
-			if err := model.CommitFinalState(i); err != nil {
+			if err := model.CommitFinalState(i, false); err != nil {
 				t.Logf("Failed to commit final state for block %d", i)
 				t.Fatal(err)
 			}

--- a/pkg/eigenState/operatorShares/operatorShares_test.go
+++ b/pkg/eigenState/operatorShares/operatorShares_test.go
@@ -107,7 +107,7 @@ func Test_OperatorSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		err = model.CommitFinalState(block.Number)
+		err = model.CommitFinalState(block.Number, false)
 		assert.Nil(t, err)
 
 		states := []OperatorShareDeltas{}
@@ -173,7 +173,7 @@ func Test_OperatorSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		err = model.CommitFinalState(block.Number)
+		err = model.CommitFinalState(block.Number, false)
 		assert.Nil(t, err)
 
 		states = []OperatorShareDeltas{}

--- a/pkg/eigenState/precommitProcessors/slashingProcessor/slashing_test.go
+++ b/pkg/eigenState/precommitProcessors/slashingProcessor/slashing_test.go
@@ -110,10 +110,10 @@ func Test_SlashingPrecommitProcessor(t *testing.T) {
 		err = esm.RunPrecommitProcessors(blockNumber)
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -179,10 +179,10 @@ func Test_SlashingPrecommitProcessor(t *testing.T) {
 		// -----------------------
 		err = esm.RunPrecommitProcessors(blockNumber)
 		assert.Nil(t, err)
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `

--- a/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
+++ b/pkg/eigenState/rewardSubmissions/rewardSubmissions.go
@@ -291,7 +291,7 @@ func (rs *RewardSubmissionsModel) prepareState(blockNumber uint64) ([]*RewardSub
 }
 
 // CommitFinalState commits the final state for the given block number.
-func (rs *RewardSubmissionsModel) CommitFinalState(blockNumber uint64) error {
+func (rs *RewardSubmissionsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	recordsToInsert, err := rs.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/rewardSubmissions/rewardSubmissions_test.go
+++ b/pkg/eigenState/rewardSubmissions/rewardSubmissions_test.go
@@ -138,7 +138,7 @@ func Test_RewardSubmissions(t *testing.T) {
 				assert.Equal(t, strategiesAndMultipliers[i].Multiplier, submission.Multiplier)
 			}
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			rewards := make([]*RewardSubmission, 0)
@@ -213,7 +213,7 @@ func Test_RewardSubmissions(t *testing.T) {
 				assert.Equal(t, strategiesAndMultipliers[i].Multiplier, submission.Multiplier)
 			}
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			rewards := make([]*RewardSubmission, 0)
@@ -285,7 +285,7 @@ func Test_RewardSubmissions(t *testing.T) {
 				assert.Equal(t, strategiesAndMultipliers[i].Multiplier, submission.Multiplier)
 			}
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			rewards := make([]*RewardSubmission, 0)
@@ -394,7 +394,7 @@ func Test_RewardSubmissions(t *testing.T) {
 				assert.Equal(t, strategiesAndMultipliers[i].Multiplier, submission.Multiplier)
 			}
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			rewards := make([]*RewardSubmission, 0)
@@ -466,7 +466,7 @@ func Test_RewardSubmissions(t *testing.T) {
 				assert.Equal(t, strategiesAndMultipliers[i].Multiplier, submission.Multiplier)
 			}
 
-			err = model.CommitFinalState(blockNumber)
+			err = model.CommitFinalState(blockNumber, false)
 			assert.Nil(t, err)
 
 			rewards := make([]*RewardSubmission, 0)
@@ -527,7 +527,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.NotNil(t, change)
 		typedChange := change.([]*RewardSubmission)
 
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `select count(*) from reward_submissions where block_number = ?`
@@ -573,7 +573,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.NotNil(t, change)
 		typedChange = change.([]*RewardSubmission)
 
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		stateRoot, err = model.GenerateStateRoot(blockNumber)
@@ -617,7 +617,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.NotNil(t, change)
 		typedChange = change.([]*RewardSubmission)
 
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		stateRoot, err = model.GenerateStateRoot(blockNumber)
@@ -661,7 +661,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.NotNil(t, change)
 		typedChange = change.([]*RewardSubmission)
 
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		stateRoot, err = model.GenerateStateRoot(blockNumber)
@@ -766,7 +766,7 @@ func Test_RewardSubmissions(t *testing.T) {
 		assert.Equal(t, 0, count)
 
 		// Commit the final state
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// Generate the stateroot

--- a/pkg/eigenState/stakerDelegations/stakerDelegations.go
+++ b/pkg/eigenState/stakerDelegations/stakerDelegations.go
@@ -192,7 +192,7 @@ func (s *StakerDelegationsModel) writeDeltaRecords(blockNumber uint64) error {
 	return nil
 }
 
-func (s *StakerDelegationsModel) CommitFinalState(blockNumber uint64) error {
+func (s *StakerDelegationsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	if err := s.writeDeltaRecords(blockNumber); err != nil {
 		return err
 	}

--- a/pkg/eigenState/stakerDelegations/stakerDelegations.go
+++ b/pkg/eigenState/stakerDelegations/stakerDelegations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"slices"
 	"sort"
 	"strings"
@@ -175,27 +174,20 @@ func (s *StakerDelegationsModel) prepareState(blockNumber uint64) ([]*StakerDele
 	return deltas, nil
 }
 
-func (s *StakerDelegationsModel) writeDeltaRecords(blockNumber uint64) error {
+func (s *StakerDelegationsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	records, ok := s.stateAccumulator[blockNumber]
 	if !ok {
 		msg := "delta accumulator was not initialized"
 		s.logger.Sugar().Errorw(msg, zap.Uint64("blockNumber", blockNumber))
 		return errors.New(msg)
 	}
-	if len(records) > 0 {
-		res := s.DB.Model(&StakerDelegationChange{}).Clauses(clause.Returning{}).Create(&records)
-		if res.Error != nil {
-			s.logger.Sugar().Errorw("Failed to insert delta records", zap.Error(res.Error))
-			return res.Error
-		}
-	}
-	return nil
-}
-
-func (s *StakerDelegationsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
-	if err := s.writeDeltaRecords(blockNumber); err != nil {
+	insertedRecords, err := base.CommitFinalState(records, ignoreInsertConflicts, s.GetTableName(), s.DB)
+	if err != nil {
+		s.logger.Sugar().Errorw("Failed to commit final state", zap.Error(err))
 		return err
 	}
+	s.committedState[blockNumber] = insertedRecords
+
 	return nil
 }
 
@@ -249,8 +241,12 @@ func (s *StakerDelegationsModel) sortValuesForMerkleTree(deltas []*StakerDelegat
 	return inputs
 }
 
+func (s *StakerDelegationsModel) GetTableName() string {
+	return "staker_delegation_changes"
+}
+
 func (s *StakerDelegationsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return s.BaseEigenState.DeleteState("staker_delegation_changes", startBlockNumber, endBlockNumber, s.DB)
+	return s.BaseEigenState.DeleteState(s.GetTableName(), startBlockNumber, endBlockNumber, s.DB)
 }
 
 func (s *StakerDelegationsModel) ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error) {

--- a/pkg/eigenState/stakerDelegations/stakerDelegationsIntegration_test.go
+++ b/pkg/eigenState/stakerDelegations/stakerDelegationsIntegration_test.go
@@ -121,7 +121,7 @@ func Test_StakerDelegationsIntegration(t *testing.T) {
 				}
 			}
 
-			if err := model.CommitFinalState(i); err != nil {
+			if err := model.CommitFinalState(i, false); err != nil {
 				t.Logf("Failed to commit final state for block %d", i)
 				t.Fatal(err)
 			}

--- a/pkg/eigenState/stakerDelegations/stakerDelegations_test.go
+++ b/pkg/eigenState/stakerDelegations/stakerDelegations_test.go
@@ -116,7 +116,7 @@ func Test_DelegatedStakersState(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotNil(t, stateChange)
 
-			err = model.CommitFinalState(log.BlockNumber)
+			err = model.CommitFinalState(log.BlockNumber, false)
 			assert.Nil(t, err)
 
 			states := []StakerDelegationChange{}

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -1190,7 +1190,7 @@ func (ss *StakerSharesModel) writeDeltaRecords(blockNumber uint64) error {
 	return nil
 }
 
-func (ss *StakerSharesModel) CommitFinalState(blockNumber uint64) error {
+func (ss *StakerSharesModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	if err := ss.writeDeltaRecords(blockNumber); err != nil {
 		return err
 	}

--- a/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
+++ b/pkg/eigenState/stakerShares/stakerSharesIntegration_test.go
@@ -121,7 +121,7 @@ func Test_StakerSharesIntegration(t *testing.T) {
 				}
 			}
 
-			if err := model.CommitFinalState(i); err != nil {
+			if err := model.CommitFinalState(i, false); err != nil {
 				t.Logf("Failed to commit final state for block %d", i)
 				t.Fatal(err)
 			}

--- a/pkg/eigenState/stakerShares/stakerShares_test.go
+++ b/pkg/eigenState/stakerShares/stakerShares_test.go
@@ -136,7 +136,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, "0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6", shareDeltas[0].Strategy)
 		assert.Equal(t, "502179505706314959", shareDeltas[0].Shares)
 
-		err = sharesModel.CommitFinalState(transaction.BlockNumber)
+		err = sharesModel.CommitFinalState(transaction.BlockNumber, false)
 		assert.Nil(t, err)
 
 		// --------------------------------------------------------------------
@@ -206,7 +206,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		err = sharesModel.CommitFinalState(transaction.BlockNumber)
+		err = sharesModel.CommitFinalState(transaction.BlockNumber, false)
 		assert.Nil(t, err)
 
 		// --------------------------------------------------------------------
@@ -277,7 +277,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		err = sharesModel.CommitFinalState(transaction.BlockNumber)
+		err = sharesModel.CommitFinalState(transaction.BlockNumber, false)
 		assert.Nil(t, err)
 
 		// --------------------------------------------------------------------
@@ -326,7 +326,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, change)
 
-		err = sharesModel.CommitFinalState(transaction.BlockNumber)
+		err = sharesModel.CommitFinalState(transaction.BlockNumber, false)
 		assert.Nil(t, err)
 
 		query := `select * from staker_share_deltas order by block_number asc`
@@ -445,7 +445,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, strings.ToLower("0x049ea11d337f185b1aa910d98e8fbd991f0fba7b"), typedChange.ShareDeltas[0].Staker)
 		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", typedChange.ShareDeltas[0].Strategy)
 
-		err = sharesModel.CommitFinalState(transaction.BlockNumber)
+		err = sharesModel.CommitFinalState(transaction.BlockNumber, false)
 		assert.Nil(t, err)
 
 		var count int
@@ -567,10 +567,10 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 401, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(2e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ----------------------
@@ -586,7 +586,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processSlashing(sharesModel, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -637,9 +637,9 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 1000, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ------------------------
@@ -655,7 +655,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processSlashing(sharesModel, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -714,9 +714,9 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadSlashed.String())
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -763,10 +763,10 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x1234567890abcdef1234567890abcdef12345678", big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 		query := `select * from staker_share_deltas where block_number = ?`
 		results := []StakerShareDeltas{}
@@ -786,7 +786,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processSlashing(sharesModel, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e17)})
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query = `select * from staker_share_deltas`
@@ -830,9 +830,9 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ------------------------
@@ -851,7 +851,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 600, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -912,9 +912,9 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 401, "0x4444444444444444444444444444444444444444", "0x1234567890abcdef1234567890abcdef12345678", big.NewInt(4e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ------------------------
@@ -945,7 +945,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, "0x1234567890abcdef1234567890abcdef12345678", slashDiff.Strategy)
 		assert.Equal(t, "900000000000000000", slashDiff.WadSlashed.String())
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -1001,9 +1001,9 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ------------------------
@@ -1019,7 +1019,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processSlashing(sharesModel, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0x7d704507b76571a51d9cae8addabbfd0ba0e63d3"}, []*big.Int{big.NewInt(1e18)})
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -1065,9 +1065,9 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 400, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", big.NewInt(0))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ------------------------
@@ -1092,7 +1092,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, "0x7d704507b76571a51d9cae8addabbfd0ba0e63d3", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadSlashed.String())
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -1143,7 +1143,7 @@ func Test_StakerSharesState(t *testing.T) {
 		assert.Equal(t, "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", slashDiff.Strategy)
 		assert.Equal(t, "100000000000000000", slashDiff.WadSlashed.String())
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// Query the database to verify the share deltas
@@ -1190,7 +1190,7 @@ func Test_StakerSharesState(t *testing.T) {
 			big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		blockNumber = blockNumber + 1
@@ -1207,7 +1207,7 @@ func Test_StakerSharesState(t *testing.T) {
 			1e18, 9e17)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// Query the database to verify the share deltas
@@ -1259,9 +1259,9 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(stakerShares, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 401, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = stakerShares.CommitFinalState(blockNumber)
+		err = stakerShares.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ------------------------
@@ -1280,7 +1280,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processBeaconChainSlashing(stakerShares, cfg.GetContractsMapForChain().EigenpodManager, blockNumber, 600, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", 1e18, 5e17)
 		assert.Nil(t, err)
 
-		err = stakerShares.CommitFinalState(blockNumber)
+		err = stakerShares.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -1332,9 +1332,9 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processDeposit(sharesModel, cfg.GetContractsMapForChain().StrategyManager, blockNumber, 401, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0", big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = delegationModel.CommitFinalState(blockNumber)
+		err = delegationModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// ------------------------
@@ -1350,7 +1350,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processSlashing(sharesModel, cfg.GetContractsMapForChain().AllocationManager, blockNumber, 500, "0xbde83df53bc7d159700e966ad5d21e8b7c619459", []string{"0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0"}, []*big.Int{big.NewInt(5e17)})
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		blockNumber = blockNumber + 1
@@ -1363,7 +1363,7 @@ func Test_StakerSharesState(t *testing.T) {
 		_, err = processBeaconChainSlashing(sharesModel, cfg.GetContractsMapForChain().EigenpodManager, blockNumber, 600, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", 1e18, 5e17)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `
@@ -1403,7 +1403,7 @@ func Test_StakerSharesState(t *testing.T) {
 			big.NewInt(1e18))
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		blockNumber = blockNumber + 1
@@ -1418,7 +1418,7 @@ func Test_StakerSharesState(t *testing.T) {
 			blockNumber, 500, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", 1e18, 0)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// Query the database to verify the share deltas
@@ -1460,7 +1460,7 @@ func Test_StakerSharesState(t *testing.T) {
 			big.NewInt(0))
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		blockNumber = blockNumber + 1
@@ -1475,7 +1475,7 @@ func Test_StakerSharesState(t *testing.T) {
 			blockNumber, 500, "0xaf6fb48ac4a60c61a64124ce9dc28f508dc8de8d", 1e18, 9e17)
 		assert.Nil(t, err)
 
-		err = sharesModel.CommitFinalState(blockNumber)
+		err = sharesModel.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		// Query the database to verify the share deltas

--- a/pkg/eigenState/stateManager/stateManager.go
+++ b/pkg/eigenState/stateManager/stateManager.go
@@ -133,7 +133,7 @@ func (e *EigenStateManager) CommitFinalState(blockNumber uint64) (map[string][]i
 	committedState := make(map[string][]interface{})
 	for _, index := range e.GetSortedModelIndexes() {
 		state := e.StateModels[index]
-		err := state.CommitFinalState(blockNumber)
+		err := state.CommitFinalState(blockNumber, false)
 		if err != nil {
 			return committedState, err
 		}

--- a/pkg/eigenState/stateManager/stateManager.go
+++ b/pkg/eigenState/stateManager/stateManager.go
@@ -129,11 +129,11 @@ func (e *EigenStateManager) RunPrecommitProcessors(blockNumber uint64) error {
 }
 
 // With all transactions/logs processed for a block, commit the final state to the table.
-func (e *EigenStateManager) CommitFinalState(blockNumber uint64) (map[string][]interface{}, error) {
+func (e *EigenStateManager) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) (map[string][]interface{}, error) {
 	committedState := make(map[string][]interface{})
 	for _, index := range e.GetSortedModelIndexes() {
 		state := e.StateModels[index]
-		err := state.CommitFinalState(blockNumber, false)
+		err := state.CommitFinalState(blockNumber, ignoreInsertConflicts)
 		if err != nil {
 			return committedState, err
 		}

--- a/pkg/eigenState/stateMigrator/stateMigrations/202502031222_operatorSets/migration.go
+++ b/pkg/eigenState/stateMigrator/stateMigrations/202502031222_operatorSets/migration.go
@@ -115,7 +115,7 @@ func (sm *StateMigration) MigrateState(currentBlockNumber uint64) ([][]byte, map
 			return nil, nil, err
 		}
 
-		committedState, err := stateMan.CommitFinalState(bn)
+		committedState, err := stateMan.CommitFinalState(bn, true)
 		if err != nil {
 			sm.logger.Sugar().Errorw("Failed to commit final state", zap.Uint64("blockNumber", bn), zap.Error(err))
 			return nil, nil, err

--- a/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
+++ b/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
@@ -234,7 +234,7 @@ func (sdr *SubmittedDistributionRootsModel) prepareState(blockNumber uint64) ([]
 	return preparedState, nil
 }
 
-func (sdr *SubmittedDistributionRootsModel) CommitFinalState(blockNumber uint64) error {
+func (sdr *SubmittedDistributionRootsModel) CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error {
 	records, err := sdr.prepareState(blockNumber)
 	if err != nil {
 		return err

--- a/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
+++ b/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/types"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type SubmittedDistributionRootsModel struct {
@@ -240,14 +239,12 @@ func (sdr *SubmittedDistributionRootsModel) CommitFinalState(blockNumber uint64,
 		return err
 	}
 
-	if len(records) > 0 {
-		res := sdr.DB.Model(&types.SubmittedDistributionRoot{}).Clauses(clause.Returning{}).Create(&records)
-		if res.Error != nil {
-			sdr.logger.Sugar().Errorw("Failed to create new submitted_distribution_roots records", zap.Error(res.Error))
-			return res.Error
-		}
+	insertedRecords, err := base.CommitFinalState(records, ignoreInsertConflicts, sdr.GetTableName(), sdr.DB)
+	if err != nil {
+		sdr.logger.Sugar().Errorw("Failed to commit final state", zap.Error(err))
+		return err
 	}
-	sdr.committedState[blockNumber] = records
+	sdr.committedState[blockNumber] = insertedRecords
 
 	return nil
 }
@@ -300,8 +297,12 @@ func (sdr *SubmittedDistributionRootsModel) GenerateStateRoot(blockNumber uint64
 	return fullTree.Root(), nil
 }
 
+func (sdr *SubmittedDistributionRootsModel) GetTableName() string {
+	return "submitted_distribution_roots"
+}
+
 func (sdr *SubmittedDistributionRootsModel) DeleteState(startBlockNumber uint64, endBlockNumber uint64) error {
-	return sdr.BaseEigenState.DeleteState("submitted_distribution_roots", startBlockNumber, endBlockNumber, sdr.DB)
+	return sdr.BaseEigenState.DeleteState(sdr.GetTableName(), startBlockNumber, endBlockNumber, sdr.DB)
 }
 
 func (sdr *SubmittedDistributionRootsModel) GetAccumulatedState(blockNumber uint64) []*types.SubmittedDistributionRoot {

--- a/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
+++ b/pkg/eigenState/submittedDistributionRoots/submittedDistributionRoots_test.go
@@ -105,7 +105,7 @@ func Test_SubmittedDistributionRoots(t *testing.T) {
 		assert.Equal(t, blockNumber, typedChange.CreatedAtBlockNumber)
 		assert.Equal(t, uint64(100), typedChange.BlockNumber)
 
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `SELECT * FROM submitted_distribution_roots WHERE block_number = ?`
@@ -167,7 +167,7 @@ func Test_SubmittedDistributionRoots(t *testing.T) {
 		assert.Equal(t, blockNumber, typedChange.CreatedAtBlockNumber)
 		assert.Equal(t, uint64(101), typedChange.BlockNumber)
 
-		err = model.CommitFinalState(blockNumber)
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
 		query := `SELECT * FROM submitted_distribution_roots WHERE block_number = ?`

--- a/pkg/eigenState/types/types.go
+++ b/pkg/eigenState/types/types.go
@@ -31,7 +31,7 @@ type IEigenStateModel interface {
 
 	// CommitFinalState
 	// Once all state changes are processed, commit the final state to the database
-	CommitFinalState(blockNumber uint64) error
+	CommitFinalState(blockNumber uint64, ignoreInsertConflicts bool) error
 
 	// GetCommittedState
 	// Get the committed state for the model at the given block height.

--- a/pkg/eigenState/types/types.go
+++ b/pkg/eigenState/types/types.go
@@ -52,6 +52,8 @@ type IEigenStateModel interface {
 	ListForBlockRange(startBlockNumber uint64, endBlockNumber uint64) ([]interface{}, error)
 
 	IsActiveForBlockHeight(blockHeight uint64) (bool, error)
+
+	GetTableName() string
 }
 
 type IEigenPrecommitProcessor interface {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -227,7 +227,7 @@ func (p *Pipeline) RunForFetchedBlock(ctx context.Context, block *fetcher.Fetche
 	}
 
 	blockFetchTime = time.Now()
-	committedState, err := p.stateManager.CommitFinalState(blockNumber)
+	committedState, err := p.stateManager.CommitFinalState(blockNumber, false)
 	if err != nil {
 		p.Logger.Sugar().Errorw("Failed to commit final state", zap.Uint64("blockNumber", blockNumber), zap.Error(err))
 		hasError = true

--- a/pkg/postgres/migrations/202503030846_cleanupConstraintNames/up.go
+++ b/pkg/postgres/migrations/202503030846_cleanupConstraintNames/up.go
@@ -1,0 +1,54 @@
+package _202503030846_cleanupConstraintNames
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func formatConstraintName(tableName string) string {
+	return fmt.Sprintf("uniq_%s", tableName)
+}
+
+func formatRenameQuery(tableName, constraintName string) string {
+	newName := formatConstraintName(tableName)
+
+	return fmt.Sprintf("ALTER TABLE %s RENAME CONSTRAINT %s TO %s", tableName, constraintName, newName)
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		formatRenameQuery("avs_operator_state_changes", "avs_operator_state_changes_operator_avs_block_number_log_in_key"),
+		formatRenameQuery("disabled_distribution_roots", "uniq_disabled_distribution_root"),
+		formatRenameQuery("default_operator_splits", "default_operator_splits_transaction_hash_log_index_block_nu_key"),
+		formatRenameQuery("operator_avs_splits", "operator_avs_splits_transaction_hash_log_index_block_number_key"),
+		formatRenameQuery("operator_directed_operator_set_reward_submissions", "operator_directed_operator_se_transaction_hash_log_index_bl_key"),
+		formatRenameQuery("operator_directed_reward_submissions", "operator_directed_reward_subm_transaction_hash_log_index_bl_key"),
+		formatRenameQuery("operator_pi_splits", "operator_pi_splits_transaction_hash_log_index_block_number_key"),
+		formatRenameQuery("operator_set_operator_registrations", "operator_set_operator_registr_transaction_hash_log_index_bl_key"),
+		formatRenameQuery("operator_set_splits", "operator_set_splits_transaction_hash_log_index_block_number_key"),
+		formatRenameQuery("operator_set_strategy_registrations", "operator_set_strategy_registr_transaction_hash_log_index_bl_key"),
+		`alter table operator_shares add constraint uniq_operator_shares unique(operator, strategy, transaction_hash, log_index, block_number)`,
+		formatRenameQuery("reward_submissions", "uniq_reward_submission"),
+		formatRenameQuery("staker_delegation_changes", "uniq_staker_delegation_change"),
+		`alter table staker_shares add constraint uniq_staker_shares unique(staker, strategy, transaction_hash, log_index, block_number)`,
+		formatRenameQuery("submitted_distribution_roots", "uniq_submitted_distribution_root"),
+	}
+
+	for _, query := range queries {
+		res := grm.Exec(query)
+		if res.Error != nil {
+			fmt.Printf("Error executing query: %s\n", query)
+			return res.Error
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202503030846_cleanupConstraintNames"
+}

--- a/pkg/postgres/migrations/202503030846_cleanupConstraintNames/up.go
+++ b/pkg/postgres/migrations/202503030846_cleanupConstraintNames/up.go
@@ -4,18 +4,15 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/pkg/eigenState/base"
 	"gorm.io/gorm"
 )
 
 type Migration struct {
 }
 
-func formatConstraintName(tableName string) string {
-	return fmt.Sprintf("uniq_%s", tableName)
-}
-
 func formatRenameQuery(tableName, constraintName string) string {
-	newName := formatConstraintName(tableName)
+	newName := base.FormatUniqueConstraintName(tableName)
 
 	return fmt.Sprintf("ALTER TABLE %s RENAME CONSTRAINT %s TO %s", tableName, constraintName, newName)
 }

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -6,6 +6,7 @@ import (
 	_202501241111_addIndexesForRpcFunctions "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501241111_addIndexesForRpcFunctions"
 	_202502100846_goldTableRewardHashIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502100846_goldTableRewardHashIndex"
 	_202502211539_hydrateClaimedRewards "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502211539_hydrateClaimedRewards"
+	_202503030846_cleanupConstraintNames "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503030846_cleanupConstraintNames"
 	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
@@ -158,6 +159,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202501301505_operatorSetStrategyRegistrationSnapshots.Migration{},
 		&_202501301945_operatorDirectedOperatorSetRewards.Migration{},
 		&_202502051830_addOperatorSetIdToStakerOperator.Migration{},
+		&_202503030846_cleanupConstraintNames.Migration{},
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Description

* Ensure that all EigenState models have a unique constraint on their table
* Add the ability to enforce or ignore the unique constraint. Enforcing the constraint and returning an error is the default expected behavior. Ignoring the constraint is meant to be used as part of the `stateMigrator` migrations where we may have partial data already but need to pull in all remaining data.
* Slightly refactors models to use the `base.CommitFinalState` function to DRY up repetitive code

## Type of change

- [x] Refactor (non-breaking change which does not add functionality)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This was a refactoring of existing code. All test suites are passing including the more involved rewards test which can be run locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
