### PR TITLE
fix: initialize BaseDataService in NewSlashingDataService constructor

### DIFF
--- a/pkg/service/slashingDataService/slashing.go
+++ b/pkg/service/slashingDataService/slashing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/slashedOperators"
 	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
@@ -26,6 +27,9 @@ func NewSlashingDataService(
 	globalConfig *config.Config,
 ) *SlashingDataService {
 	return &SlashingDataService{
+		BaseDataService: baseDataService.BaseDataService{
+			DB: db,
+		},
 		db:           db,
 		logger:       logger,
 		globalConfig: globalConfig,


### PR DESCRIPTION
## Description

This PR initializes BaseDataService in NewSlashingDataService constructor to fix the 404 issue below.

```
{"level":"info","ts":"2025-04-29T06:00:27.456Z","caller":"rpcServer/server.go:298","msg":"GET /mainnet/v1/slashing/operators/0x5accc90436492f24e6af278569691e2c942a676d/slashing-history","system":"http","method":"GET","path":"/mainnet/v1/slashing/operators/0x5accc90436492f24e6af278569691e2c942a676d/slashing-history","status_code":404,"duration":0.00007872,"pattern":"unknown","grpc.service":"","grpc.method":"","grpc.time_ms":0,"client_ip":"172.29.0.1","client_source":"","client_type":"http"}
```

Fixes #371 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)
- [ ] Performance improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
