### PR TITLE
perf: improve RPC performance by using eth_getBlockReceipts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ Please delete options that are not relevant.
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Chore (non-breaking change which does not add functionality)
 - [ ] Docs (documentation updates)
+- [ ] Performance improvement
 
 ## How Has This Been Tested?
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool(config.EthereumRpcUseNativeBatchCall, true, `Use the native eth_call method for batch calls`)
 	rootCmd.PersistentFlags().Int(config.EthereumRpcNativeBatchCallSize, 500, `The number of calls to batch together when using the native eth_call method`)
 	rootCmd.PersistentFlags().Int(config.EthereumRpcChunkedBatchCallSize, 10, `The number of calls to make in parallel when using the chunked batch call method`)
+	rootCmd.PersistentFlags().Bool(config.EthereumUseGetBlockReceipts, false, `Use the eth_getBlockReceipts method to fetch transaction receipts. Requires geth, erigon or other compatible node`)
 
 	rootCmd.PersistentFlags().String(config.DatabaseHost, "localhost", `PostgreSQL host`)
 	rootCmd.PersistentFlags().Int(config.DatabasePort, 5432, `PostgreSQL port`)

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,7 +7,7 @@ module.exports = {
 		'type-enum': [
 			2,
 			'always',
-			['feat', 'fix', 'docs', 'style', 'refactor', 'test', 'chore', 'revert']
+			['feat', 'fix', 'docs', 'style', 'refactor', 'test', 'chore', 'revert', 'perf']
 		],
 		'footer-max-line-length': [2, 'always', Infinity],
 		'footer-leading-blank': [0]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ type EthereumRpcConfig struct {
 	UseNativeBatchCall    bool // Use the native eth_call method for batch calls
 	NativeBatchCallSize   int  // Number of calls to put in a single eth_call request
 	ChunkedBatchCallSize  int  // Number of calls to make in parallel
+	UseGetBlockReceipts   bool // Use eth_getBlockReceipts instead of fetching receipts for each tx individually. Requires geth, erigon or other compatible client.
 }
 
 type DatabaseConfig struct {
@@ -189,6 +190,7 @@ var (
 	EthereumRpcUseNativeBatchCall    = "ethereum.use_native_batch_call"
 	EthereumRpcNativeBatchCallSize   = "ethereum.native_batch_call_size"
 	EthereumRpcChunkedBatchCallSize  = "ethereum.chunked_batch_call_size"
+	EthereumUseGetBlockReceipts      = "ethereum.use-get-block-receipts"
 
 	DataDogStatsdEnabled    = "datadog.statsd.enabled"
 	DataDogStatsdUrl        = "datadog.statsd.url"
@@ -215,6 +217,7 @@ func NewConfig() *Config {
 			UseNativeBatchCall:    viper.GetBool(normalizeFlagName(EthereumRpcUseNativeBatchCall)),
 			NativeBatchCallSize:   viper.GetInt(normalizeFlagName(EthereumRpcNativeBatchCallSize)),
 			ChunkedBatchCallSize:  viper.GetInt(normalizeFlagName(EthereumRpcChunkedBatchCallSize)),
+			UseGetBlockReceipts:   viper.GetBool(normalizeFlagName(EthereumUseGetBlockReceipts)),
 		},
 
 		DatabaseConfig: DatabaseConfig{

--- a/pkg/clients/ethereum/client.go
+++ b/pkg/clients/ethereum/client.go
@@ -230,6 +230,7 @@ func (c *Client) GetTransactionByHash(ctx context.Context, txHash string) (*Ethe
 	return txReceipt, nil
 }
 
+// GetTransactionReceipt retrieves the transaction receipt for a given transaction hash.
 func (c *Client) GetTransactionReceipt(ctx context.Context, txHash string) (*EthereumTransactionReceipt, error) {
 	rpcRequest := GetTransactionReceiptRequest(txHash, 1)
 
@@ -246,6 +247,24 @@ func (c *Client) GetTransactionReceipt(ctx context.Context, txHash string) (*Eth
 		return nil, err
 	}
 	return txReceipt, nil
+}
+
+// GetBlockTransactionReceipts retrieves the transaction receipts for a given block number.
+func (c *Client) GetBlockTransactionReceipts(ctx context.Context, blockNumber uint64) ([]*EthereumTransactionReceipt, error) {
+	rpcRequest := GetBlockReceiptsRequest(blockNumber, 1)
+
+	res, err := c.Call(ctx, rpcRequest)
+	if err != nil {
+		return nil, err
+	}
+	txReceipts, err := RPCMethod_getBlockReceipts.ResponseParser(res.Result)
+	if err != nil {
+		c.Logger.Sugar().Errorw("failed to parse transaction receipts",
+			zap.Error(err),
+		)
+		return nil, err
+	}
+	return txReceipts, nil
 }
 
 func (c *Client) GetStorageAt(ctx context.Context, address string, storagePosition string, block string) (string, error) {

--- a/pkg/clients/ethereum/client_test.go
+++ b/pkg/clients/ethereum/client_test.go
@@ -1,0 +1,25 @@
+package ethereum
+
+import (
+	"context"
+	"github.com/Layr-Labs/sidecar/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_EthereumClient(t *testing.T) {
+	l, err := logger.NewLogger(&logger.LoggerConfig{
+		Debug: false,
+	})
+	assert.Nil(t, err)
+
+	client := NewClient(&EthereumClientConfig{
+		BaseUrl: "http://72.46.85.253:8545",
+	}, l)
+
+	t.Run("eth_getBlockReceipts", func(t *testing.T) {
+		receipts, err := client.GetBlockTransactionReceipts(context.Background(), uint64(22019077))
+		assert.Nil(t, err)
+		assert.NotNil(t, receipts)
+	})
+}

--- a/pkg/clients/ethereum/handlers.go
+++ b/pkg/clients/ethereum/handlers.go
@@ -87,6 +87,20 @@ var (
 			return strings.ReplaceAll(string(res), "\"", ""), nil
 		},
 	}
+	RPCMethod_getBlockReceipts = &RequestResponseHandler[[]*EthereumTransactionReceipt]{
+		RequestMethod: &RequestMethod{
+			Name:    "eth_getBlockReceipts",
+			Timeout: time.Second * 5,
+		},
+		ResponseParser: func(res json.RawMessage) ([]*EthereumTransactionReceipt, error) {
+			receipts := []*EthereumTransactionReceipt{}
+
+			if err := json.Unmarshal(res, &receipts); err != nil {
+				return nil, err
+			}
+			return receipts, nil
+		},
+	}
 )
 
 func GetBlockRequest(id uint) *RPCRequest {
@@ -158,6 +172,16 @@ func GetCodeRequest(address string, id uint) *RPCRequest {
 		JSONRPC: jsonRPCVersion,
 		Method:  RPCMethod_getCode.RequestMethod.Name,
 		Params:  []interface{}{address, "latest"},
+		ID:      id,
+	}
+}
+
+func GetBlockReceiptsRequest(blockNumber uint64, id uint) *RPCRequest {
+	hexBlockNumber := hexutil.EncodeUint64(blockNumber)
+	return &RPCRequest{
+		JSONRPC: jsonRPCVersion,
+		Method:  RPCMethod_getBlockReceipts.RequestMethod.Name,
+		Params:  []interface{}{hexBlockNumber},
 		ID:      id,
 	}
 }

--- a/pkg/clients/ethereum/types.go
+++ b/pkg/clients/ethereum/types.go
@@ -87,30 +87,21 @@ type (
 	}
 
 	EthereumTransactionReceipt struct {
-		TransactionHash   EthereumHexString    `json:"transactionHash"`
-		TransactionIndex  EthereumQuantity     `json:"transactionIndex"`
-		BlockHash         EthereumHexString    `json:"blockHash"`
-		BlockNumber       EthereumQuantity     `json:"blockNumber"`
-		From              EthereumHexString    `json:"from"`
-		To                EthereumHexString    `json:"to"`
-		CumulativeGasUsed EthereumQuantity     `json:"cumulativeGasUsed"`
-		GasUsed           EthereumQuantity     `json:"gasUsed"`
-		ContractAddress   EthereumHexString    `json:"contractAddress"`
-		Logs              []*EthereumEventLog  `json:"logs"`
-		LogsBloom         EthereumHexString    `json:"logsBloom"`
-		Root              EthereumHexString    `json:"root"`
-		Status            *EthereumQuantity    `json:"status"`
-		Type              EthereumQuantity     `json:"type"`
-		EffectiveGasPrice *EthereumQuantity    `json:"effectiveGasPrice"`
-		GasUsedForL1      *EthereumQuantity    `json:"gasUsedForL1"` // For Arbitrum network https://github.com/OffchainLabs/arbitrum/blob/6ca0d163417470b9d2f7eea930c3ad71d702c0b2/packages/arb-evm/evm/result.go#L336
-		L1GasUsed         *EthereumBigQuantity `json:"l1GasUsed"`    // For Optimism and Base networks https://github.com/ethereum-optimism/optimism/blob/3c3e1a88b234a68bcd59be0c123d9f3cc152a91e/l2geth/core/types/receipt.go#L73
-		L1GasPrice        *EthereumBigQuantity `json:"l1GasPrice"`
-		L1Fee             *EthereumBigQuantity `json:"l1Fee"`
-		L1FeeScaler       *EthereumBigFloat    `json:"l1FeeScalar"`
-
-		// Base/Optimism specific fields.
-		DepositNonce          *EthereumQuantity `json:"depositNonce"`
-		DepositReceiptVersion *EthereumQuantity `json:"depositReceiptVersion"`
+		TransactionHash   EthereumHexString   `json:"transactionHash"`
+		TransactionIndex  EthereumQuantity    `json:"transactionIndex"`
+		BlockHash         EthereumHexString   `json:"blockHash"`
+		BlockNumber       EthereumQuantity    `json:"blockNumber"`
+		From              EthereumHexString   `json:"from"`
+		To                EthereumHexString   `json:"to"`
+		CumulativeGasUsed EthereumQuantity    `json:"cumulativeGasUsed"`
+		GasUsed           EthereumQuantity    `json:"gasUsed"`
+		ContractAddress   EthereumHexString   `json:"contractAddress"`
+		Logs              []*EthereumEventLog `json:"logs"`
+		LogsBloom         EthereumHexString   `json:"logsBloom"`
+		Root              EthereumHexString   `json:"root"`
+		Status            *EthereumQuantity   `json:"status"`
+		Type              EthereumQuantity    `json:"type"`
+		EffectiveGasPrice *EthereumQuantity   `json:"effectiveGasPrice"`
 
 		// Not part of the standard receipt payload, but added for convenience
 		ContractBytecode EthereumHexString `json:"contractBytecode"`

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -52,7 +52,7 @@ func (f *Fetcher) FetchBlock(ctx context.Context, blockNumber uint64) (*FetchedB
 		return nil, err
 	}
 
-	receipts, err := f.FetchReceiptsForBlock(ctx, block)
+	receipts, err := f.FetchBlockReceipts(ctx, block)
 	if err != nil {
 		f.Logger.Sugar().Errorw("failed to fetch receipts for block", zap.Error(err))
 		return nil, err
@@ -114,6 +114,66 @@ func (f *Fetcher) FetchReceiptsForBlock(ctx context.Context, block *ethereum.Eth
 		receipts[r.TransactionHash.Value()] = r
 	}
 	return receipts, nil
+}
+
+func findMissingReceipts(block *ethereum.EthereumBlock, receipts []*ethereum.EthereumTransactionReceipt) []string {
+	missingReceipts := make([]string, 0)
+	memoizedExpectedReceipts := make(map[string]bool)
+	memoizedReceivedReceipts := make(map[string]bool)
+
+	for _, receipt := range receipts {
+		memoizedReceivedReceipts[receipt.TransactionHash.Value()] = true
+	}
+
+	for _, tx := range block.Transactions {
+		memoizedExpectedReceipts[tx.Hash.Value()] = true
+	}
+
+	// find receipts that were received but not expected
+	for _, receipt := range receipts {
+		if _, ok := memoizedExpectedReceipts[receipt.TransactionHash.Value()]; !ok {
+			missingReceipts = append(missingReceipts, receipt.TransactionHash.Value())
+		}
+	}
+
+	// find receipts that were expected but not received
+	for _, tx := range block.Transactions {
+		if _, ok := memoizedReceivedReceipts[tx.Hash.Value()]; !ok {
+			missingReceipts = append(missingReceipts, tx.Hash.Value())
+		}
+	}
+	return missingReceipts
+}
+
+// FetchBlockReceipts retrieves transaction receipts for all transactions in a block using the eth_getBlockReceipts RPC method
+// rather than iterating over a list of transactions and fetching each receipt individually.
+func (f *Fetcher) FetchBlockReceipts(ctx context.Context, block *ethereum.EthereumBlock) (map[string]*ethereum.EthereumTransactionReceipt, error) {
+	receipts, err := f.EthClient.GetBlockTransactionReceipts(ctx, block.Number.Value())
+	if err != nil {
+		f.Logger.Sugar().Errorw("failed to get block receipts", zap.Error(err))
+		return nil, err
+	}
+
+	if len(receipts) != len(block.Transactions) {
+		f.Logger.Sugar().Errorw("failed to fetch all transaction receipts",
+			zap.Int("fetched", len(receipts)),
+			zap.Int("expected", len(block.Transactions)),
+		)
+
+		missing := findMissingReceipts(block, receipts)
+		f.Logger.Sugar().Errorw("missing receipts",
+			zap.Int("count", len(missing)),
+			zap.Strings("missing", missing),
+		)
+
+		return nil, errors.New("failed to fetch all transaction receipts")
+	}
+
+	receiptsMap := make(map[string]*ethereum.EthereumTransactionReceipt)
+	for _, r := range receipts {
+		receiptsMap[r.TransactionHash.Value()] = r
+	}
+	return receiptsMap, nil
 }
 
 // IsInterestingAddress checks if a contract address is in the list of interesting addresses
@@ -217,7 +277,7 @@ func (f *Fetcher) FetchBlocks(ctx context.Context, startBlockInclusive uint64, e
 		wg.Add(1)
 		go func(b *ethereum.EthereumBlock) {
 			defer wg.Done()
-			receipts, err := f.FetchReceiptsForBlock(ctx, b)
+			receipts, err := f.FetchBlockReceipts(ctx, b)
 			if err != nil {
 				f.Logger.Sugar().Errorw("failed to fetch receipts for block",
 					zap.Uint64("blockNumber", b.Number.Value()),


### PR DESCRIPTION
## Description

Currently when fetching transaction receipts when fetching blocks, we make _n_ many requests (one per transaction). Moving to `eth_getBlockReceipts` cuts this down to 1 request for ALL receipts in the block and improves block fetching by roughly 30%.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Performance improvement

## How Has This Been Tested?

Manual testing, added more unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
