### PR TITLE
perf: implement a faster from-scratch sync

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -116,7 +116,7 @@ var runDatabaseCmd = &cobra.Command{
 
 		precommitProcessors.LoadPrecommitProcessors(sm, grm, l)
 
-		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/cmd/debugger.go
+++ b/cmd/debugger.go
@@ -118,7 +118,7 @@ var runDebuggerCmd = &cobra.Command{
 
 		precommitProcessors.LoadPrecommitProcessors(sm, grm, l)
 
-		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -113,7 +113,7 @@ func main() {
 
 	precommitProcessors.LoadPrecommitProcessors(sm, grm, l)
 
-	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 	cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/cmd/operatorRestakedStrategies.go
+++ b/cmd/operatorRestakedStrategies.go
@@ -88,7 +88,7 @@ var runOperatorRestakedStrategiesCmd = &cobra.Command{
 
 		precommitProcessors.LoadPrecommitProcessors(sm, grm, l)
 
-		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,9 @@ func init() {
 	rootCmd.PersistentFlags().Bool(config.EthereumRpcUseNativeBatchCall, true, `Use the native eth_call method for batch calls`)
 	rootCmd.PersistentFlags().Int(config.EthereumRpcNativeBatchCallSize, 500, `The number of calls to batch together when using the native eth_call method`)
 	rootCmd.PersistentFlags().Int(config.EthereumRpcChunkedBatchCallSize, 10, `The number of calls to make in parallel when using the chunked batch call method`)
-	rootCmd.PersistentFlags().Bool(config.EthereumUseGetBlockReceipts, false, `Use the eth_getBlockReceipts method to fetch transaction receipts. Requires geth, erigon or other compatible node`)
+
+	// TODO(seanmcgary): if we ever expand the sidecar to more than just ethereum, we'll need to check and see if this flag is supported by the target chain
+	rootCmd.PersistentFlags().Bool(config.EthereumUseGetBlockReceipts, true, `Use the eth_getBlockReceipts method to fetch transaction receipts. Requires geth, erigon or other compatible node`)
 	rootCmd.PersistentFlags().String(config.EthereumLatestBlockType, "safe", `The type of latest block to use (safe, latest)`)
 
 	rootCmd.PersistentFlags().String(config.DatabaseHost, "localhost", `PostgreSQL host`)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -148,7 +148,7 @@ var runCmd = &cobra.Command{
 		}
 
 		precommitProcessors.LoadPrecommitProcessors(sm, grm, l)
-		
+
 		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -148,8 +148,8 @@ var runCmd = &cobra.Command{
 		}
 
 		precommitProcessors.LoadPrecommitProcessors(sm, grm, l)
-
-		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+		
+		fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 		cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, cfg.EthereumRpcConfig.ContractCallBatchSize, l)
 

--- a/examples/transactionBackfiller/main.go
+++ b/examples/transactionBackfiller/main.go
@@ -70,7 +70,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
-	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 	return cfg, l, fetchr, mds, cm, nil
 

--- a/pkg/clients/ethereum/client.go
+++ b/pkg/clients/ethereum/client.go
@@ -278,7 +278,7 @@ func (c *Client) GetBlockTransactionReceipts(ctx context.Context, blockNumber ui
 }
 
 func (c *Client) GetLogs(ctx context.Context, address string, fromBlock uint64, toBlock uint64) ([]*EthereumEventLog, error) {
-	c.Logger.Sugar().Infow("GetLogs",
+	c.Logger.Sugar().Debugw("GetLogs",
 		zap.String("address", address),
 		zap.Uint64("fromBlock", fromBlock),
 		zap.Uint64("toBlock", toBlock),

--- a/pkg/contractStore/contractStore.go
+++ b/pkg/contractStore/contractStore.go
@@ -10,7 +10,7 @@ import (
 type ContractStore interface {
 	GetContractForAddress(address string) (*Contract, error)
 	GetProxyContractForAddress(blockNumber uint64, address string) (*ProxyContract, error)
-	GetAllProxyAddressesInString() ([]string, error)
+	ListInterestingContractAddresses() ([]string, error)
 
 	CreateContract(address string, abiJson string, verified bool, bytecodeHash string, matchingContractAddress string, checkedForAbi bool, contractType ContractType) (*Contract, error)
 	FindOrCreateContract(address string, abiJson string, verified bool, bytecodeHash string, matchingContractAddress string, checkedForAbi bool, contractType ContractType) (*Contract, bool, error)

--- a/pkg/contractStore/postgresContractStore/postgresContractStore.go
+++ b/pkg/contractStore/postgresContractStore/postgresContractStore.go
@@ -72,8 +72,8 @@ func (s *PostgresContractStore) GetProxyContractForAddress(blockNumber uint64, a
 	return proxyContract, nil
 }
 
-// GetAllProxyAddressesInString returns all proxy addresses in the database as a slice of strings.
-func (s *PostgresContractStore) GetAllProxyAddressesInString() ([]string, error) {
+// ListInterestingContractAddresses returns all proxy addresses in the database as a slice of strings.
+func (s *PostgresContractStore) ListInterestingContractAddresses() ([]string, error) {
 	var addresses []string
 
 	result := s.Db.Raw(`select distinct(contract_address) from proxy_contracts`).Scan(&addresses)

--- a/pkg/contractStore/postgresContractStore/postgresContractStore_test.go
+++ b/pkg/contractStore/postgresContractStore/postgresContractStore_test.go
@@ -129,7 +129,7 @@ func Test_PostgresContractStore(t *testing.T) {
 		assert.Equal(t, proxyContract.ProxyContractAddress, proxy.ProxyContractAddress)
 	})
 	t.Run("Get all proxy addresses in string", func(t *testing.T) {
-		addresses, err := cs.GetAllProxyAddressesInString()
+		addresses, err := cs.ListInterestingContractAddresses()
 		assert.Nil(t, err)
 		assert.True(t, len(addresses) > 0)
 		assert.Contains(t, addresses, createdContracts[0].ContractAddress)

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -303,8 +303,8 @@ func (f *Fetcher) FetchLogsForContractsForBlockRange(ctx context.Context, startB
 	return blockNumbers, err
 }
 
-func (f *Fetcher) FetchFilteredBlocksWithRetries(ctx context.Context, startBlockInclusive uint64, endBlockInclusive uint64) ([]*FetchedBlock, error) {
-	f.Logger.Sugar().Debugw("Fetching filtered blocks with retries",
+func (f *Fetcher) FetchFilteredBlocks(ctx context.Context, startBlockInclusive uint64, endBlockInclusive uint64) ([]*FetchedBlock, error) {
+	f.Logger.Sugar().Debugw("Fetching filtered blocks",
 		zap.Uint64("startBlock", startBlockInclusive),
 		zap.Uint64("endBlock", endBlockInclusive),
 	)

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -164,14 +164,9 @@ func (idx *Indexer) ParseInterestingTransactionsAndLogs(ctx context.Context, fet
 	for i, tx := range fetchedBlock.Block.Transactions {
 		txReceipt, ok := fetchedBlock.TxReceipts[tx.Hash.Value()]
 		if !ok {
+			// When fetching blocks, we only get the receipts that are interesting to us
+			// so its entirely expected that some transactions will not have a receipt.
 			continue
-			// idx.Logger.Sugar().Errorw("Receipt not found for transaction",
-			// 	zap.String("txHash", tx.Hash.Value()),
-			// 	zap.Uint64("block", tx.BlockNumber.Value()),
-			// )
-			// return nil, NewIndexError(IndexError_ReceiptNotFound, fmt.Errorf("receipt not found for transaction")).
-			// 	WithBlockNumber(tx.BlockNumber.Value()).
-			// 	WithTransactionHash(tx.Hash.Value())
 		}
 
 		parsedTransactionAndLogs, err := idx.ParseTransactionLogs(tx, txReceipt)

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -164,13 +164,14 @@ func (idx *Indexer) ParseInterestingTransactionsAndLogs(ctx context.Context, fet
 	for i, tx := range fetchedBlock.Block.Transactions {
 		txReceipt, ok := fetchedBlock.TxReceipts[tx.Hash.Value()]
 		if !ok {
-			idx.Logger.Sugar().Errorw("Receipt not found for transaction",
-				zap.String("txHash", tx.Hash.Value()),
-				zap.Uint64("block", tx.BlockNumber.Value()),
-			)
-			return nil, NewIndexError(IndexError_ReceiptNotFound, fmt.Errorf("receipt not found for transaction")).
-				WithBlockNumber(tx.BlockNumber.Value()).
-				WithTransactionHash(tx.Hash.Value())
+			continue
+			// idx.Logger.Sugar().Errorw("Receipt not found for transaction",
+			// 	zap.String("txHash", tx.Hash.Value()),
+			// 	zap.Uint64("block", tx.BlockNumber.Value()),
+			// )
+			// return nil, NewIndexError(IndexError_ReceiptNotFound, fmt.Errorf("receipt not found for transaction")).
+			// 	WithBlockNumber(tx.BlockNumber.Value()).
+			// 	WithTransactionHash(tx.Hash.Value())
 		}
 
 		parsedTransactionAndLogs, err := idx.ParseTransactionLogs(tx, txReceipt)
@@ -250,7 +251,7 @@ func (idx *Indexer) IsInterestingAddress(addr string) bool {
 		return true
 	}
 
-	addresses, err := idx.ContractStore.GetAllProxyAddressesInString()
+	addresses, err := idx.ContractStore.ListInterestingContractAddresses()
 	if err != nil {
 		return false
 	}

--- a/pkg/indexer/restakedStrategies_test.go
+++ b/pkg/indexer/restakedStrategies_test.go
@@ -88,7 +88,7 @@ func Test_IndexerRestakedStrategies(t *testing.T) {
 
 	mds := pgStorage.NewPostgresBlockStore(grm, l, cfg)
 
-	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 	mccc := multicallContractCaller.NewMulticallContractCaller(client, l)
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -601,7 +601,7 @@ func (p *Pipeline) RunForBlockBatch(ctx context.Context, startBlock uint64, endB
 	fetchSpan.SetTag("end_block", endBlock)
 	fetchStartTime := time.Now()
 
-	fetchedBlocks, err := p.Fetcher.FetchFilteredBlocksWithRetries(fetchCtx, startBlock, endBlock)
+	fetchedBlocks, err := p.Fetcher.FetchFilteredBlocks(fetchCtx, startBlock, endBlock)
 
 	fetchDuration := time.Since(fetchStartTime)
 	fetchSpan.SetTag("duration_ms", fetchDuration.Milliseconds())

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -601,7 +601,7 @@ func (p *Pipeline) RunForBlockBatch(ctx context.Context, startBlock uint64, endB
 	fetchSpan.SetTag("end_block", endBlock)
 	fetchStartTime := time.Now()
 
-	fetchedBlocks, err := p.Fetcher.FetchBlocksWithRetries(fetchCtx, startBlock, endBlock)
+	fetchedBlocks, err := p.Fetcher.FetchFilteredBlocksWithRetries(fetchCtx, startBlock, endBlock)
 
 	fetchDuration := time.Since(fetchStartTime)
 	fetchSpan.SetTag("duration_ms", fetchDuration.Milliseconds())

--- a/pkg/pipeline/pipelineIntegration_test.go
+++ b/pkg/pipeline/pipelineIntegration_test.go
@@ -120,7 +120,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	rcq := rewardsCalculatorQueue.NewRewardsCalculatorQueue(rc, l)
 
-	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 	cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, 10, l)
 

--- a/pkg/providers/interfaces.go
+++ b/pkg/providers/interfaces.go
@@ -1,0 +1,5 @@
+package providers
+
+type InterestingContractsProvider interface {
+	ListInterestingContractAddresses() ([]string, error)
+}

--- a/pkg/sidecar/blockIndexer.go
+++ b/pkg/sidecar/blockIndexer.go
@@ -352,7 +352,7 @@ func (s *Sidecar) IndexFromCurrentToTip(ctx context.Context) error {
 		}
 		tip := currentTip.Load()
 
-		batchEndBlock := int64(currentBlock + 100)
+		batchEndBlock := int64(currentBlock + 200)
 		if batchEndBlock > int64(tip) {
 			batchEndBlock = int64(tip)
 		}

--- a/pkg/startupJobs/202505092016_fixRewardsClaimedTransactions/job_test.go
+++ b/pkg/startupJobs/202505092016_fixRewardsClaimedTransactions/job_test.go
@@ -82,7 +82,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 		l.Sugar().Fatalw("Failed to load meta state models", zap.Error(err))
 	}
 
-	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 	cc := sequentialContractCaller.NewSequentialContractCaller(client, cfg, 10, l)
 

--- a/pkg/transactionBackfiller/backfiller_test.go
+++ b/pkg/transactionBackfiller/backfiller_test.go
@@ -75,7 +75,7 @@ func setup(ethConfig *ethereum.EthereumClientConfig) (
 
 	cm := contractManager.NewContractManager(grm, contractStore, client, af, l)
 
-	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, l)
+	fetchr := fetcher.NewFetcher(client, &fetcher.FetcherConfig{UseGetBlockReceipts: cfg.EthereumRpcConfig.UseGetBlockReceipts}, contractStore, l)
 
 	return cfg, l, fetchr, mds, grm, cm, dbname, nil
 


### PR DESCRIPTION
## Description

Use `eth_getLogs` to only get logs that are interesting to use. This allows us to skip fetching transaction receipts that we dont need saving us on RPC requests and data transfer.

## Type of change

- [x] Performance improvement

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
