### PR TITLE
refactor: remove metricsSink in ContractManager

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -86,7 +86,7 @@ var runDatabaseCmd = &cobra.Command{
 			log.Fatalf("Failed to initialize core contracts: %v", err)
 		}
 
-		cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
+		cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -83,7 +83,7 @@ func main() {
 		log.Fatalf("Failed to initialize core contracts: %v", err)
 	}
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 	if err != nil {

--- a/cmd/loadContract.go
+++ b/cmd/loadContract.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/pkg/postgres/migrations"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -34,16 +33,6 @@ var loadContractCmd = &cobra.Command{
 		l, err := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
 		if err != nil {
 			return fmt.Errorf("failed to initialize logger: %w", err)
-		}
-
-		metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
-		if err != nil {
-			return fmt.Errorf("failed to setup metrics sink: %w", err)
-		}
-
-		sink, err := metrics.NewMetricsSink(&metrics.MetricsSinkConfig{}, metricsClients)
-		if err != nil {
-			return fmt.Errorf("failed to setup metrics sink: %w", err)
 		}
 
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
@@ -70,7 +59,7 @@ var loadContractCmd = &cobra.Command{
 		cs := postgresContractStore.NewPostgresContractStore(grm, l, cfg)
 
 		// Create the contract manager
-		cm := contractManager.NewContractManager(grm, cs, client, af, sink, l)
+		cm := contractManager.NewContractManager(grm, cs, client, af, l)
 
 		var filename string
 		var useFile bool

--- a/cmd/operatorRestakedStrategies.go
+++ b/cmd/operatorRestakedStrategies.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
@@ -37,16 +36,6 @@ var runOperatorRestakedStrategiesCmd = &cobra.Command{
 
 		l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
 
-		metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
-		if err != nil {
-			l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-		}
-
-		sdc, err := metrics.NewMetricsSink(&metrics.MetricsSinkConfig{}, metricsClients)
-		if err != nil {
-			l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-		}
-
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
 		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
@@ -73,7 +62,7 @@ var runOperatorRestakedStrategiesCmd = &cobra.Command{
 			log.Fatalf("Failed to initialize core contracts: %v", err)
 		}
 
-		cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
+		cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -91,7 +91,7 @@ var rpcCmd = &cobra.Command{
 
 		cs := postgresContractStore.NewPostgresContractStore(grm, l, cfg)
 
-		cm := contractManager.NewContractManager(grm, cs, client, af, sink, l)
+		cm := contractManager.NewContractManager(grm, cs, client, af, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -103,7 +103,7 @@ var runCmd = &cobra.Command{
 			log.Fatalf("Failed to initialize core contracts: %v", err)
 		}
 
-		cm := contractManager.NewContractManager(grm, contractStore, client, af, sink, l)
+		cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 		mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 		if err != nil {

--- a/examples/eventSubscriber/main.go
+++ b/examples/eventSubscriber/main.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
+	"log"
+	"strings"
+
 	v1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/events"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"io"
-	"log"
-	"strings"
 )
 
 func NewSidecarClient(url string, insecureConn bool) (v1.EventsClient, error) {

--- a/examples/transactionBackfiller/main.go
+++ b/examples/transactionBackfiller/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/internal/tests"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
@@ -52,16 +51,6 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, []abiSource.AbiSource{})
 
-	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-	}
-
-	sink, err := metrics.NewMetricsSink(&metrics.MetricsSinkConfig{}, metricsClients)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-	}
-
 	_, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
 	if err != nil {
 		log.Fatal(err)
@@ -74,7 +63,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sink, l)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 	fetchr := fetcher.NewFetcher(client, cfg, l)
 

--- a/pkg/contractManager/contractManager.go
+++ b/pkg/contractManager/contractManager.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
 	"github.com/Layr-Labs/sidecar/pkg/contractStore"
@@ -38,8 +37,6 @@ type ContractManager struct {
 	EthereumClient *ethereum.Client
 	// AbiFetcher is used to fetch contract ABIs
 	AbiFetcher *abiFetcher.AbiFetcher
-	// metricsSink collects metrics about contract operations
-	metricsSink *metrics.MetricsSink
 	// Logger is used for logging contract operations
 	Logger *zap.Logger
 }
@@ -50,7 +47,6 @@ func NewContractManager(
 	cs contractStore.ContractStore,
 	e *ethereum.Client,
 	af *abiFetcher.AbiFetcher,
-	ms *metrics.MetricsSink,
 	l *zap.Logger,
 ) *ContractManager {
 	return &ContractManager{
@@ -58,7 +54,6 @@ func NewContractManager(
 		ContractStore:  cs,
 		EthereumClient: e,
 		AbiFetcher:     af,
-		metricsSink:    ms,
 		Logger:         l,
 	}
 }

--- a/pkg/contractManager/contractManager_test.go
+++ b/pkg/contractManager/contractManager_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/internal/tests"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
@@ -76,11 +75,6 @@ func Test_ContractManager(t *testing.T) {
 
 	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
-	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-	}
-
 	contract := &contractStore.Contract{
 		ContractAddress:         "0x1234567890abcdef1234567890abcdef12345678",
 		ContractAbi:             "[]",
@@ -92,11 +86,6 @@ func Test_ContractManager(t *testing.T) {
 		BlockNumber:          1,
 		ContractAddress:      contract.ContractAddress,
 		ProxyContractAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-	}
-
-	sdc, err := metrics.NewMetricsSink(&metrics.MetricsSinkConfig{}, metricsClients)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
 	}
 
 	cs := postgresContractStore.NewPostgresContractStore(grm, l, cfg)
@@ -158,7 +147,7 @@ func Test_ContractManager(t *testing.T) {
 
 		// Perform the upgrade
 		blockNumber := 5
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 		err = cm.HandleContractUpgrade(context.Background(), uint64(blockNumber), upgradedLog)
 		assert.Nil(t, err)
 
@@ -194,7 +183,7 @@ func Test_ContractManager(t *testing.T) {
 
 		// Perform the upgrade
 		blockNumber := 10
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 		err = cm.HandleContractUpgrade(context.Background(), uint64(blockNumber), upgradedLog)
 		assert.Nil(t, err)
 
@@ -218,7 +207,7 @@ func Test_ContractManager(t *testing.T) {
 			})
 		defer patches.Reset()
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 
 		params := ContractLoadParams{
 			Address:      "0x2468ace02468ace02468ace02468ace02468ace0",
@@ -247,7 +236,7 @@ func Test_ContractManager(t *testing.T) {
 			})
 		defer patches.Reset()
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 
 		params := ContractLoadParams{
 			Address:      "0x1357924680135792468013579246801357924680",
@@ -287,7 +276,7 @@ func Test_ContractManager(t *testing.T) {
 			})
 		defer patches.Reset()
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 
 		params := ContractLoadParams{
 			Address:          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -323,7 +312,7 @@ func Test_ContractManager(t *testing.T) {
 		)
 		assert.Nil(t, err)
 
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 
 		params := ContractLoadParams{
 			Address:          "0xdddddddddddddddddddddddddddddddddddddddd",
@@ -339,7 +328,7 @@ func Test_ContractManager(t *testing.T) {
 	})
 
 	t.Run("Test LoadContract with nonexistent proxy", func(t *testing.T) {
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 
 		params := ContractLoadParams{
 			Address:          "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -355,7 +344,7 @@ func Test_ContractManager(t *testing.T) {
 	})
 
 	t.Run("Test LoadContract with missing parameters", func(t *testing.T) {
-		cm := NewContractManager(grm, cs, client, af, sdc, l)
+		cm := NewContractManager(grm, cs, client, af, l)
 
 		// Missing address
 		params1 := ContractLoadParams{

--- a/pkg/indexer/restakedStrategies_test.go
+++ b/pkg/indexer/restakedStrategies_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/internal/tests"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
@@ -79,16 +78,6 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 	af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{})
 
-	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-	}
-
-	sdc, err := metrics.NewMetricsSink(&metrics.MetricsSinkConfig{}, metricsClients)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-	}
-
 	contractStore := postgresContractStore.NewPostgresContractStore(grm, l, cfg)
 	if err := contractStore.InitializeCoreContracts(); err != nil {
 		log.Fatalf("Failed to initialize core contracts: %v", err)
@@ -102,7 +91,7 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 	scc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, 10, l)
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 	t.Run("Integration - gets restaked strategies for avs/operator with multicall contract caller", func(t *testing.T) {
 		avs := "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"

--- a/pkg/pipeline/pipelineIntegration_test.go
+++ b/pkg/pipeline/pipelineIntegration_test.go
@@ -93,7 +93,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 		log.Fatalf("Failed to initialize core contracts: %v", err)
 	}
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sdc, l)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 

--- a/pkg/transactionBackfiller/backfiller_test.go
+++ b/pkg/transactionBackfiller/backfiller_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
-	"github.com/Layr-Labs/sidecar/internal/metrics"
 	"github.com/Layr-Labs/sidecar/internal/tests"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
@@ -57,16 +56,6 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	af := abiFetcher.NewAbiFetcher(client, &http.Client{Timeout: 5 * time.Second}, l, []abiSource.AbiSource{})
 
-	metricsClients, err := metrics.InitMetricsSinksFromConfig(cfg, l)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-	}
-
-	sink, err := metrics.NewMetricsSink(&metrics.MetricsSinkConfig{}, metricsClients)
-	if err != nil {
-		l.Sugar().Fatal("Failed to setup metrics sink", zap.Error(err))
-	}
-
 	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
 	if err != nil {
 		log.Fatal(err)
@@ -79,7 +68,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 
-	cm := contractManager.NewContractManager(grm, contractStore, client, af, sink, l)
+	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
 	fetchr := fetcher.NewFetcher(client, cfg, l)
 


### PR DESCRIPTION
## Description

Remove `metricsSink` as a dependency on the `contractManager` module, which is not being used.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)
- [ ] Performance improvement

## How Has This Been Tested?

With existing tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
