### PR TITLE
refactor: use reward_hash filterfor GetRewardsByAvsForDistributionRoot, add pagination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.8.0
+	github.com/Layr-Labs/protocol-apis v1.9.0
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab h1:O3mHv0T
 github.com/Layr-Labs/protobuf-libs v0.0.0-20250305032038-8d1047b56aab/go.mod h1:xc4NKuzjHpf6Xr9EnI7r6Uc99B1it1bkzQH6kJvhtW4=
 github.com/Layr-Labs/protocol-apis v1.8.0 h1:1rMy6IVrghq9d85uZSnI3uNLAbA+C9oyxynGVielDzU=
 github.com/Layr-Labs/protocol-apis v1.8.0/go.mod h1:rseFsoIl5XDZNaAioipXlaf2F51Onu2tQhxac7glIrg=
+github.com/Layr-Labs/protocol-apis v1.8.1-0.20250423132653-75351e4aef49 h1:VHv6StlvAL/bS1a8sgYRZ9xkVP3YK62L292Fu7eh024=
+github.com/Layr-Labs/protocol-apis v1.8.1-0.20250423132653-75351e4aef49/go.mod h1:rseFsoIl5XDZNaAioipXlaf2F51Onu2tQhxac7glIrg=
+github.com/Layr-Labs/protocol-apis v1.9.0 h1:1pYNAUwWbYsT+7KQAYQeRvIe+q2q1VF52p7f81JUXnM=
+github.com/Layr-Labs/protocol-apis v1.9.0/go.mod h1:rseFsoIl5XDZNaAioipXlaf2F51Onu2tQhxac7glIrg=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/pkg/rpcServer/rewardsHandlers.go
+++ b/pkg/rpcServer/rewardsHandlers.go
@@ -8,6 +8,7 @@ import (
 	rewardsV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/rewards"
 	"github.com/Layr-Labs/sidecar/pkg/metaState/types"
 	"github.com/Layr-Labs/sidecar/pkg/rewards"
+	"github.com/Layr-Labs/sidecar/pkg/rewards/rewardsTypes"
 	"github.com/Layr-Labs/sidecar/pkg/rewardsCalculatorQueue"
 	"github.com/Layr-Labs/sidecar/pkg/service/rewardsDataService"
 	serviceTypes "github.com/Layr-Labs/sidecar/pkg/service/types"
@@ -555,10 +556,10 @@ func (s *RpcServer) ListEarnerLifetimeRewards(ctx context.Context, request *rewa
 	}
 
 	return &rewardsV1.ListEarnerLifetimeRewardsResponse{
-		Rewards: utils.Map(totalRewards, func(r *rewardsDataService.RewardAmount, i uint64) *rewardsV1.RewardAmount {
+		Rewards: utils.Map(totalRewards, func(r *rewardsTypes.Reward, i uint64) *rewardsV1.RewardAmount {
 			return &rewardsV1.RewardAmount{
 				Token:  r.Token,
-				Amount: r.Amount,
+				Amount: r.CumulativeAmount,
 			}
 		}),
 		// Since we're returning all rewards, there is no next page

--- a/pkg/service/rewardsDataService/rewards.go
+++ b/pkg/service/rewardsDataService/rewards.go
@@ -196,6 +196,11 @@ func (rds *RewardsDataService) GetTotalRewardsForEarner(
 	}
 	earner = strings.ToLower(earner)
 
+	blockHeight, err := rds.BaseDataService.GetCurrentBlockHeightIfNotPresent(ctx, blockHeight)
+	if err != nil {
+		return nil, err
+	}
+
 	snapshot, err := rds.findDistributionRootClosestToBlockHeight(blockHeight, claimable)
 	if err != nil {
 		return nil, err

--- a/pkg/service/rewardsDataService/rewards_test.go
+++ b/pkg/service/rewardsDataService/rewards_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/metrics"
 	"github.com/Layr-Labs/sidecar/pkg/postgres"
 	"github.com/Layr-Labs/sidecar/pkg/rewards"
+	"github.com/Layr-Labs/sidecar/pkg/service/types"
 	pgStorage "github.com/Layr-Labs/sidecar/pkg/storage/postgres"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -148,9 +149,20 @@ func Test_RewardsDataService(t *testing.T) {
 	t.Run("Test GetRewardsByAvsForDistributionRoot", func(t *testing.T) {
 		rootIndex := uint64(189)
 
-		r, err := rds.GetRewardsByAvsForDistributionRoot(context.Background(), rootIndex)
+		r, err := rds.GetRewardsByAvsForDistributionRoot(context.Background(), rootIndex, nil)
 		assert.Nil(t, err)
 		assert.NotNil(t, r)
 		assert.True(t, len(r) > 0)
+	})
+	t.Run("Test GetRewardsByAvsForDistributionRoot with pagination", func(t *testing.T) {
+		rootIndex := uint64(189)
+
+		r, err := rds.GetRewardsByAvsForDistributionRoot(context.Background(), rootIndex, &types.Pagination{
+			Page:     0,
+			PageSize: 10,
+		})
+		assert.Nil(t, err)
+		assert.NotNil(t, r)
+		assert.Equal(t, len(r), 10)
 	})
 }


### PR DESCRIPTION
## Description

* Refactored `GetRewardsByAvsForDistributionRoot` to use the reward_hash filter we used to solve #331 .
* This also fixes calls to historical rewards roots so that they only return the records that were applicable to that specific rewards root and not newly added retroactive snapshots for newer reward submissions
* Adds optional pagination to `GetRewardsByAvsForDistributionRoot`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement

## How Has This Been Tested?

Updated tests to cover new pagination functionality. Manually confirmed working by probing the API

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
