### PR TITLE
feat: support indexing latest blocks in real-time

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -614,6 +614,35 @@ func (c *Config) GetModelForks() (ModelForkMap, error) {
 
 }
 
+type BlockType string
+
+const (
+	BlockType_Safe   BlockType = "safe"
+	BlockType_Latest BlockType = "latest"
+)
+
+func (c *Config) GetBlockType() BlockType {
+	switch c.EthereumRpcConfig.BlockType {
+	case "latest":
+		return BlockType_Latest
+	case "safe":
+	default:
+		return BlockType_Safe
+	}
+	return BlockType_Safe
+}
+
+func ConvertStringToBlockType(blockType string) BlockType {
+	switch blockType {
+	case "latest":
+		return BlockType_Latest
+	case "safe":
+	default:
+		return BlockType_Safe
+	}
+	return BlockType_Safe
+}
+
 func (c *Config) GetOperatorRestakedStrategiesStartBlock() uint64 {
 	switch c.Chain {
 	case Chain_Preprod:

--- a/pkg/clients/ethereum/client.go
+++ b/pkg/clients/ethereum/client.go
@@ -24,13 +24,6 @@ const (
 	EIP1967_STORAGE_SLOT = "0x360894A13BA1A3210667C828492DB98DCA3E2076CC3735A920A3CA505D382BBC"
 )
 
-type BlockType string
-
-const (
-	BlockType_Safe   BlockType = "safe"
-	BlockType_Latest BlockType = "latest"
-)
-
 type RequestMethod struct {
 	Name    string
 	Timeout time.Duration
@@ -77,18 +70,7 @@ type EthereumClientConfig struct {
 	UseNativeBatchCall   bool // Use the native eth_call method for batch calls
 	NativeBatchCallSize  int  // Number of calls to put in a single eth_call request
 	ChunkedBatchCallSize int  // Number of calls to make in parallel
-	BlockType            BlockType
-}
-
-func convertStringBlockTypeToBlockType(blockType string) BlockType {
-	switch blockType {
-	case "latest":
-		return BlockType_Latest
-	case "safe":
-	default:
-		return BlockType_Safe
-	}
-	return BlockType_Safe
+	BlockType            config.BlockType
 }
 
 func ConvertGlobalConfigToEthereumConfig(cfg *config.EthereumRpcConfig) *EthereumClientConfig {
@@ -97,7 +79,7 @@ func ConvertGlobalConfigToEthereumConfig(cfg *config.EthereumRpcConfig) *Ethereu
 		UseNativeBatchCall:   cfg.UseNativeBatchCall,
 		NativeBatchCallSize:  cfg.NativeBatchCallSize,
 		ChunkedBatchCallSize: cfg.ChunkedBatchCallSize,
-		BlockType:            convertStringBlockTypeToBlockType(cfg.BlockType),
+		BlockType:            config.ConvertStringToBlockType(cfg.BlockType),
 	}
 }
 
@@ -106,7 +88,7 @@ func DefaultNativeCallEthereumClientConfig() *EthereumClientConfig {
 		UseNativeBatchCall:   true,
 		NativeBatchCallSize:  500,
 		ChunkedBatchCallSize: 25,
-		BlockType:            BlockType_Safe,
+		BlockType:            config.BlockType_Safe,
 	}
 }
 
@@ -115,7 +97,7 @@ func DefaultChunkedCallEthereumClientConfig() *EthereumClientConfig {
 		UseNativeBatchCall:   false,
 		NativeBatchCallSize:  500,
 		ChunkedBatchCallSize: 25,
-		BlockType:            BlockType_Safe,
+		BlockType:            config.BlockType_Safe,
 	}
 }
 
@@ -201,7 +183,7 @@ func (c *Client) GetBlockNumberUint64(ctx context.Context) (uint64, error) {
 
 func (c *Client) GetLatestBlock(ctx context.Context) (uint64, error) {
 	var rpcRequest *RPCRequest
-	if c.clientConfig.BlockType == BlockType_Latest {
+	if c.clientConfig.BlockType == config.BlockType_Latest {
 		rpcRequest = GetLatestBlockRequest(1)
 	} else {
 		rpcRequest = GetSafeBlockRequest(1)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -23,6 +23,13 @@ type BlockStore interface {
 	// @param startBlockNumber: The block number from which to start (inclusive)
 	// @param endBlockNumber: The block number at which to end (inclusive). If 0, it will delete all the corrupted state from the startBlock
 	DeleteCorruptedState(startBlockNumber uint64, endBlockNumber uint64) error
+
+	// FindLastCommonAncestor finds the block whose hash matches the provided parent hash
+	// This is used during reorganization detection to find the divergence point
+	//
+	// @param parentHash: The parent hash of the current block
+	// @return: The block number of the last common ancestor, or 0 if no common ancestor is found
+	FindLastCommonAncestor(parentHash string) (uint64, error)
 }
 
 // Tables.


### PR DESCRIPTION
## Description

This PR supports indexing latest-blocks in real-time. Because these blocks can be "unsafe," reorg can happen. 
- If a reorg is detected (latest tip is behind what we've indexed), we clean up the corrupted state
- We reset our indexing position to the valid block

With these changes, you can now:
1. Index blocks in real-time with the latest (unsafe) blocks when configured for "latest" mode
2. Continue using safe blocks when configured for "safe" mode
3. Handle potential reorgs that might occur when using real-time blocks
This gives you flexibility to choose between real-time indexing (faster but with reorg risk) or safe indexing (slower but more stable) based on your needs.

To use real-time block indexing, you'll need to set the `--ethereum.latest-block-type` configuration parameter to "latest" instead of "safe". 

Fixes #327 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)
- [ ] Performance improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
