### PR TITLE
fix: when getting claimable rewards, account for retroactive rewards correctly

### DIFF
--- a/pkg/rpcServer/rewardsHandlers.go
+++ b/pkg/rpcServer/rewardsHandlers.go
@@ -369,7 +369,6 @@ func (rpc *RpcServer) GetSummarizedRewardsForEarner(ctx context.Context, req *re
 
 	return &rewardsV1.GetSummarizedRewardsForEarnerResponse{
 		Rewards: utils.Map(summarizedRewards, func(r *rewardsDataService.SummarizedReward, i uint64) *rewardsV1.SummarizedEarnerReward {
-
 			return &rewardsV1.SummarizedEarnerReward{
 				Token:     r.Token,
 				Earned:    withDefaultValue(r.Earned, "0"),


### PR DESCRIPTION
## Description

Related to #331.

When calculating claimable rewards, we should not include any rewards associated to reward hashes that may have been retroactively created for past snapshots since this causes the claimable amount to be inaccurate.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests and manual verification

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
