### PR TITLE
fix: staker amount refund to AVS in operatorDirectedOperatorSet reward submissions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -470,11 +470,7 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				BlockNumber: 0,
 			},
 			RewardsFork_Colorado: Fork{
-<<<<<<< HEAD
-				Date:        "2025-03-27",
-=======
 				Date:        "2025-04-10",
->>>>>>> 32255d6 (feat: colorado hard fork)
 				BlockNumber: 0, // TODO(seanmcgary): set this before slashing mainnet launch
 			},
 		}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -459,18 +459,22 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				Date: "2025-01-21",
 			},
 			RewardsFork_Mississippi: Fork{
-				Date: "2025-03-27",
+				Date: "2025-04-10",
 				// mississippi fork on mainnet doesnt have a fork date since we didnt need to backfill
 				// any data for it like we did for preprod and holesky
 				BlockNumber: 0,
 			},
 			RewardsFork_Brazos: Fork{
-				Date: "2025-03-27",
+				Date: "2025-04-10",
 				// brazos fork on mainnet doesnt have a fork date since we didnt need to backfill slashing events
 				BlockNumber: 0,
 			},
 			RewardsFork_Colorado: Fork{
+<<<<<<< HEAD
 				Date:        "2025-03-27",
+=======
+				Date:        "2025-04-10",
+>>>>>>> 32255d6 (feat: colorado hard fork)
 				BlockNumber: 0, // TODO(seanmcgary): set this before slashing mainnet launch
 			},
 		}, nil

