### PR TITLE
feat: add helper route for getting rewards for a distribution root and update docs

### DIFF
--- a/docs/docs/sidecar/rewards/rewards-data.md
+++ b/docs/docs/sidecar/rewards/rewards-data.md
@@ -12,6 +12,7 @@ There are two ways to access the rewards data from the Sidecar:
 
 * Through your terminal or a bash script with `curl` and `grpcurl`
 * Using the gRPC or HTTP clients published in the [protocol-apis](https://github.com/Layr-Labs/protocol-apis) Go package.
+  * See the `examples` directory for how to use both
 
 ## Listing Distribution Roots
 
@@ -40,5 +41,21 @@ curl -s http://localhost:7101/rewards/v1/distribution-roots
 ## Fetching Rewards Data
 
 ```bash
+# grpcurl
+grpcurl -plaintext --max-msg-sz 2147483647 -d '{ "rootIndex": 217 }' localhost:7100 eigenlayer.sidecar.v1.rewards.Rewards/GetRewardsForDistributionRoot > rewardsData.json
 
+# curl
+curl -s http://localhost:7101/rewards/v1/distribution-roots/217/rewards > rewardsData.json
+
+{
+  "rewards": [
+    {
+      "earner": "0xe44ce641a7cf6d52c06c278694313b08c2b181c0",
+      "token": "0x3b78576f7d6837500ba3de27a60c7f594934027e",
+      "amount": "130212752259281570",
+      "snapshot": "2025-02-22T00:00:00Z"
+    },
+    // ...
+  ]
+}
 ```

--- a/docs/docs/sidecar/rewards/rewards-data.md
+++ b/docs/docs/sidecar/rewards/rewards-data.md
@@ -1,0 +1,44 @@
+---
+title: Rewards Data
+description: How to access the rewards data from the Sidecar
+sidebar_position: 2
+---
+
+This method of accessing the rewards data from the Sidecar replaces the previous method of downloading the data from the S3 file published by EigenLabs.
+
+## Accessing the data
+
+There are two ways to access the rewards data from the Sidecar:
+
+* Through your terminal or a bash script with `curl` and `grpcurl`
+* Using the gRPC or HTTP clients published in the [protocol-apis](https://github.com/Layr-Labs/protocol-apis) Go package.
+
+## Listing Distribution Roots
+
+```bash
+# grpcurl
+grpcurl -plaintext -d '{ }' localhost:7100 eigenlayer.sidecar.v1.rewards.Rewards/ListDistributionRoots | jq '.distributionRoots[0]'
+
+# curl
+curl -s http://localhost:7101/rewards/v1/distribution-roots
+
+
+{
+  "root": "0x2888a89a97b1d022688ef24bc2dd731ff5871465339a067874143629d92c9e49",
+  "rootIndex": "217",
+  "rewardsCalculationEnd": "2025-02-22T00:00:00Z",
+  "rewardsCalculationEndUnit": "snapshot",
+  "activatedAt": "2025-02-24T19:00:48Z",
+  "activatedAtUnit": "timestamp",
+  "createdAtBlockNumber": "3418350",
+  "transactionHash": "0x769b4efbefb99c6c80738405ae5d082829d8e2e6f97ee20da615fa7073c16d90",
+  "blockHeight": "3418350",
+  "logIndex": "544"
+}
+```
+
+## Fetching Rewards Data
+
+```bash
+
+```

--- a/examples/rewardsData/main.go
+++ b/examples/rewardsData/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/rewards"
+	"github.com/akuity/grpc-gateway-client/pkg/grpc/gateway"
+	"math"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"strings"
+)
+
+func NewGrpcSidecarClient(url string, insecureConn bool) (rewards.RewardsClient, error) {
+	var creds grpc.DialOption
+	if strings.Contains(url, "localhost:") || strings.Contains(url, "127.0.0.1:") || insecureConn {
+		creds = grpc.WithTransportCredentials(insecure.NewCredentials())
+	} else {
+		creds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: false}))
+	}
+
+	opts := []grpc.DialOption{
+		creds,
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+	}
+
+	grpcClient, err := grpc.NewClient(url, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return rewards.NewRewardsClient(grpcClient), nil
+}
+
+func NewHttpSidecarClient(url string, opts ...gateway.ClientOption) rewards.RewardsGatewayClient {
+	return rewards.NewRewardsGatewayClient(gateway.NewClient(url, opts...))
+}
+
+func grpcExample() {
+	client, err := NewGrpcSidecarClient("localhost:7100", true)
+	if err != nil {
+		panic(err)
+	}
+
+	distributionRoots, err := client.ListDistributionRoots(context.Background(), &rewards.ListDistributionRootsRequest{})
+	if err != nil {
+		panic(err)
+	}
+
+	rewardsData, err := client.GetRewardsForDistributionRoot(context.Background(), &rewards.GetRewardsForDistributionRootRequest{
+		RootIndex: distributionRoots.DistributionRoots[0].RootIndex,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, reward := range rewardsData.Rewards {
+		println(reward.String())
+	}
+}
+
+func httpExample() {
+	client := NewHttpSidecarClient("http://localhost:7101")
+
+	distributionRoots, err := client.ListDistributionRoots(context.Background(), &rewards.ListDistributionRootsRequest{})
+	if err != nil {
+		panic(err)
+	}
+
+	rewardsData, err := client.GetRewardsForDistributionRoot(context.Background(), &rewards.GetRewardsForDistributionRootRequest{
+		RootIndex: distributionRoots.DistributionRoots[0].RootIndex,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, reward := range rewardsData.Rewards {
+		println(reward.String())
+	}
+}
+
+func main() {
+	grpcExample()
+	httpExample()
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.7.0
+	github.com/Layr-Labs/protocol-apis v1.8.0-rc.1.0.20250307144153-66f17fc07f9a
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/ethereum/go-ethereum v1.15.4
@@ -37,6 +37,7 @@ require (
 )
 
 require (
+	github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,9 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.8.0-rc.1.0.20250307144153-66f17fc07f9a
+	github.com/Layr-Labs/protocol-apis v1.8.0-rc.2
 	github.com/agiledragon/gomonkey/v2 v2.13.0
+	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/ethereum/go-ethereum v1.15.4
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
@@ -40,7 +41,6 @@ require (
 	github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
-	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89 // indirect
 	github.com/alevinval/sse v1.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,10 @@ github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-0
 github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQAPooM+8EVqv9w2bL4OytgY=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
-github.com/Layr-Labs/protocol-apis v1.7.0 h1:BYzfF0mLjil3VAq8EEnswJbOL9v0OqfL32TipUryZ2s=
-github.com/Layr-Labs/protocol-apis v1.7.0/go.mod h1:zCirDItAbrnEv1kV1RTccY7eVSg0+da4/dFCXHyLNZQ=
+github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab h1:O3mHv0TxACM+575aVjPRwPOd7Ygf4CAmZmNWs/2zjaA=
+github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab/go.mod h1:xc4NKuzjHpf6Xr9EnI7r6Uc99B1it1bkzQH6kJvhtW4=
+github.com/Layr-Labs/protocol-apis v1.8.0-rc.1.0.20250307144153-66f17fc07f9a h1:LyD80rLc/qJeqIeysWQ4zlvnMg7Mk3VW22qf1j6iX6c=
+github.com/Layr-Labs/protocol-apis v1.8.0-rc.1.0.20250307144153-66f17fc07f9a/go.mod h1:rseFsoIl5XDZNaAioipXlaf2F51Onu2tQhxac7glIrg=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQA
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
 github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab h1:O3mHv0TxACM+575aVjPRwPOd7Ygf4CAmZmNWs/2zjaA=
 github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab/go.mod h1:xc4NKuzjHpf6Xr9EnI7r6Uc99B1it1bkzQH6kJvhtW4=
-github.com/Layr-Labs/protocol-apis v1.8.0-rc.1.0.20250307144153-66f17fc07f9a h1:LyD80rLc/qJeqIeysWQ4zlvnMg7Mk3VW22qf1j6iX6c=
-github.com/Layr-Labs/protocol-apis v1.8.0-rc.1.0.20250307144153-66f17fc07f9a/go.mod h1:rseFsoIl5XDZNaAioipXlaf2F51Onu2tQhxac7glIrg=
+github.com/Layr-Labs/protocol-apis v1.8.0-rc.2 h1:I2XoyMQXr8KD+EFcN8Xss6IYAxT89NG1g84ufzJjo9c=
+github.com/Layr-Labs/protocol-apis v1.8.0-rc.2/go.mod h1:rseFsoIl5XDZNaAioipXlaf2F51Onu2tQhxac7glIrg=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/pkg/rpcServer/rewardsHandlers.go
+++ b/pkg/rpcServer/rewardsHandlers.go
@@ -239,6 +239,29 @@ func (rpc *RpcServer) GetRewardsForSnapshot(ctx context.Context, req *rewardsV1.
 	}, nil
 }
 
+func (rpc *RpcServer) GetRewardsForDistributionRoot(ctx context.Context, req *rewardsV1.GetRewardsForDistributionRootRequest) (*rewardsV1.GetRewardsForDistributionRootResponse, error) {
+	rootIndex := req.GetRootIndex()
+
+	snapshotRewards, err := rpc.rewardsDataService.GetRewardsForDistributionRoot(ctx, rootIndex)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	rewardsRes := make([]*rewardsV1.Reward, 0, len(snapshotRewards))
+
+	for _, reward := range snapshotRewards {
+		rewardsRes = append(rewardsRes, &rewardsV1.Reward{
+			Earner:   reward.Earner,
+			Amount:   reward.CumulativeAmount,
+			Snapshot: reward.Snapshot,
+			Token:    reward.Token,
+		})
+	}
+
+	return &rewardsV1.GetRewardsForDistributionRootResponse{
+		Rewards: rewardsRes,
+	}, nil
+}
+
 func (rpc *RpcServer) GetAttributableRewardsForSnapshot(ctx context.Context, req *rewardsV1.GetAttributableRewardsForSnapshotRequest) (*rewardsV1.GetAttributableRewardsForSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAttributableRewardsForSnapshot not implemented")
 }

--- a/pkg/rpcServer/server.go
+++ b/pkg/rpcServer/server.go
@@ -9,6 +9,7 @@ import (
 	protocolV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/protocol"
 	rewardsV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/rewards"
 	sidecarV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/sidecar"
+	slashingV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/slashing"
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/internal/metrics/metricsTypes"
@@ -42,6 +43,9 @@ type RpcServerConfig struct {
 }
 
 type RpcServer struct {
+	rewardsV1.UnimplementedRewardsServer
+	slashingV1.UnimplementedSlashingServer
+	protocolV1.UnimplementedProtocolServer
 	Logger              *zap.Logger
 	rpcConfig           *RpcServerConfig
 	blockStore          storage.BlockStore

--- a/pkg/service/rewardsDataService/rewards.go
+++ b/pkg/service/rewardsDataService/rewards.go
@@ -52,6 +52,17 @@ func (rds *RewardsDataService) GetRewardsForSnapshot(ctx context.Context, snapsh
 	return rds.rewardsCalculator.FetchRewardsForSnapshot(snapshot)
 }
 
+func (rds *RewardsDataService) GetRewardsForDistributionRoot(ctx context.Context, rootIndex uint64) ([]*rewardsTypes.Reward, error) {
+	root, err := rds.getDistributionRootByRootIndex(rootIndex)
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		return nil, fmt.Errorf("no distribution root found for root index '%d'", rootIndex)
+	}
+	return rds.rewardsCalculator.FetchRewardsForSnapshot(root.GetSnapshotDate())
+}
+
 type TotalClaimedReward struct {
 	Earner string
 	Token  string


### PR DESCRIPTION
## Description

* Add `GetRewardsForDistributionRoot` to get rewards data for a specific distribution root
* Add an example of using the grpc and http clients
* Update docs

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Docs (documentation updates)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
