### PR TITLE
fix: simplify getTotalDelegatedOperatorSharesForStrategy query

### DIFF
--- a/pkg/service/protocolDataService/protocol_test.go
+++ b/pkg/service/protocolDataService/protocol_test.go
@@ -85,6 +85,9 @@ func Test_ProtocolDataService(t *testing.T) {
 		stake, err := pds.GetOperatorDelegatedStake(context.Background(), operator, strategy, blockNumber)
 		assert.Nil(t, err)
 		assert.NotNil(t, stake)
+		assert.Equal(t, stake.Shares, "999960761744418521836")
+		assert.Equal(t, stake.AvsAddresses[0], "0xd9b1da8159cf83ccc55ad5757bea33e6f0ce34be")
+
 	})
 
 	t.Run("Test ListDelegatedStakersForOperator", func(t *testing.T) {


### PR DESCRIPTION
## Description

`getTotalDelegatedOperatorSharesForStrategy` was not correctly returning the total shares for a delegated operator strategy. This PR simplifies the query to make it more legible and work properly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
