### PR TITLE
feat: prune blocks to before holesky pectra block number to fix and resume block processing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool(config.EthereumRpcUseNativeBatchCall, true, `Use the native eth_call method for batch calls`)
 	rootCmd.PersistentFlags().Int(config.EthereumRpcNativeBatchCallSize, 500, `The number of calls to batch together when using the native eth_call method`)
 	rootCmd.PersistentFlags().Int(config.EthereumRpcChunkedBatchCallSize, 10, `The number of calls to make in parallel when using the chunked batch call method`)
+	rootCmd.PersistentFlags().String(config.EthereumLatestBlockType, "safe", `The type of latest block to use (safe, latest)`)
 
 	rootCmd.PersistentFlags().String(config.DatabaseHost, "localhost", `PostgreSQL host`)
 	rootCmd.PersistentFlags().Int(config.DatabasePort, 5432, `PostgreSQL port`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,7 @@ type EthereumRpcConfig struct {
 	UseNativeBatchCall    bool // Use the native eth_call method for batch calls
 	NativeBatchCallSize   int  // Number of calls to put in a single eth_call request
 	ChunkedBatchCallSize  int  // Number of calls to make in parallel
+	BlockType             string
 }
 
 type DatabaseConfig struct {
@@ -191,6 +192,7 @@ var (
 	EthereumRpcUseNativeBatchCall    = "ethereum.use_native_batch_call"
 	EthereumRpcNativeBatchCallSize   = "ethereum.native_batch_call_size"
 	EthereumRpcChunkedBatchCallSize  = "ethereum.chunked_batch_call_size"
+	EthereumLatestBlockType          = "ethereum.latest-block-type"
 
 	DataDogStatsdEnabled    = "datadog.statsd.enabled"
 	DataDogStatsdUrl        = "datadog.statsd.url"
@@ -217,6 +219,7 @@ func NewConfig() *Config {
 			UseNativeBatchCall:    viper.GetBool(normalizeFlagName(EthereumRpcUseNativeBatchCall)),
 			NativeBatchCallSize:   viper.GetInt(normalizeFlagName(EthereumRpcNativeBatchCallSize)),
 			ChunkedBatchCallSize:  viper.GetInt(normalizeFlagName(EthereumRpcChunkedBatchCallSize)),
+			BlockType:             viper.GetString(normalizeFlagName(EthereumLatestBlockType)),
 		},
 
 		DatabaseConfig: DatabaseConfig{

--- a/pkg/clients/ethereum/handlers.go
+++ b/pkg/clients/ethereum/handlers.go
@@ -116,6 +116,15 @@ func GetSafeBlockRequest(id uint) *RPCRequest {
 	}
 }
 
+func GetLatestBlockRequest(id uint) *RPCRequest {
+	return &RPCRequest{
+		JSONRPC: jsonRPCVersion,
+		Method:  RPCMethod_getBlockByNumber.RequestMethod.Name,
+		Params:  []interface{}{"latest", true},
+		ID:      id,
+	}
+}
+
 func GetTransactionByHashRequest(txHash string, id uint) *RPCRequest {
 	return &RPCRequest{
 		JSONRPC: jsonRPCVersion,

--- a/pkg/eigenState/encumberedMagnitudes/encumberedMagnitudes.go
+++ b/pkg/eigenState/encumberedMagnitudes/encumberedMagnitudes.go
@@ -318,5 +318,11 @@ func (em *EncumberedMagnitudeModel) ListForBlockRange(startBlockNumber uint64, e
 }
 
 func (em *EncumberedMagnitudeModel) IsActiveForBlockHeight(blockHeight uint64) (bool, error) {
-	return true, nil
+	forks, err := em.globalConfig.GetRewardsSqlForkDates()
+	if err != nil {
+		em.logger.Sugar().Errorw("Failed to get rewards sql fork dates", zap.Error(err))
+		return false, err
+	}
+
+	return blockHeight >= forks[config.RewardsFork_Brazos].BlockNumber, nil
 }

--- a/pkg/eigenState/operatorAllocationDelays/operatorAllocationDelays.go
+++ b/pkg/eigenState/operatorAllocationDelays/operatorAllocationDelays.go
@@ -310,5 +310,11 @@ func (oad *OperatorAllocationDelayModel) ListForBlockRange(startBlockNumber uint
 }
 
 func (oad *OperatorAllocationDelayModel) IsActiveForBlockHeight(blockHeight uint64) (bool, error) {
-	return true, nil
+	forks, err := oad.globalConfig.GetRewardsSqlForkDates()
+	if err != nil {
+		oad.logger.Sugar().Errorw("Failed to get rewards sql fork dates", zap.Error(err))
+		return false, err
+	}
+
+	return blockHeight >= forks[config.RewardsFork_Brazos].BlockNumber, nil
 }

--- a/pkg/eigenState/operatorAllocations/operatorAllocations.go
+++ b/pkg/eigenState/operatorAllocations/operatorAllocations.go
@@ -331,5 +331,11 @@ func (oa *OperatorAllocationModel) ListForBlockRange(startBlockNumber uint64, en
 }
 
 func (oa *OperatorAllocationModel) IsActiveForBlockHeight(blockHeight uint64) (bool, error) {
-	return true, nil
+	forks, err := oa.globalConfig.GetRewardsSqlForkDates()
+	if err != nil {
+		oa.logger.Sugar().Errorw("Failed to get rewards sql fork dates", zap.Error(err))
+		return false, err
+	}
+
+	return blockHeight >= forks[config.RewardsFork_Brazos].BlockNumber, nil
 }

--- a/pkg/eigenState/operatorMaxMagnitudes/operatorMaxMagnitudes.go
+++ b/pkg/eigenState/operatorMaxMagnitudes/operatorMaxMagnitudes.go
@@ -318,5 +318,11 @@ func (omm *OperatorMaxMagnitudeModel) ListForBlockRange(startBlockNumber uint64,
 }
 
 func (omm *OperatorMaxMagnitudeModel) IsActiveForBlockHeight(blockHeight uint64) (bool, error) {
-	return true, nil
+	forks, err := omm.globalConfig.GetRewardsSqlForkDates()
+	if err != nil {
+		omm.logger.Sugar().Errorw("Failed to get rewards sql fork dates", zap.Error(err))
+		return false, err
+	}
+
+	return blockHeight >= forks[config.RewardsFork_Brazos].BlockNumber, nil
 }

--- a/pkg/eigenState/operatorSets/operatorSets.go
+++ b/pkg/eigenState/operatorSets/operatorSets.go
@@ -307,5 +307,11 @@ func (os *OperatorSetModel) ListForBlockRange(startBlockNumber uint64, endBlockN
 }
 
 func (os *OperatorSetModel) IsActiveForBlockHeight(blockHeight uint64) (bool, error) {
-	return true, nil
+	forks, err := os.globalConfig.GetRewardsSqlForkDates()
+	if err != nil {
+		os.logger.Sugar().Errorw("Failed to get rewards sql fork dates", zap.Error(err))
+		return false, err
+	}
+
+	return blockHeight >= forks[config.RewardsFork_Brazos].BlockNumber, nil
 }

--- a/pkg/eigenState/slashedOperatorShares/slashedOperatorShares.go
+++ b/pkg/eigenState/slashedOperatorShares/slashedOperatorShares.go
@@ -322,5 +322,11 @@ func (sos *SlashedOperatorSharesModel) ListForBlockRange(startBlockNumber uint64
 }
 
 func (sos *SlashedOperatorSharesModel) IsActiveForBlockHeight(blockHeight uint64) (bool, error) {
-	return true, nil
+	forks, err := sos.globalConfig.GetRewardsSqlForkDates()
+	if err != nil {
+		sos.logger.Sugar().Errorw("Failed to get rewards sql fork dates", zap.Error(err))
+		return false, err
+	}
+
+	return blockHeight >= forks[config.RewardsFork_Brazos].BlockNumber, nil
 }

--- a/pkg/eigenState/slashedOperators/slashedOperators.go
+++ b/pkg/eigenState/slashedOperators/slashedOperators.go
@@ -351,5 +351,11 @@ func (so *SlashedOperatorModel) ListForBlockRange(startBlockNumber uint64, endBl
 }
 
 func (so *SlashedOperatorModel) IsActiveForBlockHeight(blockHeight uint64) (bool, error) {
-	return true, nil
+	forks, err := so.globalConfig.GetRewardsSqlForkDates()
+	if err != nil {
+		so.logger.Sugar().Errorw("Failed to get rewards sql fork dates", zap.Error(err))
+		return false, err
+	}
+
+	return blockHeight >= forks[config.RewardsFork_Brazos].BlockNumber, nil
 }

--- a/pkg/postgres/migrations/202503061009_pectraPrune/up.go
+++ b/pkg/postgres/migrations/202503061009_pectraPrune/up.go
@@ -1,0 +1,23 @@
+package _202503061009_pectraPrune
+
+import (
+	"database/sql"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	if cfg.Chain != config.Chain_Holesky {
+		return nil
+	}
+
+	res := grm.Exec(`delete from state_roots where eth_block_number > 3419700`)
+	return res.Error
+}
+
+func (m *Migration) GetName() string {
+	return "202503061009_pectraPrune"
+}

--- a/pkg/postgres/migrations/202503061223_renameConstraint/up.go
+++ b/pkg/postgres/migrations/202503061223_renameConstraint/up.go
@@ -1,0 +1,22 @@
+package _202503061223_renameConstraint
+
+import (
+	"database/sql"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	query := `alter table staker_share_deltas rename constraint uniq_staker_share_delta to uniq_staker_share_deltas`
+
+	res := grm.Exec(query)
+	return res.Error
+
+}
+
+func (m *Migration) GetName() string {
+	return "202503061223_renameConstraint"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"database/sql"
 	"fmt"
+	_202503061009_pectraPrune "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503061009_pectraPrune"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"time"
@@ -198,6 +199,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202502051830_addOperatorSetIdToStakerOperator.Migration{},
 		&_202503030846_cleanupConstraintNames.Migration{},
 		&_202502252204_slashingModels.Migration{},
+		&_202503061009_pectraPrune.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	_202503061009_pectraPrune "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503061009_pectraPrune"
+	_202503061223_renameConstraint "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503061223_renameConstraint"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"time"
@@ -200,6 +201,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202503030846_cleanupConstraintNames.Migration{},
 		&_202502252204_slashingModels.Migration{},
 		&_202503061009_pectraPrune.Migration{},
+		&_202503061223_renameConstraint.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/sidecar/blockIndexer.go
+++ b/pkg/sidecar/blockIndexer.go
@@ -50,7 +50,7 @@ func (s *Sidecar) ProcessNewBlocks(ctx context.Context) error {
 		}
 
 		// Get the latest safe block from the Ethereum node
-		latestTip, err := s.EthereumClient.GetLatestSafeBlock(ctx)
+		latestTip, err := s.EthereumClient.GetLatestBlock(ctx)
 		if err != nil {
 			s.Logger.Sugar().Fatalw("Failed to get latest tip", zap.Error(err))
 			return errors.New("Failed to get latest tip")
@@ -204,7 +204,7 @@ func (s *Sidecar) IndexFromCurrentToTip(ctx context.Context) error {
 
 	for retryCount < 3 {
 		// Get the latest safe block as a starting point
-		latestSafe, err := s.EthereumClient.GetLatestSafeBlock(ctx)
+		latestSafe, err := s.EthereumClient.GetLatestBlock(ctx)
 		if err != nil {
 			s.Logger.Sugar().Fatalw("Failed to get current tip", zap.Error(err))
 		}
@@ -255,7 +255,7 @@ func (s *Sidecar) IndexFromCurrentToTip(ctx context.Context) error {
 				s.Logger.Sugar().Infow("Indexing complete, shutting down tip listener")
 				return
 			}
-			latestTip, err := s.EthereumClient.GetLatestSafeBlock(ctx)
+			latestTip, err := s.EthereumClient.GetLatestBlock(ctx)
 			if err != nil {
 				s.Logger.Sugar().Errorw("Failed to get latest tip", zap.Error(err))
 				continue


### PR DESCRIPTION
## Description

* For holesky sidecars only, prune blocks back to `3419700`, which is before the pectra fork
* Allow overriding the use of `"safe"` blocks with `--ethereum.latest-block-type="latest"`. Because holesky blocks havent been finalized, the latest `"safe"` block is stuck right around the fork block. This is problematic for anyone wanting to continue to run the Sidecar on the current "correct" holesky fork. Using latest blocks allows this, but runs the risk of ingesting bad state if a re-org happens or if the target RPC execution client drifts off onto the wrong chain.
* Updates the unique constraint name on the `staker_share_deltas` table

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests and manual validation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
