### PR TITLE
feat: set max call and recv message size for grpc client

### DIFF
--- a/pkg/clients/sidecar/client.go
+++ b/pkg/clients/sidecar/client.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"math"
 	"strings"
 )
 
@@ -57,7 +58,13 @@ func newGrpcClient(url string, insecureConn bool) (*grpc.ClientConn, error) {
 		creds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: false}))
 	}
 
-	return grpc.NewClient(url, creds)
+	opts := []grpc.DialOption{
+		creds,
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(math.MaxInt32)),
+	}
+
+	return grpc.NewClient(url, opts...)
 }
 
 func NewSidecarRewardsClient(url string, insecureConn bool) (rewardsV1.RewardsClient, error) {


### PR DESCRIPTION
## Description

Set max call and recv message size for the sidecar "self" client that is used when proxying requests from an RPC only instance of the sidecar to the "primary" sidecar.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
