### PR TITLE
feat: add an optional snapshotDate query param to GetSummarizedRewardsForEarner

### DIFF
--- a/docs/docs/api/rewards-get-summarized-rewards-for-earner.api.mdx
+++ b/docs/docs/api/rewards-get-summarized-rewards-for-earner.api.mdx
@@ -51,7 +51,11 @@ GetSummarizedRewardsForEarner returns the summarized rewards for the given earne
 </Heading>
 
 <ParamsDetails
-  parameters={[{"name":"earner_address","in":"path","required":true,"schema":{"type":"string"}}]}
+  parameters={[
+    {"name":"earner_address","in":"path","required":true,"schema":{"type":"string"}},
+    {"name":"block_height","in":"query","required":false,"schema":{"type":"integer"},"description":"Block height to use for calculating rewards. If not provided, the latest block is used."},
+    {"name":"snapshot_date","in":"query","required":false,"schema":{"type":"string"},"description":"Snapshot date in YYYY-MM-DD format. If provided, the minimum block height for that date will be used instead of block_height."}
+  ]}
 >
   
 </ParamsDetails>

--- a/docs/docs/public-api/rewards-get-summarized-rewards-for-earner.api.mdx
+++ b/docs/docs/public-api/rewards-get-summarized-rewards-for-earner.api.mdx
@@ -51,7 +51,11 @@ GetSummarizedRewardsForEarner returns the summarized rewards for the given earne
 </Heading>
 
 <ParamsDetails
-  parameters={[{"name":"earner_address","in":"path","required":true,"schema":{"type":"string"}}]}
+  parameters={[
+    {"name":"earner_address","in":"path","required":true,"schema":{"type":"string"}},
+    {"name":"block_height","in":"query","required":false,"schema":{"type":"integer"},"description":"Block height to use for calculating rewards. If not provided, the latest block is used."},
+    {"name":"snapshot_date","in":"query","required":false,"schema":{"type":"string"},"description":"Snapshot date in YYYY-MM-DD format. If provided, the minimum block height for that date will be used instead of block_height."}
+  ]}
 >
   
 </ParamsDetails>

--- a/docs/docs/public-api/schemas/getsummarizedrewardsforearnerrequest.schema.mdx
+++ b/docs/docs/public-api/schemas/getsummarizedrewardsforearnerrequest.schema.mdx
@@ -6,7 +6,7 @@ sidebar_label: "GetSummarizedRewardsForEarnerRequest"
 hide_title: true
 hide_table_of_contents: true
 schema: true
-sample: {"blockHeight":0,"earnerAddress":"string"}
+sample: {"blockHeight":0,"earnerAddress":"string","snapshotDate":"2023-01-16"}
 custom_edit_url: null
 ---
 
@@ -25,7 +25,7 @@ import Heading from "@theme/Heading";
 
 
 <Schema
-  schema={{"type":"object","properties":{"blockHeight":{"type":"integer","format":"uint64"},"earnerAddress":{"type":"string"}},"required":["block_height"],"title":"GetSummarizedRewardsForEarnerRequest"}}
+  schema={{"type":"object","properties":{"blockHeight":{"type":"integer","format":"uint64","description":"Block height to use for calculating rewards. If not provided, the latest block is used."},"earnerAddress":{"type":"string"},"snapshotDate":{"type":"string","description":"Snapshot date in YYYY-MM-DD format. If provided, the minimum block height for that date will be used instead of block_height."}},"required":["block_height"],"title":"GetSummarizedRewardsForEarnerRequest"}}
   schemaType={"response"}
 >
   

