### PR TITLE
fix: operator registration in avs refund

### DIFF
--- a/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/14_goldAvsODOperatorSetRewardAmounts.go
@@ -76,6 +76,11 @@ registered_operators AS (
         ap.multiplier,
         ap.reward_submission_date
     FROM {{.activeODRewardsTable}} ap
+    JOIN operator_set_operator_registration_snapshots osor
+        ON ap.avs = osor.avs 
+        AND ap.operator_set_id = osor.operator_set_id
+        AND ap.snapshot = osor.snapshot 
+        AND ap.operator = osor.operator
     WHERE ap.num_registered_snapshots != 0
       AND ap.reward_submission_date >= @coloradoHardforkDate
 ),


### PR DESCRIPTION
## Description

Openblock found the following issue:

The `registered_operators` CTE fails to properly identify snapshots where operators were actually registered. The condition `num_registered_snapshots != 0` does not guarantee that an operator was registered for that specific snapshot.

Fix: 

In the registered_operators CTE, join the `activeODRewardsTable` with the `operator_set_operator_registration_snapshots` table to ensure that only snapshots where operators were registered are included.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Re-ran Reward v2.1 test suite.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
