### PR TITLE
fix: check for config in GetReceiptsForBlock in Fetcher

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -103,7 +103,7 @@ var runDatabaseCmd = &cobra.Command{
 			l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
 		}
 
-		fetchr := fetcher.NewFetcher(client, cfg, l)
+		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -100,7 +100,7 @@ func main() {
 		l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
 	}
 
-	fetchr := fetcher.NewFetcher(client, cfg, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 	cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/cmd/operatorRestakedStrategies.go
+++ b/cmd/operatorRestakedStrategies.go
@@ -75,7 +75,7 @@ var runOperatorRestakedStrategiesCmd = &cobra.Command{
 			l.Sugar().Fatalw("Failed to load eigen state models", zap.Error(err))
 		}
 
-		fetchr := fetcher.NewFetcher(client, cfg, l)
+		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -120,7 +120,7 @@ var runCmd = &cobra.Command{
 			l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
 		}
 
-		fetchr := fetcher.NewFetcher(client, cfg, l)
+		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/examples/transactionBackfiller/main.go
+++ b/examples/transactionBackfiller/main.go
@@ -3,6 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/Layr-Labs/sidecar/internal/tests"
@@ -18,11 +24,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/transactionBackfiller"
 	"github.com/Layr-Labs/sidecar/pkg/transactionLogParser"
 	"go.uber.org/zap"
-	"log"
-	"net/http"
-	"os"
-	"strings"
-	"time"
 )
 
 func setup(ethConfig *ethereum.EthereumClientConfig) (
@@ -65,7 +66,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
-	fetchr := fetcher.NewFetcher(client, cfg, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 	return cfg, l, fetchr, mds, cm, nil
 

--- a/pkg/indexer/restakedStrategies_test.go
+++ b/pkg/indexer/restakedStrategies_test.go
@@ -85,7 +85,7 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 
-	fetchr := fetcher.NewFetcher(client, cfg, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 	mccc := multicallContractCaller.NewMulticallContractCaller(client, l)
 

--- a/pkg/pipeline/pipelineIntegration_test.go
+++ b/pkg/pipeline/pipelineIntegration_test.go
@@ -112,7 +112,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	rcq := rewardsCalculatorQueue.NewRewardsCalculatorQueue(rc, l)
 
-	fetchr := fetcher.NewFetcher(client, cfg, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 	cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, 10, l)
 

--- a/pkg/transactionBackfiller/backfiller_test.go
+++ b/pkg/transactionBackfiller/backfiller_test.go
@@ -3,6 +3,14 @@ package transactionBackfiller
 import (
 	"context"
 	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/Layr-Labs/sidecar/internal/tests"
@@ -19,13 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"log"
-	"net/http"
-	"os"
-	"strings"
-	"sync/atomic"
-	"testing"
-	"time"
 )
 
 func setup(ethConfig *ethereum.EthereumClientConfig) (
@@ -70,7 +71,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
-	fetchr := fetcher.NewFetcher(client, cfg, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
 
 	return cfg, l, fetchr, mds, grm, cm, dbname, nil
 


### PR DESCRIPTION
## Description

This PR adds checking for Config in GetReceiptsForBlock function in Fetcher. When Fetcher is initialized with nil for Config, this function will not break and call `FetchReceiptsForBlock`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)
- [ ] Performance improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
