### PR TITLE
fix: resolve unique constraint violation on QueuedSlashingWithdrawals

### DIFF
--- a/pkg/eigenState/queuedSlashingWithdrawals/queuedSlashingWithdrawals.go
+++ b/pkg/eigenState/queuedSlashingWithdrawals/queuedSlashingWithdrawals.go
@@ -231,7 +231,11 @@ func (omm *QueuedSlashingWithdrawalModel) CommitFinalState(blockNumber uint64, i
 
 	insertedRecords, err := base.CommitFinalState(recordsToInsert, ignoreInsertConflicts, omm.GetTableName(), omm.DB)
 	if err != nil {
-		omm.logger.Sugar().Errorw("Failed to commit final state", zap.Error(err))
+		omm.logger.Sugar().Errorw("Failed to commit final state",
+			zap.Error(err),
+			zap.Uint64("blockNumber", blockNumber),
+			zap.Any("recordsToInsert", recordsToInsert),
+		)
 		return err
 	}
 	omm.committedState[blockNumber] = insertedRecords

--- a/pkg/postgres/migrations/202504240743_fixQueuedSlashingWithdrawalsPk/up.go
+++ b/pkg/postgres/migrations/202504240743_fixQueuedSlashingWithdrawalsPk/up.go
@@ -1,0 +1,29 @@
+package _202504240743_fixQueuedSlashingWithdrawalsPk
+
+import (
+	"database/sql"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		`alter table queued_slashing_withdrawals drop constraint queued_slashing_withdrawals_pk;`,
+		`alter table queued_slashing_withdrawals add constraint queued_slashing_withdrawals_pk primary key (block_number, log_index, transaction_hash, staker, strategy, operator)`,
+	}
+
+	for _, query := range queries {
+		res := grm.Exec(query)
+		if res.Error != nil {
+			return res.Error
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202504240743_fixQueuedSlashingWithdrawalsPk"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -69,6 +69,7 @@ import (
 	_202503130907_pectraPrunePartTwo "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503130907_pectraPrunePartTwo"
 	_202503171414_slashingWithdrawals "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503171414_slashingWithdrawals"
 	_202503311108_goldRewardHashIndex "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202503311108_goldRewardHashIndex"
+	_202504240743_fixQueuedSlashingWithdrawalsPk "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202504240743_fixQueuedSlashingWithdrawalsPk"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"time"
@@ -209,6 +210,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202503061223_renameConstraint.Migration{},
 		&_202503130907_pectraPrunePartTwo.Migration{},
 		&_202503171414_slashingWithdrawals.Migration{},
+		&_202504240743_fixQueuedSlashingWithdrawalsPk.Migration{},
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Description

The primary key on the QueuedSlashingWithdrawals table was not specific enough given that there are multiple records that come from a single event. 

Originally it was set to:

```sql
queued_slashing_withdrawals_pk primary key (block_number, log_index, transaction_hash)
```

And is now:

```sql
queued_slashing_withdrawals_pk primary key (block_number, log_index, transaction_hash, staker, strategy, operator)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
