### PR TITLE
feat: backport rewards history RPCs from testnet-slashing

### DIFF
--- a/internal/metrics/metricsTypes/metrics.go
+++ b/internal/metrics/metricsTypes/metrics.go
@@ -57,6 +57,8 @@ var MetricTypes = map[MetricsType][]MetricsTypeConfig{
 				"status",
 				"status_code",
 				"rpc",
+				"client_source",
+				"client_type",
 			},
 		},
 		MetricsTypeConfig{
@@ -69,6 +71,8 @@ var MetricTypes = map[MetricsType][]MetricsTypeConfig{
 				"pattern",
 				"rpc",
 				"client_ip",
+				"client_source",
+				"client_type",
 			},
 		},
 	},
@@ -90,6 +94,8 @@ var MetricTypes = map[MetricsType][]MetricsTypeConfig{
 				"status",
 				"status_code",
 				"rpc",
+				"client_source",
+				"client_type",
 			},
 		},
 		MetricsTypeConfig{
@@ -102,6 +108,8 @@ var MetricTypes = map[MetricsType][]MetricsTypeConfig{
 				"pattern",
 				"rpc",
 				"client_ip",
+				"client_source",
+				"client_type",
 			},
 		},
 		MetricsTypeConfig{

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -207,7 +207,7 @@ func (rc *RewardsCalculator) MerkelizeRewardsForSnapshot(snapshotDate string) (
 	*distribution.Distribution,
 	error,
 ) {
-	rewards, err := rc.FetchRewardsForSnapshot(snapshotDate)
+	rewards, err := rc.FetchRewardsForSnapshot(snapshotDate, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -518,24 +518,41 @@ func (rc *RewardsCalculator) DeleteCorruptedRewardsFromBlockHeight(blockHeight u
 	return nil
 }
 
-func (rc *RewardsCalculator) FetchRewardsForSnapshot(snapshotDate string) ([]*rewardsTypes.Reward, error) {
+func (rc *RewardsCalculator) FetchRewardsForSnapshot(snapshotDate string, earners []string) ([]*rewardsTypes.Reward, error) {
 	var goldRows []*rewardsTypes.Reward
-	query, err := rewardsUtils.RenderQueryTemplate(`
+
+	query := `
 		select
 			earner,
 			token,
 			max(snapshot) as snapshot,
 			cast(sum(amount) as varchar) as cumulative_amount
 		from gold_table
-		where snapshot <= date '{{.snapshotDate}}'
+		where
+		    snapshot <= date '{{.snapshotDate}}'
+		{{ if .filterEarners }}
+			and earner in @earners
+		{{ end }}
 		group by 1, 2
 		order by snapshot desc
-    `, map[string]interface{}{"snapshotDate": snapshotDate})
+    `
+	templateArgs := map[string]interface{}{
+		"snapshotDate":  snapshotDate,
+		"filterEarners": false,
+	}
+	args := make([]interface{}, 0)
+
+	if len(earners) > 0 {
+		templateArgs["filterEarners"] = true
+		args = append(args, sql.Named("earners", earners))
+	}
+
+	renderedQuery, err := rewardsUtils.RenderQueryTemplate(query, templateArgs)
 
 	if err != nil {
 		return nil, err
 	}
-	res := rc.grm.Raw(query).Scan(&goldRows)
+	res := rc.grm.Raw(renderedQuery, args...).Scan(&goldRows)
 	if res.Error != nil {
 		return nil, res.Error
 	}

--- a/pkg/service/baseDataService/base.go
+++ b/pkg/service/baseDataService/base.go
@@ -2,6 +2,9 @@ package baseDataService
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"github.com/Layr-Labs/sidecar/pkg/eigenState/stateManager"
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"gorm.io/gorm"
 )
@@ -20,4 +23,29 @@ func (b *BaseDataService) GetCurrentBlockHeightIfNotPresent(ctx context.Context,
 		blockHeight = currentBlock.Number
 	}
 	return blockHeight, nil
+}
+
+func (b *BaseDataService) GetBlock(ctx context.Context, blockHeight uint64) (*storage.Block, error) {
+	var block *storage.Block
+	res := b.DB.Model(&storage.Block{}).Where("number = ?", blockHeight).First(&block)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, res.Error
+	}
+	return block, nil
+}
+
+func (b *BaseDataService) GetLatestConfirmedBlock(ctx context.Context) (*storage.Block, error) {
+	var stateRoot *stateManager.StateRoot
+	res := b.DB.Model(&stateManager.StateRoot{}).Order("eth_block_number desc").First(&stateRoot)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("no state root found")
+		}
+		return nil, res.Error
+	}
+
+	return b.GetBlock(ctx, stateRoot.EthBlockNumber)
 }

--- a/pkg/service/rewardsDataService/rewards.go
+++ b/pkg/service/rewardsDataService/rewards.go
@@ -48,8 +48,8 @@ func NewRewardsDataService(
 	}
 }
 
