### PR TITLE
feat: add index to staker_operator table to speed up query time

### DIFF
--- a/pkg/postgres/migrations/202503042014_stakerOperatorIndex/up.go
+++ b/pkg/postgres/migrations/202503042014_stakerOperatorIndex/up.go
@@ -1,0 +1,23 @@
+package _202503042014_stakerOperatorIndex
+
+import (
+	"database/sql"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	query := `create index concurrently if not exists idx_staker_operator_snapshot_operator_strategy on staker_operator (snapshot, operator, strategy);`
+	res := grm.Exec(query)
+	if res.Error != nil {
+		return res.Error
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202503042014_stakerOperatorIndex"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -6,6 +6,7 @@ import (
 	_202501241111_addIndexesForRpcFunctions "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202501241111_addIndexesForRpcFunctions"
 	_202502100846_goldTableRewardHashIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502100846_goldTableRewardHashIndex"
 	_202502211539_hydrateClaimedRewards "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202502211539_hydrateClaimedRewards"
+	_202503042014_stakerOperatorIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503042014_stakerOperatorIndex"
 	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
@@ -172,6 +173,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202501241111_addIndexesForRpcFunctions.Migration{},
 		&_202502100846_goldTableRewardHashIndex.Migration{},
 		&_202502211539_hydrateClaimedRewards.Migration{},
+		&_202503042014_stakerOperatorIndex.Migration{},
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Description

Original query was taking between 3 and 5 seconds to complete:

```sql
SELECT DISTINCT ON (snapshot, strategy, operator)
    snapshot, strategy, operator, shares AS total_staked
FROM sidecar_mainnet_ethereum.staker_operator
WHERE snapshot > '2025-02-25' 
  AND snapshot <= '2025-03-02'
  AND operator IN ('0x5accc90436492f24e6af278569691e2c942a676d')
ORDER BY snapshot ASC, strategy ASC, operator ASC, shares DESC;
```

![Screenshot 2025-03-04 at 8 14 34 PM](https://github.com/user-attachments/assets/186d67af-f54e-41b5-badc-6db3f5f01cc3)


Adding this index and tweaking the query slightly to manipulate the query planner got the run time down to ~120ms

```sql
with results as (
    SELECT DISTINCT ON (snapshot, strategy, operator)
        snapshot, strategy, operator, shares AS total_staked
    FROM staker_operator
    WHERE snapshot > '2025-02-25'
      AND snapshot <= '2025-03-02'
      AND operator IN ('0x5accc90436492f24e6af278569691e2c942a676d')
)
select * from results
ORDER BY snapshot ASC, strategy ASC, operator ASC, total_staked DESC;
```

![image](https://github.com/user-attachments/assets/6c85fd9b-1aca-45bb-88b7-96cdc0c6e495)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual testing with above `explain analyze` sample output.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