--- a/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
@@ -9,7 +9,7 @@ const _14_goldAvsODOperatorSetRewardAmountsQuery = `
 CREATE TABLE {{.destTableName}} AS
 
 -- Step 1: Get the rows where operators have not registered for the AVS or if the AVS does not exist
-WITH reward_snapshot_operators AS (
+WITH not_registered_operators AS (
     SELECT
         ap.reward_hash,
         ap.snapshot AS snapshot,
@@ -28,7 +28,7 @@ WITH reward_snapshot_operators AS (
 
 -- Step 2: Dedupe the operator tokens across strategies for each (operator, reward hash, snapshot)
 -- Since the above result is a flattened operator-directed reward submission across strategies
-distinct_operators AS (
+distinct_not_registered_operators AS (
     SELECT *
     FROM (
         SELECT 
@@ -39,7 +39,7 @@ distinct_operators AS (
                 PARTITION BY reward_hash, snapshot, operator 
                 ORDER BY strategy ASC
             ) AS rn
-        FROM reward_snapshot_operators
+        FROM not_registered_operators
     ) t
     WHERE rn = 1
 ),
@@ -55,11 +55,107 @@ operator_token_sums AS (
         operator_set_id,
         operator,
         SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
-    FROM distinct_operators
+    FROM distinct_not_registered_operators
+),
+
+-- Step 4: Find rows where operators are registered but strategies are not registered for the operator set
+-- First, get all rows where operators are registered
+registered_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs,
+        ap.operator_set_id,
+        ap.operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    WHERE ap.num_registered_snapshots != 0
+),
+
+-- Step 5: For each reward/snapshot/operator_set, check if any strategies are registered
+strategies_registered AS (
+    SELECT DISTINCT
+        ro.reward_hash,
+        ro.snapshot,
+        ro.avs,
+        ro.operator_set_id
+    FROM registered_operators ro
+    JOIN operator_set_strategy_registration_snapshots ossr
+        ON ro.avs = ossr.avs
+        AND ro.operator_set_id = ossr.operator_set_id
+        AND ro.snapshot = ossr.snapshot
+        AND ro.strategy = ossr.strategy
+),
+
+-- Step 6: Find reward/snapshot combinations where operators registered but no strategies registered
+strategies_not_registered AS (
+    SELECT 
+        ro.*
+    FROM registered_operators ro
+    LEFT JOIN strategies_registered sr
+        ON ro.reward_hash = sr.reward_hash
+        AND ro.snapshot = sr.snapshot
+        AND ro.avs = sr.avs
+        AND ro.operator_set_id = sr.operator_set_id
+    WHERE sr.reward_hash IS NULL
+),
+
+-- Step 7: Calculate the staker split for each reward with dynamic split logic
+-- If no split is found, default to 1000 (10%)
+staker_splits AS (
+    SELECT 
+        snr.*,
+        snr.tokens_per_registered_snapshot_decimal - FLOOR(snr.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS staker_split
+    FROM strategies_not_registered snr
+    LEFT JOIN operator_set_split_snapshots oss
+        ON snr.operator = oss.operator 
+        AND snr.avs = oss.avs 
+        AND snr.operator_set_id = oss.operator_set_id
+        AND snr.snapshot = oss.snapshot
+    LEFT JOIN default_operator_split_snapshots dos ON (snr.snapshot = dos.snapshot)
+),
+
+-- Step 8: Dedupe the staker splits across operators and strategies
+distinct_staker_splits AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM staker_splits
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 9: Sum the staker tokens for each (reward hash, snapshot) that should be refunded
+staker_token_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(staker_split) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_staker_splits
+),
+
+-- Step 10: Combine both refund cases into one result
+combined_refund_amounts AS (
+    SELECT * FROM operator_token_sums
+    UNION ALL
+    SELECT * FROM staker_token_sums
 )
 
--- Step 4: Output the final table
-SELECT * FROM operator_token_sums
+-- Output the final table
+SELECT * FROM combined_refund_amounts
 `
 
 func (rc *RewardsCalculator) GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate string) error {

--- a/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
@@ -49,7 +49,7 @@ distinct_not_registered_operators AS (
 
 -- Step 3: Sum the operator tokens for each (reward hash, snapshot)
 -- Since we want to refund the sum of those operator amounts to the AVS in that reward submission for that snapshot
-operator_token_sums AS (
+avs_operator_refund_sums AS (
     SELECT
         reward_hash,
         snapshot,
@@ -140,7 +140,7 @@ distinct_staker_splits AS (
 ),
 
 -- Step 9: Sum the staker tokens for each (reward hash, snapshot) that should be refunded
-staker_token_sums AS (
+avs_staker_refund_sums AS (
     SELECT
         reward_hash,
         snapshot,
@@ -153,14 +153,14 @@ staker_token_sums AS (
 ),
 
 -- Step 10: Combine both refund cases into one result
-combined_refund_amounts AS (
-    SELECT * FROM operator_token_sums
+combined_avs_refund_amounts AS (
+    SELECT * FROM avs_operator_refund_sums
     UNION ALL
-    SELECT * FROM staker_token_sums
+    SELECT * FROM avs_staker_refund_sums
 )
 
 -- Output the final table
-SELECT * FROM combined_refund_amounts
+SELECT * FROM combined_avs_refund_amounts
 `
 
 func (rc *RewardsCalculator) GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate string, forks config.ForkMap) error {

--- a/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
@@ -119,7 +119,8 @@ staker_splits AS (
     LEFT JOIN default_operator_split_snapshots dos ON (snr.snapshot = dos.snapshot)
 ),
 
--- Step 8: Dedupe the staker splits across operators and strategies
+-- Step 8: Dedupe the staker splits across across strategies for each (operator, reward hash, snapshot)
+-- Since the above result is a flattened operator-directed reward submission across strategies.
 distinct_staker_splits AS (
     SELECT *
     FROM (

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -4,10 +4,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/internal/metrics/metricsTypes"
 	"github.com/Layr-Labs/sidecar/pkg/rewards/rewardsTypes"
-	"time"
 
 	"sync/atomic"
 
@@ -745,7 +746,7 @@ func (rc *RewardsCalculator) generateGoldTables(snapshotDate string) error {
 		return err
 	}
 
-	if err := rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate); err != nil {
+	if err := rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate, forks); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate avs od operator set rewards", "error", err)
 		return err
 	}

--- a/pkg/rewards/rewardsV2_1_test.go
+++ b/pkg/rewards/rewardsV2_1_test.go
@@ -243,7 +243,7 @@ func Test_RewardsV2_1(t *testing.T) {
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_14_avs_od_operator_set_rewards\n")
-			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate)
+			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate, forks)
 			assert.Nil(t, err)
 			if rewardsV2_1Enabled {
 				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts])

--- a/pkg/rewards/rewardsV2_test.go
+++ b/pkg/rewards/rewardsV2_test.go
@@ -230,7 +230,7 @@ func Test_RewardsV2(t *testing.T) {
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_14_avs_od_operator_set_rewards\n")
-			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate)
+			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate, forks)
 			assert.Nil(t, err)
 			if rewardsV2_1Enabled {
 				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts])

--- a/pkg/rewards/rewards_test.go
+++ b/pkg/rewards/rewards_test.go
@@ -3,12 +3,13 @@ package rewards
 import (
 	"errors"
 	"fmt"
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Layr-Labs/sidecar/internal/metrics"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
@@ -386,7 +387,7 @@ func Test_Rewards(t *testing.T) {
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_14_avs_od_operator_set_rewards\n")
-			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate)
+			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate, forks)
 			assert.Nil(t, err)
 			if rewardsV2_1Enabled {
 				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts])


### PR DESCRIPTION
## Description

This PR addresses `Unallocated Staker Rewards Due to Late Strategy Registration to Operator Set` issue brought up by OpenBlock during the Rewards v2.1 audit.

The TL;DR is that staker funds will be locked in the RewardsCoordinator for a given snapshot if there is an OperatorDirectedOpeatorSet reward submission where none of the specified strategies are registered to the operator set. 

In such a case, we need to refund the staker funds back to the AVS for that specific snapshot.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Re-ran existing Rewards v2.1 test suite.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
