### PR TITLE
fix: handle edgecase where there are no rewards

### DIFF
--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -238,9 +238,33 @@ func (rc *RewardsCalculator) MerkelizeRewardsForSnapshot(snapshotDate string) (
 func (rc *RewardsCalculator) GetMaxSnapshotDateForCutoffDate(cutoffDate string) (string, error) {
 	goldStagingTableName := rewardsUtils.GetGoldTableNames(cutoffDate)[rewardsUtils.Table_11_GoldStaging]
 
+	// check to see if there are any rows at all in the staging table
+	var count int64
+	res := rc.grm.Raw(fmt.Sprintf(`select count(*) as count from %s`, goldStagingTableName)).Scan(&count)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to get count of rows in staging table", "error", res.Error)
+		return "", res.Error
+	}
+	
+	// if there arent any rows, we need to create what the rewardsCalcEndDate would be
+	if count == 0 {
+		cutoffDateTime, err := time.Parse(time.DateOnly, cutoffDate)
+		if err != nil {
+			rc.logger.Sugar().Errorw("Failed to parse cutoff date", "error", err)
+			return "", err
+		}
+		// since cutoffDate is exclusive, the possible rewardsCalcEndDate is cutoffDate - 1day
+		rewardsCalcEndDate := cutoffDateTime.Add(-24 * time.Hour).Format(time.DateOnly)
+		rc.logger.Sugar().Infow("No rows found in staging table, using cutoff date",
+			zap.String("cutoffDate", cutoffDate),
+			zap.String("rewardsCalcEndDate", rewardsCalcEndDate),
+		)
+		return rewardsCalcEndDate, nil
+	}
+
 	var maxSnapshotStr string
 	query := fmt.Sprintf(`select to_char(max(snapshot), 'YYYY-MM-DD') as snapshot from %s`, goldStagingTableName)
-	res := rc.grm.Raw(query).Scan(&maxSnapshotStr)
+	res = rc.grm.Raw(query).Scan(&maxSnapshotStr)
 	if res.Error != nil {
 		rc.logger.Sugar().Errorw("Failed to get max snapshot date", "error", res.Error)
 		return "", res.Error

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -245,7 +245,7 @@ func (rc *RewardsCalculator) GetMaxSnapshotDateForCutoffDate(cutoffDate string) 
 		rc.logger.Sugar().Errorw("Failed to get count of rows in staging table", "error", res.Error)
 		return "", res.Error
 	}
-	
+
 	// if there arent any rows, we need to create what the rewardsCalcEndDate would be
 	if count == 0 {
 		cutoffDateTime, err := time.Parse(time.DateOnly, cutoffDate)


### PR DESCRIPTION
## Description

This fixes an issue seen on holesky when trying to generate the rewards proof. If the staging table lacks any rows due to no new rewards generated, the query fails when attempting to cast the snapshot date.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
