### PR TITLE
refactor: improve snapshot generation performance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: protocol-gha-runners
     services:
       postgres:
         image: postgres:15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
       - name: Run linter
         run: |
           make deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: protocol-gha-runners
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:15

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.14.1-0.20250523180146-9ebe4230a014
+	github.com/Layr-Labs/protocol-apis v1.15.0
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89
@@ -50,7 +50,7 @@ require (
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
-	github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab // indirect
+	github.com/Layr-Labs/protobuf-libs v0.1.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/alevinval/sse v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,7 @@ github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQA
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
 github.com/Layr-Labs/protobuf-libs v0.1.0 h1:hfawlutriLq1i7cI2kXH8o2N+mx02cJTVlKrwAMazBY=
 github.com/Layr-Labs/protobuf-libs v0.1.0/go.mod h1:Om3Qb39NrWwald+08yTIj/VexKmocIMsMXXIM/iRcW8=
-github.com/Layr-Labs/protocol-apis v1.15.0 h1:vRIbBBLLpKpiaZpnbvWRYdSyYA6xVnEwxDCRJzkTMqE=
+github.com/Layr-Labs/protocol-apis v1.15.0 h1:vwE62d3YjYzEfDRUVlCF0Nl5IqSXX0SwvmwBZ1o92xM=
 github.com/Layr-Labs/protocol-apis v1.15.0/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/go.sum
+++ b/go.sum
@@ -26,12 +26,10 @@ github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-0
 github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQAPooM+8EVqv9w2bL4OytgY=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
-github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab h1:O3mHv0TxACM+575aVjPRwPOd7Ygf4CAmZmNWs/2zjaA=
-github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab/go.mod h1:xc4NKuzjHpf6Xr9EnI7r6Uc99B1it1bkzQH6kJvhtW4=
-github.com/Layr-Labs/protocol-apis v1.13.2 h1:WKzw8B0wObbZ9TBb+SuzXsgz+IXIRO2LvNUEkTvtZ0c=
-github.com/Layr-Labs/protocol-apis v1.13.2/go.mod h1:tyzQDWHu4/dmBSRKNRXi65wLic3j5B+7YQ8lMQB08aM=
-github.com/Layr-Labs/protocol-apis v1.14.1-0.20250523180146-9ebe4230a014 h1:Fobe61GmMwq5LsGv4XGlNle28J1wM+kR6JSu8tEiAAk=
-github.com/Layr-Labs/protocol-apis v1.14.1-0.20250523180146-9ebe4230a014/go.mod h1:tyzQDWHu4/dmBSRKNRXi65wLic3j5B+7YQ8lMQB08aM=
+github.com/Layr-Labs/protobuf-libs v0.1.0 h1:hfawlutriLq1i7cI2kXH8o2N+mx02cJTVlKrwAMazBY=
+github.com/Layr-Labs/protobuf-libs v0.1.0/go.mod h1:Om3Qb39NrWwald+08yTIj/VexKmocIMsMXXIM/iRcW8=
+github.com/Layr-Labs/protocol-apis v1.15.0 h1:vRIbBBLLpKpiaZpnbvWRYdSyYA6xVnEwxDCRJzkTMqE=
+github.com/Layr-Labs/protocol-apis v1.15.0/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/pkg/postgres/migrations/202503181244_snapshotUniqueConstraintsPartTwo/up.go
+++ b/pkg/postgres/migrations/202503181244_snapshotUniqueConstraintsPartTwo/up.go
@@ -1,0 +1,40 @@
+package _202503181244_snapshotUniqueConstraintsPartTwo
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`truncate table operator_directed_operator_set_rewards cascade`,
+		`alter table operator_directed_operator_set_rewards add constraint uniq_operator_directed_operator_set_rewards unique (block_number, reward_hash, strategy_index, operator_index)`,
+
+		`truncate table operator_set_operator_registration_snapshots cascade`,
+		`alter table operator_set_operator_registration_snapshots add constraint uniq_operator_set_operator_registration_snapshots unique (avs, operator, operator_set_id, snapshot)`,
+
+		`truncate table operator_set_split_snapshots cascade`,
+		`alter table operator_set_split_snapshots add constraint uniq_operator_set_split_snapshots unique (operator, avs, operator_set_id, snapshot)`,
+
+		`truncate table operator_set_strategy_registration_snapshots cascade`,
+		`alter table operator_set_strategy_registration_snapshots add constraint uniq_operator_set_strategy_registration_snapshots unique (avs, operator_set_id, strategy, snapshot)`,
+	}
+
+	for _, query := range queries {
+		res := grm.Exec(query)
+		if res.Error != nil {
+			fmt.Printf("Error executing query: %s\n", query)
+			return res.Error
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202503181244_snapshotUniqueConstraintsPartTwo"
+}

--- a/pkg/postgres/migrations/202503181244_snapshotUniqueConstraintsPartTwo/up.go
+++ b/pkg/postgres/migrations/202503181244_snapshotUniqueConstraintsPartTwo/up.go
@@ -13,6 +13,7 @@ type Migration struct {
 func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 	queries := []string{
 		`truncate table operator_directed_operator_set_rewards cascade`,
+		`alter table operator_directed_operator_set_rewards alter column block_date type text`,
 		`alter table operator_directed_operator_set_rewards add constraint uniq_operator_directed_operator_set_rewards unique (block_number, reward_hash, strategy_index, operator_index)`,
 
 		`truncate table operator_set_operator_registration_snapshots cascade`,

--- a/pkg/postgres/migrations/202506172149_snapshotUniqueConstraintsPartTwo/up.go
+++ b/pkg/postgres/migrations/202506172149_snapshotUniqueConstraintsPartTwo/up.go
@@ -1,4 +1,4 @@
-package _202503181244_snapshotUniqueConstraintsPartTwo
+package _202506172149_snapshotUniqueConstraintsPartTwo
 
 import (
 	"database/sql"
@@ -37,5 +37,5 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 }
 
 func (m *Migration) GetName() string {
-	return "202503181244_snapshotUniqueConstraintsPartTwo"
+	return "202506172149_snapshotUniqueConstraintsPartTwo"
 }

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -3,6 +3,10 @@ package migrations
 import (
 	"database/sql"
 	"fmt"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"time"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	_202409061249_bootstrapDb "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202409061249_bootstrapDb"
 	_202409061250_eigenlayerStateTables "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202409061250_eigenlayerStateTables"
@@ -68,12 +72,10 @@ import (
 	_202503061223_renameConstraint "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503061223_renameConstraint"
 	_202503130907_pectraPrunePartTwo "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503130907_pectraPrunePartTwo"
 	_202503171414_slashingWithdrawals "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503171414_slashingWithdrawals"
+	_202503181244_snapshotUniqueConstraintsPartTwo "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503181244_snapshotUniqueConstraintsPartTwo"
 	_202503311108_goldRewardHashIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503311108_goldRewardHashIndex"
 	_202504240743_fixQueuedSlashingWithdrawalsPk "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202504240743_fixQueuedSlashingWithdrawalsPk"
 	_202505092007_startupJobs "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202505092007_startupJobs"
-	"go.uber.org/zap"
-	"gorm.io/gorm"
-	"time"
 )
 
 // Migration interface defines the contract for database migrations.
@@ -213,6 +215,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202503171414_slashingWithdrawals.Migration{},
 		&_202504240743_fixQueuedSlashingWithdrawalsPk.Migration{},
 		&_202505092007_startupJobs.Migration{},
+		&_202503181244_snapshotUniqueConstraintsPartTwo.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -72,10 +72,10 @@ import (
 	_202503061223_renameConstraint "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503061223_renameConstraint"
 	_202503130907_pectraPrunePartTwo "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503130907_pectraPrunePartTwo"
 	_202503171414_slashingWithdrawals "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503171414_slashingWithdrawals"
-	_202503181244_snapshotUniqueConstraintsPartTwo "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503181244_snapshotUniqueConstraintsPartTwo"
 	_202503311108_goldRewardHashIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503311108_goldRewardHashIndex"
 	_202504240743_fixQueuedSlashingWithdrawalsPk "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202504240743_fixQueuedSlashingWithdrawalsPk"
 	_202505092007_startupJobs "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202505092007_startupJobs"
+	_202506172149_snapshotUniqueConstraintsPartTwo "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202506172149_snapshotUniqueConstraintsPartTwo"
 )
 
 // Migration interface defines the contract for database migrations.
@@ -215,7 +215,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202503171414_slashingWithdrawals.Migration{},
 		&_202504240743_fixQueuedSlashingWithdrawalsPk.Migration{},
 		&_202505092007_startupJobs.Migration{},
-		&_202503181244_snapshotUniqueConstraintsPartTwo.Migration{},
+		&_202506172149_snapshotUniqueConstraintsPartTwo.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/rewards/operatorDirectedOperatorSetRewards.go
+++ b/pkg/rewards/operatorDirectedOperatorSetRewards.go
@@ -1,8 +1,12 @@
 package rewards
 
-import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
 
 const operatorDirectedOperatorSetRewardsQuery = `
+insert into operator_directed_operator_set_rewards (avs, operator_set_id, reward_hash, token, operator, operator_index, amount, strategy, strategy_index, multiplier, start_timestamp, end_timestamp, duration, block_number, block_time, block_date)
 SELECT
 	odosrs.avs,
 	odosrs.operator_set_id,
@@ -23,23 +27,25 @@ SELECT
 FROM operator_directed_operator_set_reward_submissions AS odosrs
 JOIN blocks AS b ON (b.number = odosrs.block_number)
 WHERE b.block_time < TIMESTAMP '{{.cutoffDate}}'
+on conflict on constraint uniq_operator_directed_operator_set_rewards do nothing;
 `
 
 func (r *RewardsCalculator) GenerateAndInsertOperatorDirectedOperatorSetRewards(snapshotDate string) error {
-	tableName := "operator_directed_operator_set_rewards"
-
 	query, err := rewardsUtils.RenderQueryTemplate(operatorDirectedOperatorSetRewardsQuery, map[string]interface{}{
 		"cutoffDate": snapshotDate,
 	})
 	if err != nil {
-		r.logger.Sugar().Errorw("Failed to render rewards combined query", "error", err)
+		r.logger.Sugar().Errorw("Failed to render operator_directed_operator_set_rewards query", "error", err)
 		return err
 	}
 
-	err = r.generateAndInsertFromQuery(tableName, query, nil)
-	if err != nil {
-		r.logger.Sugar().Errorw("Failed to generate combined rewards", "error", err)
-		return err
+	res := r.grm.Exec(query)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_directed_operator_set_rewards",
+			zap.Error(res.Error),
+			zap.String("snapshotDate", snapshotDate),
+		)
+		return res.Error
 	}
 	return nil
 }

--- a/pkg/rewards/operatorSetOperatorRegistrationSnapshots.go
+++ b/pkg/rewards/operatorSetOperatorRegistrationSnapshots.go
@@ -121,7 +121,7 @@ func (r *RewardsCalculator) GenerateAndInsertOperatorSetOperatorRegistrationSnap
 	res := r.grm.Exec(query)
 	if res.Error != nil {
 		r.logger.Sugar().Errorw("Failed to generate operator_set_operator_registration_snapshots",
-			zap.Error(err),
+			zap.Error(res.Error),
 			zap.String("snapshotDate", snapshotDate),
 		)
 		return res.Error

--- a/pkg/rewards/operatorSetOperatorRegistrationSnapshots.go
+++ b/pkg/rewards/operatorSetOperatorRegistrationSnapshots.go
@@ -1,6 +1,9 @@
 package rewards
 
-import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
 
 // Operator Set Operator Registration Windows: Ranges at which an operator has registered for an operator set
 // 1. Marked_statuses: Denote which registration status comes after one another
@@ -17,6 +20,7 @@ import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
 // Entry        Exit
 // Since exits (deregistrations) are rounded down, we must only look at the day 2 snapshot on a pipeline run on day 3.
 const operatorSetOperatorRegistrationSnapshotsQuery = `
+insert into operator_set_operator_registration_snapshots (operator, avs, operator_set_id, snapshot)
 WITH state_changes as (
 	select
 		osor.*,
@@ -102,11 +106,10 @@ SELECT
 	d AS snapshot
 FROM cleaned_records
 CROSS JOIN generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS d
+on conflict on constraint uniq_operator_set_operator_registration_snapshots do nothing;
 `
 
 func (r *RewardsCalculator) GenerateAndInsertOperatorSetOperatorRegistrationSnapshots(snapshotDate string) error {
-	tableName := "operator_set_operator_registration_snapshots"
-
 	query, err := rewardsUtils.RenderQueryTemplate(operatorSetOperatorRegistrationSnapshotsQuery, map[string]interface{}{
 		"cutoffDate": snapshotDate,
 	})
@@ -115,10 +118,13 @@ func (r *RewardsCalculator) GenerateAndInsertOperatorSetOperatorRegistrationSnap
 		return err
 	}
 
-	err = r.generateAndInsertFromQuery(tableName, query, nil)
-	if err != nil {
-		r.logger.Sugar().Errorw("Failed to generate operator_set_operator_registration_snapshots", "error", err)
-		return err
+	res := r.grm.Exec(query)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_set_operator_registration_snapshots",
+			zap.Error(err),
+			zap.String("snapshotDate", snapshotDate),
+		)
+		return res.Error
 	}
 	return nil
 }

--- a/pkg/rewards/operatorSetSplitSnapshots.go
+++ b/pkg/rewards/operatorSetSplitSnapshots.go
@@ -1,8 +1,12 @@
 package rewards
 
-import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
 
 const operatorSetSplitSnapshotQuery = `
+insert into operator_set_split_snapshots (operator, avs, operator_set_id, split, snapshot)
 WITH operator_set_splits_with_block_info as (
 	select
 		oss.operator,
@@ -66,11 +70,10 @@ final_results as (
 		generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS d
 )
 select * from final_results
+on conflict on constraint uniq_operator_set_split_snapshots do nothing;
 `
 
 func (r *RewardsCalculator) GenerateAndInsertOperatorSetSplitSnapshots(snapshotDate string) error {
-	tableName := "operator_set_split_snapshots"
-
 	query, err := rewardsUtils.RenderQueryTemplate(operatorSetSplitSnapshotQuery, map[string]interface{}{
 		"cutoffDate": snapshotDate,
 	})
@@ -79,10 +82,13 @@ func (r *RewardsCalculator) GenerateAndInsertOperatorSetSplitSnapshots(snapshotD
 		return err
 	}
 
-	err = r.generateAndInsertFromQuery(tableName, query, nil)
-	if err != nil {
-		r.logger.Sugar().Errorw("Failed to generate operator_set_split_snapshots", "error", err)
-		return err
+	res := r.grm.Exec(query)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_set_split_snapshots",
+			zap.Error(err),
+			zap.String("snapshotDate", snapshotDate),
+		)
+		return res.Error
 	}
 	return nil
 }

--- a/pkg/rewards/operatorSetSplitSnapshots.go
+++ b/pkg/rewards/operatorSetSplitSnapshots.go
@@ -85,7 +85,7 @@ func (r *RewardsCalculator) GenerateAndInsertOperatorSetSplitSnapshots(snapshotD
 	res := r.grm.Exec(query)
 	if res.Error != nil {
 		r.logger.Sugar().Errorw("Failed to generate operator_set_split_snapshots",
-			zap.Error(err),
+			zap.Error(res.Error),
 			zap.String("snapshotDate", snapshotDate),
 		)
 		return res.Error

--- a/pkg/rewards/operatorSetStrategyRegistrationSnapshots.go
+++ b/pkg/rewards/operatorSetStrategyRegistrationSnapshots.go
@@ -115,7 +115,7 @@ func (r *RewardsCalculator) GenerateAndInsertOperatorSetStrategyRegistrationSnap
 	res := r.grm.Exec(query)
 	if res.Error != nil {
 		r.logger.Sugar().Errorw("Failed to generate operator_set_strategy_registration_snapshots",
-			zap.Error(err),
+			zap.Error(res.Error),
 			zap.String("snapshotDate", snapshotDate),
 		)
 		return res.Error

--- a/pkg/rewards/operatorSetStrategyRegistrationSnapshots.go
+++ b/pkg/rewards/operatorSetStrategyRegistrationSnapshots.go
@@ -1,6 +1,9 @@
 package rewards
 
-import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
 
 // Operator Set Strategy Registration Windows: Ranges at which a strategy has been registered for an operator set by an AVS.
 // 1. Marked_statuses: Denote which registration status comes after one another
@@ -11,6 +14,7 @@ import "github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
 // 4. Registration_snapshots: Round up each start_time and end_time to 0 UTC on NEXT DAY.
 // 5. Operator_set_strategy_registration_windows: Ranges that start and end on same day are invalid
 const operatorSetStrategyRegistrationSnapshotsQuery = `
+insert into operator_set_strategy_registration_snapshots (strategy, avs, operator_set_id, snapshot)
 WITH state_changes as (
 	select
 		ossr.*,
@@ -96,11 +100,10 @@ SELECT
 	d AS snapshot
 FROM cleaned_records
 CROSS JOIN generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS d
+on conflict on constraint uniq_operator_set_strategy_registration_snapshots do nothing;
 `
 
 func (r *RewardsCalculator) GenerateAndInsertOperatorSetStrategyRegistrationSnapshots(snapshotDate string) error {
-	tableName := "operator_set_strategy_registration_snapshots"
-
 	query, err := rewardsUtils.RenderQueryTemplate(operatorSetStrategyRegistrationSnapshotsQuery, map[string]interface{}{
 		"cutoffDate": snapshotDate,
 	})
@@ -109,10 +112,13 @@ func (r *RewardsCalculator) GenerateAndInsertOperatorSetStrategyRegistrationSnap
 		return err
 	}
 
-	err = r.generateAndInsertFromQuery(tableName, query, nil)
-	if err != nil {
-		r.logger.Sugar().Errorw("Failed to generate operator_set_strategy_registration_snapshots", "error", err)
-		return err
+	res := r.grm.Exec(query)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_set_strategy_registration_snapshots",
+			zap.Error(err),
+			zap.String("snapshotDate", snapshotDate),
+		)
+		return res.Error
 	}
 	return nil
 }

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -944,17 +944,3 @@ func (rc *RewardsCalculator) ListDistributionRoots(blockHeight uint64) ([]*Distr
 	}
 	return submittedDistributionRoots, nil
 }
-
-func (rc *RewardsCalculator) generateAndInsertFromQuery(
-	tableName string,
-	query string,
-	variables []interface{},
-) error {
-	return rewardsUtils.GenerateAndInsertFromQuery(
-		rc.grm,
-		tableName,
-		query,
-		variables,
-		rc.logger,
-	)
-}

--- a/pkg/rewardsUtils/rewardsUtils.go
+++ b/pkg/rewardsUtils/rewardsUtils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"github.com/Layr-Labs/sidecar/pkg/postgres/helpers"
 	"text/template"
 
 	"github.com/Layr-Labs/sidecar/pkg/utils"
@@ -184,39 +183,4 @@ func FindRewardsTableNamesForSearchPatterns(patterns map[string]string, cutoffDa
 		results[key] = tname
 	}
 	return results, nil
-}
-
-func GenerateAndInsertFromQuery(
-	grm *gorm.DB,
-	tableName string,
-	query string,
-	variables []interface{},
-	l *zap.Logger,
-) error {
-	tmpTableName := fmt.Sprintf("%s_tmp", tableName)
-
-	queryWithInsert := fmt.Sprintf("CREATE TABLE %s AS %s", tmpTableName, query)
-
-	_, err := helpers.WrapTxAndCommit(func(tx *gorm.DB) (interface{}, error) {
-		queries := []string{
-			queryWithInsert,
-			fmt.Sprintf(`drop table if exists %s`, tableName),
-			fmt.Sprintf(`alter table %s rename to %s`, tmpTableName, tableName),
-		}
-		for i, query := range queries {
-			var res *gorm.DB
-			if i == 0 && variables != nil && len(variables) > 0 {
-				res = tx.Exec(query, variables...)
-			} else {
-				res = tx.Exec(query)
-			}
-			if res.Error != nil {
-				l.Sugar().Errorw("Failed to execute query", "query", query, "error", res.Error)
-				return nil, res.Error
-			}
-		}
-		return nil, nil
-	}, grm, nil)
-
-	return err
 }


### PR DESCRIPTION
Part 2 of #251 for tables added post rewards v2

> Makes all snapshot tables long-lived with proper unique constraints.
>
> Previously, snapshot tables were dropped (if they existed) and re-generated for a given snapshot date. This results in a lot of data being generated and thrown out for no reason. It also meant that we couldnt put proper indexes on these tables since they would disappear when the table was dropped and re-created.