### PR TITLE
fix: remove unnecessary join condition

### DIFF
--- a/pkg/service/protocolDataService/protocol.go
+++ b/pkg/service/protocolDataService/protocol.go
@@ -110,7 +110,6 @@ func (pds *ProtocolDataService) ListDelegatedStrategiesForOperator(ctx context.C
 			from operator_stakers as os
 			left join staker_share_deltas as ssd
 					on ssd.staker = os.staker
-					and ssd.block_number <= os.block_number
 			where
 				os.delegated = true
 		),


### PR DESCRIPTION
## Description

Join condition when querying for staker_delegation_changes had an extra condition that lead to certain rows being excluded.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
