### PR TITLE
feat: index transaction's gas data and add backfill for transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -323,6 +323,9 @@ func (idx *Indexer) IndexTransaction(
 		tx.To.Value(),
 		receipt.ContractAddress.Value(),
 		receipt.GetBytecodeHash(),
+		receipt.GasUsed.Value(),
+		receipt.CumulativeGasUsed.Value(),
+		receipt.EffectiveGasPrice.Value(),
 	)
 }
 

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -326,6 +326,7 @@ func (idx *Indexer) IndexTransaction(
 		receipt.GasUsed.Value(),
 		receipt.CumulativeGasUsed.Value(),
 		receipt.EffectiveGasPrice.Value(),
+		false,
 	)
 }
 

--- a/pkg/rpcServer/eventHandlers.go
+++ b/pkg/rpcServer/eventHandlers.go
@@ -2,6 +2,8 @@ package rpcServer
 
 import (
 	"context"
+	"io"
+
 	v1EigenState "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/eigenState"
 	v1EthereumTypes "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/ethereumTypes"
 	v1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/events"
@@ -12,7 +14,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"io"
 )
 
 func (rpc *RpcServer) subscribeToBlocks(ctx context.Context, requestId string, handleBlock func(interface{}) error) error {

--- a/pkg/service/rewardsDataService/rewards_test.go
+++ b/pkg/service/rewardsDataService/rewards_test.go
@@ -3,6 +3,9 @@ package rewardsDataService
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/tests"
 	"github.com/Layr-Labs/sidecar/pkg/logger"
@@ -14,8 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"os"
-	"testing"
 )
 
 func setup() (

--- a/pkg/storage/postgres/storage.go
+++ b/pkg/storage/postgres/storage.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Layr-Labs/sidecar/pkg/parser"
-	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"strings"
 	"time"
+
+	"github.com/Layr-Labs/sidecar/pkg/parser"
+	"github.com/Layr-Labs/sidecar/pkg/storage"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"go.uber.org/zap"
@@ -62,19 +63,25 @@ func (s *PostgresBlockStore) InsertBlockTransaction(
 	to string,
 	contractAddress string,
 	bytecodeHash string,
+	gasUsed uint64,
+	cumulativeGasUsed uint64,
+	effectiveGasPrice uint64,
 ) (*storage.Transaction, error) {
 	to = strings.ToLower(to)
 	from = strings.ToLower(from)
 	contractAddress = strings.ToLower(contractAddress)
 
 	tx := &storage.Transaction{
-		BlockNumber:      blockNumber,
-		TransactionHash:  txHash,
-		TransactionIndex: txIndex,
-		FromAddress:      from,
-		ToAddress:        to,
-		ContractAddress:  contractAddress,
-		BytecodeHash:     bytecodeHash,
+		BlockNumber:       blockNumber,
+		TransactionHash:   txHash,
+		TransactionIndex:  txIndex,
+		FromAddress:       from,
+		ToAddress:         to,
+		ContractAddress:   contractAddress,
+		BytecodeHash:      bytecodeHash,
+		GasUsed:           gasUsed,
+		CumulativeGasUsed: cumulativeGasUsed,
+		EffectiveGasPrice: effectiveGasPrice,
 	}
 
 	result := s.Db.Model(&storage.Transaction{}).Clauses(clause.Returning{}).Create(&tx)

--- a/pkg/storage/postgres/storage_test.go
+++ b/pkg/storage/postgres/storage_test.go
@@ -99,13 +99,16 @@ func Test_PostgresqlBlockstore(t *testing.T) {
 
 		t.Run("InsertBlockTransaction", func(t *testing.T) {
 			tx := storage.Transaction{
-				BlockNumber:      block.Number,
-				TransactionHash:  "txHash",
-				TransactionIndex: 0,
-				FromAddress:      "from",
-				ToAddress:        "to",
-				ContractAddress:  "contractAddress",
-				BytecodeHash:     "bytecodeHash",
+				BlockNumber:       block.Number,
+				TransactionHash:   "txHash",
+				TransactionIndex:  0,
+				FromAddress:       "from",
+				ToAddress:         "to",
+				ContractAddress:   "contractAddress",
+				BytecodeHash:      "bytecodeHash",
+				GasUsed:           1000000,
+				CumulativeGasUsed: 1000000,
+				EffectiveGasPrice: 1000000,
 			}
 			insertedTx, err := blockStore.InsertBlockTransaction(
 				tx.BlockNumber,
@@ -115,6 +118,9 @@ func Test_PostgresqlBlockstore(t *testing.T) {
 				tx.ToAddress,
 				tx.ContractAddress,
 				tx.BytecodeHash,
+				tx.GasUsed,
+				tx.CumulativeGasUsed,
+				tx.EffectiveGasPrice,
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, insertedTx)
@@ -125,18 +131,24 @@ func Test_PostgresqlBlockstore(t *testing.T) {
 			assert.Equal(t, tx.ToAddress, insertedTx.ToAddress)
 			assert.Equal(t, strings.ToLower(tx.ContractAddress), insertedTx.ContractAddress)
 			assert.Equal(t, tx.BytecodeHash, insertedTx.BytecodeHash)
+			assert.Equal(t, tx.GasUsed, insertedTx.GasUsed)
+			assert.Equal(t, tx.CumulativeGasUsed, insertedTx.CumulativeGasUsed)
+			assert.Equal(t, tx.EffectiveGasPrice, insertedTx.EffectiveGasPrice)
 
 			insertedTransactions = append(insertedTransactions, insertedTx)
 		})
 		t.Run("Fail to insert a duplicate transaction", func(t *testing.T) {
 			tx := storage.Transaction{
-				BlockNumber:      block.Number,
-				TransactionHash:  "txHash",
-				TransactionIndex: 0,
-				FromAddress:      "from",
-				ToAddress:        "to",
-				ContractAddress:  "contractAddress",
-				BytecodeHash:     "bytecodeHash",
+				BlockNumber:       block.Number,
+				TransactionHash:   "txHash",
+				TransactionIndex:  0,
+				FromAddress:       "from",
+				ToAddress:         "to",
+				ContractAddress:   "contractAddress",
+				BytecodeHash:      "bytecodeHash",
+				GasUsed:           1000000,
+				CumulativeGasUsed: 1000000,
+				EffectiveGasPrice: 1000000,
 			}
 			_, err := blockStore.InsertBlockTransaction(
 				tx.BlockNumber,
@@ -146,6 +158,9 @@ func Test_PostgresqlBlockstore(t *testing.T) {
 				tx.ToAddress,
 				tx.ContractAddress,
 				tx.BytecodeHash,
+				tx.GasUsed,
+				tx.CumulativeGasUsed,
+				tx.EffectiveGasPrice,
 			)
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), "duplicate key value violates unique constraint")

--- a/pkg/storage/postgres/storage_test.go
+++ b/pkg/storage/postgres/storage_test.go
@@ -121,6 +121,7 @@ func Test_PostgresqlBlockstore(t *testing.T) {
 				tx.GasUsed,
 				tx.CumulativeGasUsed,
 				tx.EffectiveGasPrice,
+				false,
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, insertedTx)
@@ -161,6 +162,7 @@ func Test_PostgresqlBlockstore(t *testing.T) {
 				tx.GasUsed,
 				tx.CumulativeGasUsed,
 				tx.EffectiveGasPrice,
+				false,
 			)
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), "duplicate key value violates unique constraint")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,13 +1,14 @@
 package storage
 
 import (
-	"github.com/Layr-Labs/sidecar/pkg/parser"
 	"time"
+
+	"github.com/Layr-Labs/sidecar/pkg/parser"
 )
 
 type BlockStore interface {
 	InsertBlockAtHeight(blockNumber uint64, hash string, parentHash string, blockTime uint64) (*Block, error)
-	InsertBlockTransaction(blockNumber uint64, txHash string, txIndex uint64, from string, to string, contractAddress string, bytecodeHash string) (*Transaction, error)
+	InsertBlockTransaction(blockNumber uint64, txHash string, txIndex uint64, from string, to string, contractAddress string, bytecodeHash string, gasUsed uint64, cumulativeGasUsed uint64, effectiveGasPrice uint64) (*Transaction, error)
 	InsertTransactionLog(txHash string, transactionIndex uint64, blockNumber uint64, log *parser.DecodedLog, outputData map[string]interface{}, ignoreOnConflict bool) (*TransactionLog, error)
 	GetLatestBlock() (*Block, error)
 	GetBlockByNumber(blockNumber uint64) (*Block, error)
@@ -36,16 +37,19 @@ type Block struct {
 }
 
 type Transaction struct {
-	BlockNumber      uint64
-	TransactionHash  string
-	TransactionIndex uint64
-	FromAddress      string
-	ToAddress        string
-	ContractAddress  string
-	BytecodeHash     string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	DeletedAt        time.Time
+	BlockNumber       uint64
+	TransactionHash   string
+	TransactionIndex  uint64
+	FromAddress       string
+	ToAddress         string
+	ContractAddress   string
+	BytecodeHash      string
+	GasUsed           uint64
+	CumulativeGasUsed uint64
+	EffectiveGasPrice uint64
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         time.Time
 }
 
 type TransactionLog struct {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -8,7 +8,7 @@ import (
 
 type BlockStore interface {
 	InsertBlockAtHeight(blockNumber uint64, hash string, parentHash string, blockTime uint64) (*Block, error)
-	InsertBlockTransaction(blockNumber uint64, txHash string, txIndex uint64, from string, to string, contractAddress string, bytecodeHash string, gasUsed uint64, cumulativeGasUsed uint64, effectiveGasPrice uint64) (*Transaction, error)
+	InsertBlockTransaction(blockNumber uint64, txHash string, txIndex uint64, from string, to string, contractAddress string, bytecodeHash string, gasUsed uint64, cumulativeGasUsed uint64, effectiveGasPrice uint64, ignoreOnConflict bool) (*Transaction, error)
 	InsertTransactionLog(txHash string, transactionIndex uint64, blockNumber uint64, log *parser.DecodedLog, outputData map[string]interface{}, ignoreOnConflict bool) (*TransactionLog, error)
 	GetLatestBlock() (*Block, error)
 	GetBlockByNumber(blockNumber uint64) (*Block, error)

--- a/pkg/transactionBackfiller/backfiller.go
+++ b/pkg/transactionBackfiller/backfiller.go
@@ -386,33 +386,6 @@ func (t *TransactionBackfiller) ProcessBlock(ctx context.Context, blockNumber ui
 func (t *TransactionBackfiller) ProcessBlocksWithAddresses(ctx context.Context, queueMessage *BackfillerMessage) *BackfillerResponse {
 	response := &BackfillerResponse{}
 
-	// Validate that proper handlers are provided based on what we're backfilling
-	if !queueMessage.BackfillTransactionsOnly {
-		if queueMessage.TransactionLogHandler == nil {
-			return &BackfillerResponse{
-				Errors: []error{fmt.Errorf("TransactionLogHandler is required when backfilling logs")},
-			}
-		}
-		if queueMessage.IsInterestingLog == nil {
-			return &BackfillerResponse{
-				Errors: []error{fmt.Errorf("IsInterestingLog is required when backfilling logs")},
-			}
-		}
-	}
-
-	if !queueMessage.BackfillLogsOnly {
-		if queueMessage.TransactionHandler == nil {
-			return &BackfillerResponse{
-				Errors: []error{fmt.Errorf("TransactionHandler is required when backfilling transactions")},
-			}
-		}
-		if queueMessage.IsInterestingTransaction == nil {
-			return &BackfillerResponse{
-				Errors: []error{fmt.Errorf("IsInterestingTransaction is required when backfilling transactions")},
-			}
-		}
-	}
-
 	_, logs, err := t.fetcher.FetchInterestingBlocksAndLogsForContractsForBlockRange(ctx, queueMessage.StartBlock, queueMessage.EndBlock, queueMessage.Addresses)
 	if err != nil {
 		t.logger.Sugar().Errorw("Error fetching interesting blocks and logs", zap.Error(err))

--- a/pkg/transactionBackfiller/backfiller.go
+++ b/pkg/transactionBackfiller/backfiller.go
@@ -37,6 +37,14 @@ type BackfillerMessage struct {
 	TransactionLogHandler func(block *ethereum.EthereumBlock, receipt *ethereum.EthereumTransactionReceipt, log *ethereum.EthereumEventLog) error
 	// IsInterestingLog determines if a log should be processed
 	IsInterestingLog func(log *ethereum.EthereumEventLog) bool
+	// TransactionHandler is a function called for each interesting transaction
+	TransactionHandler func(block *ethereum.EthereumBlock, receipt *ethereum.EthereumTransactionReceipt) error
+	// IsInterestingTransaction determines if a transaction should be processed
+	IsInterestingTransaction func(receipt *ethereum.EthereumTransactionReceipt) bool
+	// BackfillLogsOnly indicates if only logs should be backfilled (no transactions)
+	BackfillLogsOnly bool
+	// BackfillTransactionsOnly indicates if only transactions should be backfilled (no logs)
+	BackfillTransactionsOnly bool
 	// ResponseChan is a channel to send the backfill response
 	ResponseChan chan *BackfillerResponse
 	// Context is the context for the backfill operation
@@ -215,6 +223,33 @@ func (t *TransactionBackfiller) Process() {
 func (t *TransactionBackfiller) ProcessBlocks(ctx context.Context, queueMessage *BackfillerMessage) *BackfillerResponse {
 	response := &BackfillerResponse{}
 
+	// Validate that proper handlers are provided based on what we're backfilling
+	if !queueMessage.BackfillTransactionsOnly {
+		if queueMessage.TransactionLogHandler == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("TransactionLogHandler is required when backfilling logs")},
+			}
+		}
+		if queueMessage.IsInterestingLog == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("IsInterestingLog is required when backfilling logs")},
+			}
+		}
+	}
+
+	if !queueMessage.BackfillLogsOnly {
+		if queueMessage.TransactionHandler == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("TransactionHandler is required when backfilling transactions")},
+			}
+		}
+		if queueMessage.IsInterestingTransaction == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("IsInterestingTransaction is required when backfilling transactions")},
+			}
+		}
+	}
+
 	// If addresses are specified, use the optimized method
 	if len(queueMessage.Addresses) > 0 {
 		return t.ProcessBlocksWithAddresses(ctx, queueMessage)
@@ -304,11 +339,12 @@ func (t *TransactionBackfiller) ProcessBlock(ctx context.Context, blockNumber ui
 	)
 
 	for txHash, receipt := range block.TxReceipts {
-		for _, log := range receipt.Logs {
-			if message.IsInterestingLog(log) {
-				err = message.TransactionLogHandler(block.Block, receipt, log)
+		// Process full transactions if we're not only processing logs
+		if !message.BackfillLogsOnly && message.TransactionHandler != nil && message.IsInterestingTransaction != nil {
+			if message.IsInterestingTransaction(receipt) {
+				err = message.TransactionHandler(block.Block, receipt)
 				if err != nil {
-					t.logger.Sugar().Errorw("Error processing transaction log",
+					t.logger.Sugar().Errorw("Error processing transaction",
 						zap.Error(err),
 						zap.String("txHash", txHash),
 						zap.Uint64("blockNumber", blockNumber),
@@ -317,11 +353,28 @@ func (t *TransactionBackfiller) ProcessBlock(ctx context.Context, blockNumber ui
 				}
 			}
 		}
+
+		// Process logs if we're not only processing transactions
+		if !message.BackfillTransactionsOnly && message.TransactionLogHandler != nil && message.IsInterestingLog != nil {
+			for _, log := range receipt.Logs {
+				if message.IsInterestingLog(log) {
+					err = message.TransactionLogHandler(block.Block, receipt, log)
+					if err != nil {
+						t.logger.Sugar().Errorw("Error processing transaction log",
+							zap.Error(err),
+							zap.String("txHash", txHash),
+							zap.Uint64("blockNumber", blockNumber),
+						)
+						return err
+					}
+				}
+			}
+		}
 	}
 	return nil
 }
 
-// ProcessBlocksWithAddresses processes logs for specified addresses within a block range.
+// ProcessBlocksWithAddresses processes logs and transactions for specified addresses within a block range.
 // It uses eth_getLogs RPC call to efficiently fetch logs for specific addresses.
 //
 // Parameters:
@@ -329,9 +382,36 @@ func (t *TransactionBackfiller) ProcessBlock(ctx context.Context, blockNumber ui
 //   - queueMessage: The backfill message containing the block range, addresses, and handlers
 //
 // Returns:
-//   - *BackfillerResponse: The result of processing the logs
+//   - *BackfillerResponse: The result of processing the logs and transactions
 func (t *TransactionBackfiller) ProcessBlocksWithAddresses(ctx context.Context, queueMessage *BackfillerMessage) *BackfillerResponse {
 	response := &BackfillerResponse{}
+
+	// Validate that proper handlers are provided based on what we're backfilling
+	if !queueMessage.BackfillTransactionsOnly {
+		if queueMessage.TransactionLogHandler == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("TransactionLogHandler is required when backfilling logs")},
+			}
+		}
+		if queueMessage.IsInterestingLog == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("IsInterestingLog is required when backfilling logs")},
+			}
+		}
+	}
+
+	if !queueMessage.BackfillLogsOnly {
+		if queueMessage.TransactionHandler == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("TransactionHandler is required when backfilling transactions")},
+			}
+		}
+		if queueMessage.IsInterestingTransaction == nil {
+			return &BackfillerResponse{
+				Errors: []error{fmt.Errorf("IsInterestingTransaction is required when backfilling transactions")},
+			}
+		}
+	}
 
 	_, logs, err := t.fetcher.FetchInterestingBlocksAndLogsForContractsForBlockRange(ctx, queueMessage.StartBlock, queueMessage.EndBlock, queueMessage.Addresses)
 	if err != nil {
@@ -367,6 +447,19 @@ func (t *TransactionBackfiller) ProcessBlocksWithAddresses(ctx context.Context, 
 
 		// Add this log to the block's logs
 		blockLogs.logs = append(blockLogs.logs, logWithMetadata)
+	}
+
+	// For transaction backfilling, we need to ensure we process all blocks in the range,
+	// not just those with logs if we're also handling transactions
+	if !queueMessage.BackfillLogsOnly {
+		for blockNum := queueMessage.StartBlock; blockNum <= queueMessage.EndBlock; blockNum++ {
+			if _, exists := blockLogsMap[blockNum]; !exists {
+				blockLogsMap[blockNum] = &blockWithLogs{
+					blockNumber: blockNum,
+					logs:        make([]*LogWithMetadata, 0),
+				}
+			}
+		}
 	}
 
 	// If context is already canceled, fail fast
@@ -434,7 +527,7 @@ func (t *TransactionBackfiller) ProcessBlocksWithAddresses(ctx context.Context, 
 					}
 
 					// Process logs for this block
-					if err := t.processLogsForBlock(queueMessage, blockLogs.logs, fetchedBlock); err != nil {
+					if err := t.processBlockData(queueMessage, blockLogs.logs, fetchedBlock); err != nil {
 						errorsRecv <- err
 						cancelProcessing() // Cancel other workers
 						return
@@ -481,33 +574,53 @@ func (t *TransactionBackfiller) ProcessBlocksWithAddresses(ctx context.Context, 
 	return response
 }
 
-// processLogsForBlock processes all logs for a specific block
-// Returns the first error encountered or nil if all logs are processed successfully
-func (t *TransactionBackfiller) processLogsForBlock(
+// processBlockData processes all logs and transactions for a specific block
+// Returns the first error encountered or nil if all data is processed successfully
+func (t *TransactionBackfiller) processBlockData(
 	queueMessage *BackfillerMessage,
 	logs []*LogWithMetadata,
 	fetchedBlock *fetcher.FetchedBlock,
 ) error {
-	for _, logData := range logs {
-		// Get the transaction receipt from the fetched block
-		receipt, exists := fetchedBlock.TxReceipts[logData.TxHash]
-		if !exists {
-			t.logger.Sugar().Warnw("Transaction receipt not found in block",
-				zap.String("txHash", logData.TxHash),
-				zap.Uint64("blockNumber", fetchedBlock.Block.Number.Value()),
-			)
-			continue
-		}
-
-		// Handle the log
-		if err := queueMessage.TransactionLogHandler(fetchedBlock.Block, receipt, logData.Log); err != nil {
-			t.logger.Sugar().Errorw("Error processing transaction log",
-				zap.Error(err),
-				zap.String("txHash", logData.TxHash),
-				zap.Uint64("blockNumber", fetchedBlock.Block.Number.Value()),
-			)
-			return err
+	// Process transactions if transaction handler is provided and we're not only processing logs
+	if !queueMessage.BackfillLogsOnly && queueMessage.TransactionHandler != nil && queueMessage.IsInterestingTransaction != nil {
+		for txHash, receipt := range fetchedBlock.TxReceipts {
+			if queueMessage.IsInterestingTransaction(receipt) {
+				if err := queueMessage.TransactionHandler(fetchedBlock.Block, receipt); err != nil {
+					t.logger.Sugar().Errorw("Error processing transaction",
+						zap.Error(err),
+						zap.String("txHash", txHash),
+						zap.Uint64("blockNumber", fetchedBlock.Block.Number.Value()),
+					)
+					return err
+				}
+			}
 		}
 	}
+
+	// Process logs if log handler is provided and we're not only processing transactions
+	if !queueMessage.BackfillTransactionsOnly && queueMessage.TransactionLogHandler != nil && queueMessage.IsInterestingLog != nil {
+		for _, logData := range logs {
+			// Get the transaction receipt from the fetched block
+			receipt, exists := fetchedBlock.TxReceipts[logData.TxHash]
+			if !exists {
+				t.logger.Sugar().Warnw("Transaction receipt not found in block",
+					zap.String("txHash", logData.TxHash),
+					zap.Uint64("blockNumber", fetchedBlock.Block.Number.Value()),
+				)
+				continue
+			}
+
+			// Handle the log
+			if err := queueMessage.TransactionLogHandler(fetchedBlock.Block, receipt, logData.Log); err != nil {
+				t.logger.Sugar().Errorw("Error processing transaction log",
+					zap.Error(err),
+					zap.String("txHash", logData.TxHash),
+					zap.Uint64("blockNumber", fetchedBlock.Block.Number.Value()),
+				)
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/transactionBackfiller/backfiller_test.go
+++ b/pkg/transactionBackfiller/backfiller_test.go
@@ -163,6 +163,200 @@ func Test_TransactionBackfiller(t *testing.T) {
 		assert.Equal(t, uint64(1), logsHandled.Load())
 	})
 
+	t.Run("Test backfill transactions only", func(t *testing.T) {
+		bf := NewTransactionBackfiller(&TransactionBackfillerConfig{}, l, fetcher, mds)
+		txsHandled := atomic.Uint64{}
+		txsHandled.Store(0)
+
+		targetAddress := cfg.GetContractsMapForChain().RewardsCoordinator
+
+		message := &BackfillerMessage{
+			StartBlock: 22020900,
+			EndBlock:   22020901,
+			Addresses:  []string{targetAddress},
+			IsInterestingTransaction: func(receipt *ethereum.EthereumTransactionReceipt) bool {
+				// Check if transaction is to our target address
+				if receipt.To.Value() != "" && strings.ToLower(receipt.To.Value()) == targetAddress {
+					return true
+				}
+				return false
+			},
+			TransactionHandler: func(block *ethereum.EthereumBlock, receipt *ethereum.EthereumTransactionReceipt) error {
+				fmt.Printf("Handling transaction: %s to %s\n", receipt.TransactionHash.Value(), receipt.To.Value())
+				txsHandled.Add(1)
+				return nil
+			},
+			BackfillLogsOnly:         false,
+			BackfillTransactionsOnly: true,
+		}
+
+		go bf.Process()
+		defer bf.Close()
+
+		res, err := bf.EnqueueAndWait(context.Background(), message)
+		fmt.Printf("Error: %v\n", err)
+		fmt.Printf("Response: %v\n", res)
+		// We expect at least one transaction to our target address
+		assert.GreaterOrEqual(t, txsHandled.Load(), uint64(1))
+	})
+
+	t.Run("Test backfill both transactions and logs", func(t *testing.T) {
+		bf := NewTransactionBackfiller(&TransactionBackfillerConfig{}, l, fetcher, mds)
+		txsHandled := atomic.Uint64{}
+		txsHandled.Store(0)
+		logsHandled := atomic.Uint64{}
+		logsHandled.Store(0)
+
+		targetAddress := cfg.GetContractsMapForChain().RewardsCoordinator
+		logHandler := &customLogHandler{}
+		logParser := transactionLogParser.NewTransactionLogParser(l, cm, logHandler)
+
+		message := &BackfillerMessage{
+			StartBlock: 22021062,
+			EndBlock:   22021063,
+			Addresses:  []string{targetAddress},
+			IsInterestingLog: func(log *ethereum.EthereumEventLog) bool {
+				return strings.ToLower(log.Address.Value()) == targetAddress
+			},
+			TransactionLogHandler: func(block *ethereum.EthereumBlock, receipt *ethereum.EthereumTransactionReceipt, log *ethereum.EthereumEventLog) error {
+				fmt.Printf("Handling log: %+v\n", receipt)
+				logsHandled.Add(1)
+
+				decodedLog, err := logParser.DecodeLogWithAbi(nil, receipt, log)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Decoded log: %+v\n", decodedLog)
+				return nil
+			},
+			IsInterestingTransaction: func(receipt *ethereum.EthereumTransactionReceipt) bool {
+				// Check if transaction is to our target address
+				if receipt.To.Value() != "" && strings.ToLower(receipt.To.Value()) == targetAddress {
+					return true
+				}
+				return false
+			},
+			TransactionHandler: func(block *ethereum.EthereumBlock, receipt *ethereum.EthereumTransactionReceipt) error {
+				fmt.Printf("Handling transaction: %s to %s\n", receipt.TransactionHash.Value(), receipt.To.Value())
+				txsHandled.Add(1)
+				return nil
+			},
+			BackfillLogsOnly:         false,
+			BackfillTransactionsOnly: false,
+		}
+
+		go bf.Process()
+		defer bf.Close()
+
+		res, err := bf.EnqueueAndWait(context.Background(), message)
+		fmt.Printf("Error: %v\n", err)
+		fmt.Printf("Response: %v\n", res)
+
+		// We expect both logs and transactions to be processed
+		assert.GreaterOrEqual(t, txsHandled.Load(), uint64(1))
+		assert.GreaterOrEqual(t, logsHandled.Load(), uint64(1))
+	})
+
+	t.Run("Test error handling with missing transaction handler", func(t *testing.T) {
+		bf := NewTransactionBackfiller(&TransactionBackfillerConfig{}, l, fetcher, mds)
+
+		// Create a backfill message with transaction mode but no transaction handler
+		message := &BackfillerMessage{
+			StartBlock: 22020900,
+			EndBlock:   22020901,
+			IsInterestingTransaction: func(receipt *ethereum.EthereumTransactionReceipt) bool {
+				return true
+			},
+			// Missing TransactionHandler
+			BackfillLogsOnly:         false,
+			BackfillTransactionsOnly: true,
+		}
+
+		go bf.Process()
+		defer bf.Close()
+
+		res, err := bf.EnqueueAndWait(context.Background(), message)
+
+		// Expect an error because TransactionHandler is missing
+		assert.Nil(t, err)
+		assert.NotNil(t, res)
+		assert.NotEmpty(t, res.Errors)
+		assert.Contains(t, res.Errors[0].Error(), "TransactionHandler is required")
+	})
+
+	t.Run("Test error handling with missing transaction filter", func(t *testing.T) {
+		bf := NewTransactionBackfiller(&TransactionBackfillerConfig{}, l, fetcher, mds)
+
+		// Create a backfill message with transaction mode but no IsInterestingTransaction filter
+		message := &BackfillerMessage{
+			StartBlock: 22020900,
+			EndBlock:   22020901,
+			TransactionHandler: func(block *ethereum.EthereumBlock, receipt *ethereum.EthereumTransactionReceipt) error {
+				return nil
+			},
+			// Missing IsInterestingTransaction filter
+			BackfillLogsOnly:         false,
+			BackfillTransactionsOnly: true,
+		}
+
+		go bf.Process()
+		defer bf.Close()
+
+		res, err := bf.EnqueueAndWait(context.Background(), message)
+
+		// Expect an error because IsInterestingTransaction is missing
+		assert.Nil(t, err)
+		assert.NotNil(t, res)
+		assert.NotEmpty(t, res.Errors)
+		assert.Contains(t, res.Errors[0].Error(), "IsInterestingTransaction is required")
+	})
+
+	t.Run("Test backfill logs only", func(t *testing.T) {
+		bf := NewTransactionBackfiller(&TransactionBackfillerConfig{}, l, fetcher, mds)
+		logsHandled := atomic.Uint64{}
+		logsHandled.Store(0)
+
+		targetAddress := cfg.GetContractsMapForChain().RewardsCoordinator
+		logHandler := &customLogHandler{}
+		logParser := transactionLogParser.NewTransactionLogParser(l, cm, logHandler)
+
+		message := &BackfillerMessage{
+			StartBlock: 22021062,
+			EndBlock:   22021063,
+			Addresses:  []string{targetAddress},
+			IsInterestingLog: func(log *ethereum.EthereumEventLog) bool {
+				return strings.ToLower(log.Address.Value()) == targetAddress
+			},
+			TransactionLogHandler: func(block *ethereum.EthereumBlock, receipt *ethereum.EthereumTransactionReceipt, log *ethereum.EthereumEventLog) error {
+				fmt.Printf("Handling log: %+v\n", receipt)
+				logsHandled.Add(1)
+
+				decodedLog, err := logParser.DecodeLogWithAbi(nil, receipt, log)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Decoded log: %+v\n", decodedLog)
+				return nil
+			},
+			// Transaction handlers not required in logs-only mode
+			BackfillLogsOnly:         true,
+			BackfillTransactionsOnly: false,
+		}
+
+		go bf.Process()
+		defer bf.Close()
+
+		res, err := bf.EnqueueAndWait(context.Background(), message)
+		fmt.Printf("Error: %v\n", err)
+		fmt.Printf("Response: %v\n", res)
+
+		// We expect logs to be processed
+		assert.Nil(t, err)
+		assert.NotNil(t, res)
+		assert.Empty(t, res.Errors)
+		assert.GreaterOrEqual(t, logsHandled.Load(), uint64(1))
+	})
+
 	t.Cleanup(func() {
 		postgres.TeardownTestDatabase(dbname, cfg, grm, l)
 	})

--- a/pkg/transactionBackfiller/backfiller_test.go
+++ b/pkg/transactionBackfiller/backfiller_test.go
@@ -114,6 +114,8 @@ func Test_TransactionBackfiller(t *testing.T) {
 				fmt.Printf("Decoded log: %+v\n", decodedLog)
 				return nil
 			},
+			BackfillLogsOnly:         true,
+			BackfillTransactionsOnly: false,
 		}
 
 		go bf.Process()
@@ -152,6 +154,8 @@ func Test_TransactionBackfiller(t *testing.T) {
 				fmt.Printf("Decoded log: %+v\n", decodedLog)
 				return nil
 			},
+			BackfillLogsOnly:         true,
+			BackfillTransactionsOnly: false,
 		}
 
 		go bf.Process()


### PR DESCRIPTION
## Description

`gasUsed`, `cumulativeGasUsed`, and `effectiveGasPrice` is missing from transactions table.

Fixes #382 

Example:
```
blocklake=> select * from sidecar_testnet_holesky.transactions where transaction_hash='0xf412094961e2602876a7f73eb5ea3d56d8177a56153f76aba43dd2157e99ec59';
 block_number |                          transaction_hash                          | transaction_index |                from_address                |                 to_address                 | contract_address |                          bytecode_hash                           | gas_used | cumulative_gas_used | effective_gas_price |         created_at         |         updated_at         |     deleted_at      
--------------+--------------------------------------------------------------------+-------------------+--------------------------------------------+--------------------------------------------+------------------+------------------------------------------------------------------+----------+---------------------+---------------------+----------------------------+----------------------------+---------------------
      3787713 | 0xf412094961e2602876a7f73eb5ea3d56d8177a56153f76aba43dd2157e99ec59 |                13 | 0x91b10ee88b64bb70dc559cdef79cd0f0ba1ef6a5 | 0xa44151489861fe9e3055d95adc98fbd462b948e7 |                  | e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 |          |                     |                     | 2025-05-05 14:08:04.878602 | 2025-05-05 14:08:04.878602 | 0001-01-01 00:00:00
(1 row)
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
