### PR TITLE
feat: calculate rewards daily given the flag, instead of using the cronjob

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ func init() {
 
 	rootCmd.PersistentFlags().Bool(config.RewardsValidateRewardsRoot, true, `Validate rewards roots while indexing`)
 	rootCmd.PersistentFlags().Bool(config.RewardsGenerateStakerOperatorsTable, false, `Generate staker operators table while indexing`)
+	rootCmd.PersistentFlags().Bool(config.RewardsCalculateRewardsDaily, false, `Calculate rewards daily while indexing`)
 
 	rootCmd.PersistentFlags().Int("rpc.grpc-port", 7100, `gRPC port`)
 	rootCmd.PersistentFlags().Int("rpc.http-port", 7101, `http rpc port`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,7 @@ type RpcConfig struct {
 type RewardsConfig struct {
 	ValidateRewardsRoot          bool
 	GenerateStakerOperatorsTable bool
+	CalculateRewardsDaily        bool
 }
 
 type StatsdConfig struct {
@@ -201,6 +202,7 @@ var (
 
 	RewardsValidateRewardsRoot          = "rewards.validate_rewards_root"
 	RewardsGenerateStakerOperatorsTable = "rewards.generate_staker_operators_table"
+	RewardsCalculateRewardsDaily        = "rewards.calculate_rewards_daily"
 
 	EthereumRpcBaseUrl               = "ethereum.rpc_url"
 	EthereumRpcContractCallBatchSize = "ethereum.contract_call_batch_size"
@@ -282,6 +284,7 @@ func NewConfig() *Config {
 		Rewards: RewardsConfig{
 			ValidateRewardsRoot:          viper.GetBool(normalizeFlagName(RewardsValidateRewardsRoot)),
 			GenerateStakerOperatorsTable: viper.GetBool(normalizeFlagName(RewardsGenerateStakerOperatorsTable)),
+			CalculateRewardsDaily:        viper.GetBool(normalizeFlagName(RewardsCalculateRewardsDaily)),
 		},
 
 		DataDogConfig: DataDogConfig{

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -121,6 +121,16 @@ func (p *Pipeline) RunForFetchedBlock(ctx context.Context, block *fetcher.Fetche
 		})
 	}()
 
+	// Check if we should calculate daily rewards
+	if p.globalConfig.Rewards.CalculateRewardsDaily && !isBackfill {
+		err := p.CalculateRewardsDaily(ctx, block)
+		if err != nil {
+			p.Logger.Sugar().Errorw("Failed to calculate daily rewards", zap.Uint64("blockNumber", blockNumber), zap.Error(err))
+			hasError = true
+			return err
+		}
+	}
+
 	indexedBlock, found, err := p.Indexer.IndexFetchedBlock(block)
 	if err != nil {
 		p.Logger.Sugar().Errorw("Failed to index block", zap.Uint64("blockNumber", blockNumber), zap.Error(err))
@@ -510,6 +520,59 @@ func (p *Pipeline) RunForBlockBatch(ctx context.Context, startBlock uint64, endB
 			p.Logger.Sugar().Errorw("Failed to run pipeline for fetched block", zap.Uint64("blockNumber", block.Block.Number.Value()), zap.Error(err))
 			return err
 		}
+	}
+
+	return nil
+}
+
+// CalculateRewardsDaily checks if the current block crosses a day boundary (UTC)
+// and if so, queues a reward calculation request. This allows one rewards calculation
+// per day, even when processing multiple days in a batch.
+func (p *Pipeline) CalculateRewardsDaily(ctx context.Context, block *fetcher.FetchedBlock) error {
+	blockNumber := block.Block.Number.Value()
+
+	blockTime := time.Unix(int64(block.Block.Timestamp), 0).UTC()
+
+	// Fast path: Only blocks between midnight and 1 minute past midnight
+	// have a reasonable chance of crossing day boundaries
+	if blockTime.Hour() != 0 || blockTime.Minute() >= 1 {
+		// Most blocks will take this path and exit quickly
+		return nil
+	}
+
+	// Get previous block
+	prevBlock, err := p.Fetcher.FetchBlock(ctx, blockNumber-1)
+	if err != nil {
+		p.Logger.Sugar().Debugw("Failed to fetch previous block for rewards check",
+			zap.Uint64("blockNumber", blockNumber-1),
+			zap.Error(err))
+		return err
+	}
+
+	// Get previous block time in UTC
+	prevBlockTime := time.Unix(int64(prevBlock.Block.Timestamp), 0).UTC()
+
+	// Check if we've crossed a day boundary
+	if prevBlockTime.Day() != blockTime.Day() {
+
+		// Format today's date as cutoff date (YYYY-MM-DD)
+		cutoffDate := blockTime.Format(time.DateOnly)
+
+		p.Logger.Sugar().Infow("Day boundary crossed, queueing daily rewards calculation",
+			zap.Uint64("blockNumber", blockNumber),
+			zap.String("prevBlockTime", prevBlockTime.Format(time.RFC3339)),
+			zap.String("blockTime", blockTime.Format(time.RFC3339)),
+			zap.String("cutoffDate", cutoffDate),
+		)
+
+		// Queue up a rewards generation request (non-blocking)
+		p.rcq.Enqueue(&rewardsCalculatorQueue.RewardsCalculationMessage{
+			Data: rewardsCalculatorQueue.RewardsCalculationData{
+				CalculationType: rewardsCalculatorQueue.RewardsCalculationType_CalculateRewards,
+				CutoffDate:      cutoffDate,
+			},
+			ResponseChan: make(chan *rewardsCalculatorQueue.RewardsCalculatorResponse),
+		})
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Currently, sidecar users have to run the cronjob to probe the API and calculate rewards daily on their own, but this PR provides a flag during indexing blocks to automatically does the job, given the `--rewards.calculate_rewards_daily` flag.

Fixes #315 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)
- [ ] Performance improvement

## How Has This Been Tested?

Tested the date logic of finding the first block past midnight locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
