### PR TITLE
refactor: remove refs to config.Config where unused

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -62,7 +62,7 @@ var runDatabaseCmd = &cobra.Command{
 
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
-		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -86,7 +86,7 @@ var runDatabaseCmd = &cobra.Command{
 			log.Fatalf("Failed to initialize core contracts: %v", err)
 		}
 
-		cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l, cfg)
+		cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
-	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
 	pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -83,7 +83,7 @@ func main() {
 		log.Fatalf("Failed to initialize core contracts: %v", err)
 	}
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l, cfg)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 	if err != nil {

--- a/cmd/loadContract.go
+++ b/cmd/loadContract.go
@@ -48,7 +48,7 @@ var loadContractCmd = &cobra.Command{
 
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
-		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -70,7 +70,7 @@ var loadContractCmd = &cobra.Command{
 		cs := postgresContractStore.NewPostgresContractStore(grm, l, cfg)
 
 		// Create the contract manager
-		cm := contractManager.NewContractManager(grm, cs, client, af, sink, l, cfg)
+		cm := contractManager.NewContractManager(grm, cs, client, af, sink, l)
 
 		var filename string
 		var useFile bool

--- a/cmd/operatorRestakedStrategies.go
+++ b/cmd/operatorRestakedStrategies.go
@@ -49,7 +49,7 @@ var runOperatorRestakedStrategiesCmd = &cobra.Command{
 
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
-		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -73,7 +73,7 @@ var runOperatorRestakedStrategiesCmd = &cobra.Command{
 			log.Fatalf("Failed to initialize core contracts: %v", err)
 		}
 
-		cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l, cfg)
+		cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -75,7 +75,7 @@ var rpcCmd = &cobra.Command{
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
 		ipfs := ipfs.NewIpfs(ipfs.DefaultHttpClient(), l, cfg)
-		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{ipfs})
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{ipfs})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -91,7 +91,7 @@ var rpcCmd = &cobra.Command{
 
 		cs := postgresContractStore.NewPostgresContractStore(grm, l, cfg)
 
-		cm := contractManager.NewContractManager(grm, cs, client, af, sink, l, cfg)
+		cm := contractManager.NewContractManager(grm, cs, client, af, sink, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -79,7 +79,7 @@ var runCmd = &cobra.Command{
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
 		ipfs := ipfs.NewIpfs(ipfs.DefaultHttpClient(), l, cfg)
-		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{ipfs})
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{ipfs})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 
@@ -103,7 +103,7 @@ var runCmd = &cobra.Command{
 			log.Fatalf("Failed to initialize core contracts: %v", err)
 		}
 
-		cm := contractManager.NewContractManager(grm, contractStore, client, af, sink, l, cfg)
+		cm := contractManager.NewContractManager(grm, contractStore, client, af, sink, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/pkg/abiFetcher/abiFetcher.go
+++ b/pkg/abiFetcher/abiFetcher.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
 	"go.uber.org/zap"
@@ -16,7 +15,6 @@ type AbiFetcher struct {
 	ethereumClient *ethereum.Client
 	httpClient     *http.Client
 	logger         *zap.Logger
-	config         *config.Config
 	abiSources     []abiSource.AbiSource
 }
 
@@ -24,14 +22,12 @@ func NewAbiFetcher(
 	e *ethereum.Client,
 	hc *http.Client,
 	l *zap.Logger,
-	cfg *config.Config,
 	sources []abiSource.AbiSource,
 ) *AbiFetcher {
 	return &AbiFetcher{
 		ethereumClient: e,
 		httpClient:     hc,
 		logger:         l,
-		config:         cfg,
 		abiSources:     sources,
 	}
 }

--- a/pkg/contractManager/contractManager_test.go
+++ b/pkg/contractManager/contractManager_test.go
@@ -74,7 +74,7 @@ func Test_ContractManager(t *testing.T) {
 	client := ethereum.NewClient(ethConfig, l)
 	client.SetHttpClient(mockHttpClient)
 
-	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
 	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
 	if err != nil {
@@ -158,7 +158,7 @@ func Test_ContractManager(t *testing.T) {
 
 		// Perform the upgrade
 		blockNumber := 5
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 		err = cm.HandleContractUpgrade(context.Background(), uint64(blockNumber), upgradedLog)
 		assert.Nil(t, err)
 
@@ -194,7 +194,7 @@ func Test_ContractManager(t *testing.T) {
 
 		// Perform the upgrade
 		blockNumber := 10
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 		err = cm.HandleContractUpgrade(context.Background(), uint64(blockNumber), upgradedLog)
 		assert.Nil(t, err)
 
@@ -218,7 +218,7 @@ func Test_ContractManager(t *testing.T) {
 			})
 		defer patches.Reset()
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 
 		params := ContractLoadParams{
 			Address:      "0x2468ace02468ace02468ace02468ace02468ace0",
@@ -247,7 +247,7 @@ func Test_ContractManager(t *testing.T) {
 			})
 		defer patches.Reset()
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 
 		params := ContractLoadParams{
 			Address:      "0x1357924680135792468013579246801357924680",
@@ -287,7 +287,7 @@ func Test_ContractManager(t *testing.T) {
 			})
 		defer patches.Reset()
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 
 		params := ContractLoadParams{
 			Address:          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -323,7 +323,7 @@ func Test_ContractManager(t *testing.T) {
 		)
 		assert.Nil(t, err)
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 
 		params := ContractLoadParams{
 			Address:          "0xdddddddddddddddddddddddddddddddddddddddd",
@@ -339,7 +339,7 @@ func Test_ContractManager(t *testing.T) {
 	})
 
 	t.Run("Test LoadContract with nonexistent proxy", func(t *testing.T) {
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 
 		params := ContractLoadParams{
 			Address:          "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -355,7 +355,7 @@ func Test_ContractManager(t *testing.T) {
 	})
 
 	t.Run("Test LoadContract with missing parameters", func(t *testing.T) {
-		cm := NewContractManager(grm, cs, client, af, sdc, l, cfg)
+		cm := NewContractManager(grm, cs, client, af, sdc, l)
 
 		// Missing address
 		params1 := ContractLoadParams{

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -150,7 +150,7 @@ func NewIndexer(
 		db:              grm,
 	}
 
-	tlp := transactionLogParser.NewTransactionLogParser(l, cfg, cm, i)
+	tlp := transactionLogParser.NewTransactionLogParser(l, cm, i)
 	i.TransactionLogParser = tlp
 
 	return i

--- a/pkg/indexer/restakedStrategies_test.go
+++ b/pkg/indexer/restakedStrategies_test.go
@@ -77,7 +77,7 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 	client := ethereum.NewClient(ethConfig, l)
 
-	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
 	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
 	if err != nil {
@@ -102,7 +102,7 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 	scc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, 10, l)
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l, cfg)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
 
 	t.Run("Integration - gets restaked strategies for avs/operator with multicall contract caller", func(t *testing.T) {
 		avs := "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"

--- a/pkg/pipeline/pipelineIntegration_test.go
+++ b/pkg/pipeline/pipelineIntegration_test.go
@@ -81,7 +81,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 	ethConfig.BaseUrl = rpcUrl
 	client := ethereum.NewClient(ethConfig, l)
 
-	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, cfg, []abiSource.AbiSource{})
+	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
 	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
 	if err != nil {
@@ -93,7 +93,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 		log.Fatalf("Failed to initialize core contracts: %v", err)
 	}
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l, cfg)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 

--- a/pkg/transactionBackfiller/backfiller.go
+++ b/pkg/transactionBackfiller/backfiller.go
@@ -3,7 +3,6 @@ package transactionBackfiller
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
 	"github.com/Layr-Labs/sidecar/pkg/fetcher"
 	"github.com/Layr-Labs/sidecar/pkg/storage"
@@ -42,13 +41,12 @@ type BackfillerMessage struct {
 // TransactionBackfiller processes transaction logs for specified block ranges.
 // It uses a worker pool to concurrently process blocks and extract relevant transaction logs.
 type TransactionBackfiller struct {
-	logger       *zap.Logger
-	config       *TransactionBackfillerConfig
-	globalConfig *config.Config
-	fetcher      *fetcher.Fetcher
-	blockStore   storage.BlockStore
-	queue        chan *BackfillerMessage
-	done         chan struct{}
+	logger     *zap.Logger
+	config     *TransactionBackfillerConfig
+	fetcher    *fetcher.Fetcher
+	blockStore storage.BlockStore
+	queue      chan *BackfillerMessage
+	done       chan struct{}
 }
 
 const (
@@ -63,7 +61,6 @@ const (
 // Parameters:
 //   - cfg: Configuration for the backfiller
 //   - logger: Logger for recording operations
-//   - globalConfig: Global application configuration
 //   - fetcher: Service for fetching blockchain data
 //   - bs: Storage for block data
 //
@@ -72,7 +69,6 @@ const (
 func NewTransactionBackfiller(
 	cfg *TransactionBackfillerConfig,
 	logger *zap.Logger,
-	globalConfig *config.Config,
 	fetcher *fetcher.Fetcher,
 	bs storage.BlockStore,
 ) *TransactionBackfiller {
@@ -80,13 +76,12 @@ func NewTransactionBackfiller(
 		cfg.Workers = defaultWorkers
 	}
 	return &TransactionBackfiller{
-		config:       cfg,
-		logger:       logger,
-		globalConfig: globalConfig,
-		fetcher:      fetcher,
-		blockStore:   bs,
-		queue:        make(chan *BackfillerMessage, queueDepth),
-		done:         make(chan struct{}),
+		config:     cfg,
+		logger:     logger,
+		fetcher:    fetcher,
+		blockStore: bs,
+		queue:      make(chan *BackfillerMessage, queueDepth),
+		done:       make(chan struct{}),
 	}
 }
 

--- a/pkg/transactionBackfiller/backfiller_test.go
+++ b/pkg/transactionBackfiller/backfiller_test.go
@@ -55,7 +55,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 	ethConfig.NativeBatchCallSize = 10
 	client := ethereum.NewClient(ethConfig, l)
 
-	af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, cfg, []abiSource.AbiSource{})
+	af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, []abiSource.AbiSource{})
 
 	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
 	if err != nil {
@@ -79,7 +79,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sink, l, cfg)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, sink, l)
 
 	fetchr := fetcher.NewFetcher(client, cfg, l)
 
@@ -98,7 +98,7 @@ func Test_TransactionBackfiller(t *testing.T) {
 	cfg, l, fetcher, mds, grm, cm, dbname, err := setup(&ethereum.EthereumClientConfig{})
 	assert.Nil(t, err)
 
-	bf := NewTransactionBackfiller(&TransactionBackfillerConfig{}, l, cfg, fetcher, mds)
+	bf := NewTransactionBackfiller(&TransactionBackfillerConfig{}, l, fetcher, mds)
 
 	t.Run("Test backfill two blocks", func(t *testing.T) {
 		logsHandled := atomic.Uint64{}
@@ -106,7 +106,7 @@ func Test_TransactionBackfiller(t *testing.T) {
 
 		logHandler := &customLogHandler{}
 
-		logParser := transactionLogParser.NewTransactionLogParser(l, cfg, cm, logHandler)
+		logParser := transactionLogParser.NewTransactionLogParser(l, cm, logHandler)
 
 		message := &BackfillerMessage{
 			StartBlock: 22020900,

--- a/pkg/transactionLogParser/logParser.go
+++ b/pkg/transactionLogParser/logParser.go
@@ -3,7 +3,6 @@ package transactionLogParser
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
 	"github.com/Layr-Labs/sidecar/pkg/contractAbi"
 	"github.com/Layr-Labs/sidecar/pkg/contractManager"
@@ -27,7 +26,6 @@ type InterestingLogQualifier interface {
 // It uses contract ABIs to decode event data into structured format.
 type TransactionLogParser struct {
 	logger                  *zap.Logger
-	globalConfig            *config.Config
 	contractManager         *contractManager.ContractManager
 	interestingLogQualifier InterestingLogQualifier
 }
@@ -36,7 +34,6 @@ type TransactionLogParser struct {
 //
 // Parameters:
 //   - logger: Logger for recording operations
-//   - globalConfig: Global application configuration
 //   - contractManager: Manager for contract ABIs and metadata
 //   - interestingLogQualifier: Qualifier to determine which logs to process
 //
@@ -44,13 +41,11 @@ type TransactionLogParser struct {
 //   - *TransactionLogParser: A configured transaction log parser
 func NewTransactionLogParser(
 	logger *zap.Logger,
-	globalConfig *config.Config,
 	contractManager *contractManager.ContractManager,
 	interestingLogQualifier InterestingLogQualifier,
 ) *TransactionLogParser {
 	return &TransactionLogParser{
 		logger:                  logger,
-		globalConfig:            globalConfig,
 		contractManager:         contractManager,
 		interestingLogQualifier: interestingLogQualifier,
 	}


### PR DESCRIPTION
## Description

Remove `config.Config` as a dependency on modules where it is used to initialize the module and then never actually used.

This helps keep modules re-usable and not directly coupled to the Sidecar's global config object.

## Type of change

- [x] Refactor (non-breaking change which does not add or remove functionality)

## How Has This Been Tested?

Ran against existing test suite.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