--- a/docs/openapi/api.json
+++ b/docs/openapi/api.json
@@ -1231,6 +1231,25 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "block_height",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64"
+            },
+            "description": "Block height to use for calculating rewards. If not provided, the latest block is used."
+          },
+          {
+            "name": "snapshot_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Snapshot date in YYYY-MM-DD format. If provided, the minimum block height for that date will be used instead of block_height."
           }
         ],
         "responses": {

--- a/docs/openapi/api.public.json
+++ b/docs/openapi/api.public.json
@@ -108,6 +108,25 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "block_height",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64"
+            },
+            "description": "Block height to use for calculating rewards. If not provided, the latest block is used."
+          },
+          {
+            "name": "snapshot_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Snapshot date in YYYY-MM-DD format. If provided, the minimum block height for that date will be used instead of block_height."
           }
         ],
         "responses": {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.13.2
+	github.com/Layr-Labs/protocol-apis v1.14.1-0.20250523180146-9ebe4230a014
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/Layr-Labs/protocol-apis v1.13.1 h1:fnknM3bITUZJovTVGdNgjS9NJeZyFoxu39
 github.com/Layr-Labs/protocol-apis v1.13.1/go.mod h1:tyzQDWHu4/dmBSRKNRXi65wLic3j5B+7YQ8lMQB08aM=
 github.com/Layr-Labs/protocol-apis v1.13.2 h1:WKzw8B0wObbZ9TBb+SuzXsgz+IXIRO2LvNUEkTvtZ0c=
 github.com/Layr-Labs/protocol-apis v1.13.2/go.mod h1:tyzQDWHu4/dmBSRKNRXi65wLic3j5B+7YQ8lMQB08aM=
+github.com/Layr-Labs/protocol-apis v1.14.1-0.20250523180146-9ebe4230a014 h1:Fobe61GmMwq5LsGv4XGlNle28J1wM+kR6JSu8tEiAAk=
+github.com/Layr-Labs/protocol-apis v1.14.1-0.20250523180146-9ebe4230a014/go.mod h1:tyzQDWHu4/dmBSRKNRXi65wLic3j5B+7YQ8lMQB08aM=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/pkg/rpcServer/rewardsHandlers.go
+++ b/pkg/rpcServer/rewardsHandlers.go
@@ -360,9 +360,18 @@ func withDefaultValue(value string, defaultValue string) string {
 func (rpc *RpcServer) GetSummarizedRewardsForEarner(ctx context.Context, req *rewardsV1.GetSummarizedRewardsForEarnerRequest) (*rewardsV1.GetSummarizedRewardsForEarnerResponse, error) {
 	earner := req.GetEarnerAddress()
 	blockHeight := req.GetBlockHeight()
+	snapshotDate := req.GetSnapshotDate()
 
 	if earner == "" {
 		return nil, status.Error(codes.InvalidArgument, "earner address is required")
+	}
+
+	if snapshotDate != "" {
+		var err error
+		blockHeight, err = rpc.rewardsDataService.GetBlockHeightForSnapshotDate(ctx, snapshotDate)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	summarizedRewards, err := rpc.rewardsDataService.GetSummarizedRewards(ctx, earner, nil, blockHeight)

--- a/pkg/service/baseDataService/base.go
+++ b/pkg/service/baseDataService/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/stateManager"
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"gorm.io/gorm"
@@ -48,4 +49,17 @@ func (b *BaseDataService) GetLatestConfirmedBlock(ctx context.Context) (*storage
 	}
 
 	return b.GetBlock(ctx, stateRoot.EthBlockNumber)
+}
+
+func (b *BaseDataService) GetBlockHeightForSnapshotDate(ctx context.Context, snapshotDate string) (uint64, error) {
+	var block storage.Block
+	res := b.DB.Model(&storage.Block{}).
+		Where("to_char(block_time, 'YYYY-MM-DD') = ?", snapshotDate).
+		Order("number ASC").
+		First(&block)
+
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return block.Number, nil
 }

--- a/pkg/service/rewardsDataService/rewards.go
+++ b/pkg/service/rewardsDataService/rewards.go
@@ -425,6 +425,14 @@ func setTokenValueInMap(tokenMap map[string]*SummarizedReward, values []*RewardA
 	}
 }
 
+func (rds *RewardsDataService) GetBlockHeightForSnapshotDate(ctx context.Context, snapshotDate string) (uint64, error) {
+	blockHeight, err := rds.BaseDataService.GetBlockHeightForSnapshotDate(ctx, snapshotDate)
+	if err != nil {
+		return 0, err
+	}
+	return blockHeight, nil
+}
+
 // GetSummarizedRewards returns the summarized rewards for a given earner at a given block height.
 // The blockHeight will be used to find the root that is <= the provided blockHeight
 func (rds *RewardsDataService) GetSummarizedRewards(ctx context.Context, earner string, tokens []string, blockHeight uint64) ([]*SummarizedReward, error) {

--- a/pkg/service/rewardsDataService/rewards_test.go
+++ b/pkg/service/rewardsDataService/rewards_test.go
@@ -174,4 +174,17 @@ func Test_RewardsDataService(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, r)
 	})
+	t.Run("Test GetBlockHeightForSnapshotDate", func(t *testing.T) {
+		// Test with a known date that should exist in the database
+		snapshotDate := "2025-01-16"
+		blockHeight, err := rds.GetBlockHeightForSnapshotDate(context.Background(), snapshotDate)
+		assert.Nil(t, err)
+		assert.Greater(t, blockHeight, uint64(0), "Block height should be greater than 0")
+		fmt.Printf("Block height for snapshot date %s: %d\n", snapshotDate, blockHeight)
+
+		// Test with a snapshot date that should not exist
+		nonExistentDate := "1970-01-01"
+		_, err = rds.GetBlockHeightForSnapshotDate(context.Background(), nonExistentDate)
+		assert.NotNil(t, err, "Should return an error for non-existent date")
+	})
 }


### PR DESCRIPTION
## Description

add an optional snapshotDate query param to GetSummarizedRewardsForEarner

Fixes #396

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Docs (documentation updates)

## How Has This Been Tested?

Added a unit test for `GetBlockHeightForSnapshotDate`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
