### PR TITLE
chore: set WriteTimeout to handle long-running requests/responses

### DIFF
--- a/pkg/rpcServer/server.go
+++ b/pkg/rpcServer/server.go
@@ -353,6 +353,7 @@ func (s *RpcServer) Start(ctx context.Context, shutdown chan bool) error {
 			ctx = context.WithValue(ctx, "httpServer", listener.Addr().String())
 			return ctx
 		},
+		WriteTimeout: time.Second * 300,
 	}
 
 	s.Logger.Sugar().Infow("Starting servers...",


### PR DESCRIPTION
## Description

Set the `WriteTimeout` to 300 seconds to accomadate requesting data from routes that take a while to process, or are returning large amounts of data

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
