### PR TITLE
feat: prune to pectra block now that holesky is stable

### DIFF
--- a/pkg/postgres/migrations/202503130907_pectraPrunePartTwo/up.go
+++ b/pkg/postgres/migrations/202503130907_pectraPrunePartTwo/up.go
@@ -1,0 +1,23 @@
+package _202503130907_pectraPrunePartTwo
+
+import (
+	"database/sql"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	if cfg.Chain != config.Chain_Holesky {
+		return nil
+	}
+
+	res := grm.Exec(`delete from state_roots where eth_block_number > 3419700`)
+	return res.Error
+}
+
+func (m *Migration) GetName() string {
+	return "202503130907_pectraPrunePartTwo"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	_202503061009_pectraPrune "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503061009_pectraPrune"
 	_202503061223_renameConstraint "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503061223_renameConstraint"
+	_202503130907_pectraPrunePartTwo "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503130907_pectraPrunePartTwo"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"time"
@@ -202,6 +203,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202502252204_slashingModels.Migration{},
 		&_202503061009_pectraPrune.Migration{},
 		&_202503061223_renameConstraint.Migration{},
+		&_202503130907_pectraPrunePartTwo.Migration{},
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Description

Now that holesky is finalizing blocks, we can again prune back to a block before the pectra upgrade and sync back to the tip of the chain.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
