### PR TITLE
perf: add eth_getLogs RPC method

### DIFF
--- a/pkg/clients/ethereum/client.go
+++ b/pkg/clients/ethereum/client.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Layr-Labs/sidecar/internal/config"
 	"io"
 	"net/http"
 	"slices"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -265,6 +266,24 @@ func (c *Client) GetBlockTransactionReceipts(ctx context.Context, blockNumber ui
 		return nil, err
 	}
 	return txReceipts, nil
+}
+
+func (c *Client) GetLogs(ctx context.Context, address string, fromBlock uint64, toBlock uint64) ([]*EthereumEventLog, error) {
+	rpcRequest := GetLogsRequest(address, fromBlock, toBlock, 1)
+
+	res, err := c.Call(ctx, rpcRequest)
+	if err != nil {
+		return nil, err
+	}
+	logs, err := RPCMethod_getLogs.ResponseParser(res.Result)
+	if err != nil {
+		c.Logger.Sugar().Errorw("failed to parse logs",
+			zap.Error(err),
+			zap.Any("raw response", res.Result),
+		)
+		return nil, err
+	}
+	return logs, nil
 }
 
 func (c *Client) GetStorageAt(ctx context.Context, address string, storagePosition string, block string) (string, error) {

--- a/pkg/clients/ethereum/client_test.go
+++ b/pkg/clients/ethereum/client_test.go
@@ -2,9 +2,10 @@ package ethereum
 
 import (
 	"context"
+	"testing"
+
 	"github.com/Layr-Labs/sidecar/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_EthereumClient(t *testing.T) {
@@ -21,5 +22,28 @@ func Test_EthereumClient(t *testing.T) {
 		receipts, err := client.GetBlockTransactionReceipts(context.Background(), uint64(22019077))
 		assert.Nil(t, err)
 		assert.NotNil(t, receipts)
+	})
+
+	t.Run("eth_getLogs", func(t *testing.T) {
+		// Use a known contract address, for example, WETH on mainnet
+		contractAddress := "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+		fromBlock := uint64(17000000)
+		toBlock := uint64(17000100)
+
+		logs, err := client.GetLogs(context.Background(), contractAddress, fromBlock, toBlock)
+		assert.Nil(t, err)
+		assert.NotNil(t, logs)
+
+		if len(logs) > 0 {
+			// Verify that logs contain the expected fields
+			for _, log := range logs {
+				assert.NotEmpty(t, log.Address)
+				assert.NotEmpty(t, log.BlockHash)
+				assert.NotEmpty(t, log.TransactionHash)
+				// BlockNumber should be within the requested range
+				blockNum := log.BlockNumber.Value()
+				assert.True(t, blockNum >= fromBlock && blockNum <= toBlock)
+			}
+		}
 	})
 }

--- a/pkg/clients/ethereum/handlers.go
+++ b/pkg/clients/ethereum/handlers.go
@@ -101,6 +101,20 @@ var (
 			return receipts, nil
 		},
 	}
+	RPCMethod_getLogs = &RequestResponseHandler[[]*EthereumEventLog]{
+		RequestMethod: &RequestMethod{
+			Name:    "eth_getLogs",
+			Timeout: time.Second * 5,
+		},
+		ResponseParser: func(res json.RawMessage) ([]*EthereumEventLog, error) {
+			logs := []*EthereumEventLog{}
+
+			if err := json.Unmarshal(res, &logs); err != nil {
+				return nil, err
+			}
+			return logs, nil
+		},
+	}
 )
 
 func GetBlockRequest(id uint) *RPCRequest {
@@ -182,6 +196,25 @@ func GetBlockReceiptsRequest(blockNumber uint64, id uint) *RPCRequest {
 		JSONRPC: jsonRPCVersion,
 		Method:  RPCMethod_getBlockReceipts.RequestMethod.Name,
 		Params:  []interface{}{hexBlockNumber},
+		ID:      id,
+	}
+}
+
+func GetLogsRequest(address string, fromBlock uint64, toBlock uint64, id uint) *RPCRequest {
+	hexFromBlock := hexutil.EncodeUint64(fromBlock)
+	hexToBlock := hexutil.EncodeUint64(toBlock)
+
+	// Create a filter object as expected by eth_getLogs
+	filter := map[string]interface{}{
+		"address":   address,
+		"fromBlock": hexFromBlock,
+		"toBlock":   hexToBlock,
+	}
+
+	return &RPCRequest{
+		JSONRPC: jsonRPCVersion,
+		Method:  RPCMethod_getLogs.RequestMethod.Name,
+		Params:  []interface{}{filter},
 		ID:      id,
 	}
 }


### PR DESCRIPTION
## Description

`eth_getLogs` RPC method will call 10,000 blocks per request and only return logs for the address specified, thus improving the performance when backfilling a contract

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)
- [x] Performance improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
