### PR TITLE
fix: initialize prometheus labels and add label check to prevent crashing

### DIFF
--- a/internal/metrics/metricsTypes/metrics.go
+++ b/internal/metrics/metricsTypes/metrics.go
@@ -51,12 +51,24 @@ var MetricTypes = map[MetricsType][]MetricsTypeConfig{
 			Labels: []string{},
 		},
 		MetricsTypeConfig{
-			Name:   Metric_Incr_GrpcRequest,
-			Labels: []string{},
+			Name: Metric_Incr_GrpcRequest,
+			Labels: []string{
+				"grpc_method",
+				"status",
+				"status_code",
+				"rpc",
+			},
 		},
 		MetricsTypeConfig{
-			Name:   Metric_Incr_HttpRequest,
-			Labels: []string{},
+			Name: Metric_Incr_HttpRequest,
+			Labels: []string{
+				"method",
+				"path",
+				"status_code",
+				"grpc_method",
+				"pattern",
+				"rpc",
+			},
 		},
 	},
 	MetricsType_Gauge: {
@@ -71,24 +83,45 @@ var MetricTypes = map[MetricsType][]MetricsTypeConfig{
 	},
 	MetricsType_Timing: {
 		MetricsTypeConfig{
-			Name:   Metric_Timing_GrpcDuration,
-			Labels: []string{},
+			Name: Metric_Timing_GrpcDuration,
+			Labels: []string{
+				"grpc_method",
+				"status",
+				"status_code",
+				"rpc",
+			},
 		},
 		MetricsTypeConfig{
-			Name:   Metric_Timing_HttpDuration,
-			Labels: []string{},
+			Name: Metric_Timing_HttpDuration,
+			Labels: []string{
+				"method",
+				"path",
+				"status_code",
+				"grpc_method",
+				"pattern",
+				"rpc",
+			},
 		},
 		MetricsTypeConfig{
-			Name:   Metric_Timing_RewardsCalcDuration,
-			Labels: []string{},
+			Name: Metric_Timing_RewardsCalcDuration,
+			Labels: []string{
+				"snapshotDate",
+			},
 		},
 		MetricsTypeConfig{
-			Name:   Metric_Timing_BlockProcessDuration,
-			Labels: []string{},
+			Name: Metric_Timing_BlockProcessDuration,
+			Labels: []string{
+				"rewardsCalculated",
+				"hasError",
+			},
 		},
 		MetricsTypeConfig{
-			Name:   Metric_Timing_CreateSnapshot,
-			Labels: []string{},
+			Name: Metric_Timing_CreateSnapshot,
+			Labels: []string{
+				"chain",
+				"sidecarVersion",
+				"kind",
+			},
 		},
 	},
 }

--- a/internal/metrics/prometheus/prometheus_test.go
+++ b/internal/metrics/prometheus/prometheus_test.go
@@ -29,12 +29,16 @@ func Test_UnexpectedLabelsParsing(t *testing.T) {
 		})
 		assert.Nil(t, err)
 	})
-	t.Run("Should return an error for no labels", func(t *testing.T) {
-		err := pmc.hasUnexpectedLabels(metricsTypes.MetricsType_Timing, metricsTypes.Metric_Timing_BlockProcessDuration, []metricsTypes.MetricsLabel{})
-		assert.NotNil(t, err)
-	})
 	t.Run("Should return an error for unexpected labels", func(t *testing.T) {
 		err := pmc.hasUnexpectedLabels(metricsTypes.MetricsType_Timing, metricsTypes.Metric_Timing_BlockProcessDuration, []metricsTypes.MetricsLabel{
+			{Name: "rewardsCalculated", Value: "10"},
+			{Name: "hasError", Value: "false"},
+			{Name: "unexpectedLabel", Value: "unexpectedValue"},
+		})
+		assert.NotNil(t, err)
+	})
+	t.Run("Should return an error for unexpected labels when expecting 0 labels", func(t *testing.T) {
+		err := pmc.hasUnexpectedLabels(metricsTypes.MetricsType_Gauge, metricsTypes.Metric_Gauge_CurrentBlockHeight, []metricsTypes.MetricsLabel{
 			{Name: "rewardsCalculated", Value: "10"},
 			{Name: "hasError", Value: "false"},
 			{Name: "unexpectedLabel", Value: "unexpectedValue"},

--- a/internal/metrics/prometheus/prometheus_test.go
+++ b/internal/metrics/prometheus/prometheus_test.go
@@ -1,0 +1,45 @@
+package prometheus
+
+import (
+	"github.com/Layr-Labs/sidecar/internal/logger"
+	"github.com/Layr-Labs/sidecar/internal/metrics/metricsTypes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_UnexpectedLabelsParsing(t *testing.T) {
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	assert.Nil(t, err)
+
+	pmc, err := NewPrometheusMetricsClient(&PrometheusMetricsConfig{
+		Metrics: metricsTypes.MetricTypes,
+	}, l)
+	assert.Nil(t, err)
+
+	t.Run("Should return no error for all labels", func(t *testing.T) {
+		err := pmc.hasUnexpectedLabels(metricsTypes.MetricsType_Timing, metricsTypes.Metric_Timing_BlockProcessDuration, []metricsTypes.MetricsLabel{
+			{Name: "rewardsCalculated", Value: "10"},
+			{Name: "hasError", Value: "false"},
+		})
+		assert.Nil(t, err)
+	})
+	t.Run("Should return no error for a subset labels", func(t *testing.T) {
+		err := pmc.hasUnexpectedLabels(metricsTypes.MetricsType_Timing, metricsTypes.Metric_Timing_BlockProcessDuration, []metricsTypes.MetricsLabel{
+			{Name: "rewardsCalculated", Value: "10"},
+		})
+		assert.Nil(t, err)
+	})
+	t.Run("Should return an error for no labels", func(t *testing.T) {
+		err := pmc.hasUnexpectedLabels(metricsTypes.MetricsType_Timing, metricsTypes.Metric_Timing_BlockProcessDuration, []metricsTypes.MetricsLabel{})
+		assert.NotNil(t, err)
+	})
+	t.Run("Should return an error for unexpected labels", func(t *testing.T) {
+		err := pmc.hasUnexpectedLabels(metricsTypes.MetricsType_Timing, metricsTypes.Metric_Timing_BlockProcessDuration, []metricsTypes.MetricsLabel{
+			{Name: "rewardsCalculated", Value: "10"},
+			{Name: "hasError", Value: "false"},
+			{Name: "unexpectedLabel", Value: "unexpectedValue"},
+		})
+		assert.NotNil(t, err)
+	})
+
+}


### PR DESCRIPTION
## Description

Prometheus needs its labels defined when each metric is created. This PR adds those missing labels and adds a check to make sure each label passed is expected in the initialized list. If it encounters a label not in the list, it logs a warning and skips sending the metric to prevent the server from crashing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added additional tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

Fixes #280