-func (rds *RewardsDataService) GetRewardsForSnapshot(ctx context.Context, snapshot string) ([]*rewardsTypes.Reward, error) {
-	return rds.rewardsCalculator.FetchRewardsForSnapshot(snapshot)
+func (rds *RewardsDataService) GetRewardsForSnapshot(ctx context.Context, snapshot string, earners []string) ([]*rewardsTypes.Reward, error) {
+	return rds.rewardsCalculator.FetchRewardsForSnapshot(snapshot, earners)
 }
 
 func (rds *RewardsDataService) GetRewardsForDistributionRoot(ctx context.Context, rootIndex uint64) ([]*rewardsTypes.Reward, error) {
@@ -60,7 +60,7 @@ func (rds *RewardsDataService) GetRewardsForDistributionRoot(ctx context.Context
 	if root == nil {
 		return nil, fmt.Errorf("no distribution root found for root index '%d'", rootIndex)
 	}
-	return rds.rewardsCalculator.FetchRewardsForSnapshot(root.GetSnapshotDate())
+	return rds.rewardsCalculator.FetchRewardsForSnapshot(root.GetSnapshotDate(), nil)
 }
 
 type TotalClaimedReward struct {
@@ -699,4 +699,93 @@ func (rds *RewardsDataService) GetRewardsByAvsForDistributionRoot(ctx context.Co
 		return nil, res.Error
 	}
 	return rewards, nil
+}
+
+type HistoricalReward struct {
+	Token    string
+	Amount   string
+	Snapshot string
+}
+
+func (rds *RewardsDataService) ListHistoricalRewardsForEarner(
+	ctx context.Context,
+	earnerAddress string,
+	startBlockHeight uint64,
+	endBlockHeight uint64,
+	tokens []string,
+) ([]*HistoricalReward, error) {
+	if earnerAddress == "" {
+		return nil, fmt.Errorf("earner is required")
+	}
+	if endBlockHeight != 0 && startBlockHeight > endBlockHeight {
+		return nil, fmt.Errorf("startBlockHeight must be less than or equal to endBlockHeight")
+	}
+
+	var startBlock *storage.Block
+	var endBlock *storage.Block
+	var err error
+
+	if startBlockHeight > 0 {
+		startBlock, err = rds.BaseDataService.GetBlock(ctx, startBlockHeight)
+		if err != nil {
+			return nil, err
+		}
+		if startBlock == nil {
+			return nil, fmt.Errorf("no block found for startBlock '%d'", startBlockHeight)
+		}
+	}
+
+	// if endBlockHeight is 0, we will use the latest confirmed block
+	if endBlockHeight == 0 {
+		endBlock, err = rds.BaseDataService.GetLatestConfirmedBlock(ctx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		endBlock, err = rds.BaseDataService.GetBlock(ctx, endBlockHeight)
+		if err != nil {
+			return nil, err
+		}
+		if endBlock == nil {
+			return nil, fmt.Errorf("no block found for endBlock '%d'", endBlockHeight)
+		}
+	}
+
+	args := []interface{}{
+		sql.Named("earner", earnerAddress),
+	}
+	query := `
+		select
+		    snapshot,
+			token,
+			sum(amount) as amount
+		from gold_table as gt
+		where
+			earner = @earner
+	`
+	if startBlock != nil {
+		query += " and gt.snapshot >= @startBlockDate"
+		startBlockDate := startBlock.BlockTime.Format(time.DateOnly)
+		args = append(args, sql.Named("startBlockDate", startBlockDate))
+	}
+	if endBlock != nil {
+		query += " and gt.snapshot <= @endBlockDate"
+		endBlockDate := endBlock.BlockTime.Format(time.DateOnly)
+		args = append(args, sql.Named("endBlockDate", endBlockDate))
+	}
+
+	if len(tokens) > 0 {
+		query += " and gt.token in (?)"
+		tokens = lowercaseTokenList(tokens)
+		args = append(args, sql.Named("tokens", tokens))
+	}
+
+	query += "group by 1, 2 order by 1 desc, 2 asc"
+
+	var historicalRewards []*HistoricalReward
+	res := rds.db.Raw(query, args...).Scan(&historicalRewards)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return historicalRewards, nil
 }

--- a/pkg/service/rewardsDataService/rewards_test.go
+++ b/pkg/service/rewardsDataService/rewards_test.go
@@ -73,7 +73,7 @@ func Test_RewardsDataService(t *testing.T) {
 	t.Run("Test GetRewardsForSnapshot", func(t *testing.T) {
 		snapshot := "2025-01-16"
 
-		r, err := rds.GetRewardsForSnapshot(context.Background(), snapshot)
+		r, err := rds.GetRewardsForSnapshot(context.Background(), snapshot, nil)
 		assert.Nil(t, err)
 		assert.NotNil(t, r)
 	})


### PR DESCRIPTION
## Description

The historical rewards routes that were added along with the slashing RPCs do not depend on slashing functionality. This PR backports them to be released on mainnet.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Included backporting applicable tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
