### PR TITLE
fix: handling external contracts and etherscan abi fetcher

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -10,8 +10,10 @@ import (
 	"github.com/Layr-Labs/sidecar/internal/version"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
+	"github.com/Layr-Labs/sidecar/pkg/abiSource/etherscan"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource/ipfs"
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
+	etherscanClient "github.com/Layr-Labs/sidecar/pkg/clients/etherscan"
 	sidecarClient "github.com/Layr-Labs/sidecar/pkg/clients/sidecar"
 	"github.com/Layr-Labs/sidecar/pkg/contractManager"
 	"github.com/Layr-Labs/sidecar/pkg/contractStore/postgresContractStore"
@@ -78,7 +80,10 @@ var rpcCmd = &cobra.Command{
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
 		ipfs := ipfs.NewIpfs(ipfs.DefaultHttpClient(), l, cfg)
-		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{ipfs})
+		etherscanClient := etherscanClient.NewEtherscanClient(etherscanClient.DefaultHttpClient(), l, cfg)
+		etherscan := etherscan.NewEtherscan(etherscanClient, l)
+
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{ipfs, etherscan})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,8 +10,10 @@ import (
 	"github.com/Layr-Labs/sidecar/internal/version"
 	"github.com/Layr-Labs/sidecar/pkg/abiFetcher"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource"
+	"github.com/Layr-Labs/sidecar/pkg/abiSource/etherscan"
 	"github.com/Layr-Labs/sidecar/pkg/abiSource/ipfs"
 	"github.com/Layr-Labs/sidecar/pkg/clients/ethereum"
+	etherscanClient "github.com/Layr-Labs/sidecar/pkg/clients/etherscan"
 	sidecarClient "github.com/Layr-Labs/sidecar/pkg/clients/sidecar"
 	"github.com/Layr-Labs/sidecar/pkg/contractCaller/sequentialContractCaller"
 	"github.com/Layr-Labs/sidecar/pkg/contractManager"
@@ -82,7 +84,10 @@ var runCmd = &cobra.Command{
 		client := ethereum.NewClient(ethereum.ConvertGlobalConfigToEthereumConfig(&cfg.EthereumRpcConfig), l)
 
 		ipfs := ipfs.NewIpfs(ipfs.DefaultHttpClient(), l, cfg)
-		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{ipfs})
+		etherscanClient := etherscanClient.NewEtherscanClient(etherscanClient.DefaultHttpClient(), l, cfg)
+		etherscan := etherscan.NewEtherscan(etherscanClient, l)
+
+		af := abiFetcher.NewAbiFetcher(client, abiFetcher.DefaultHttpClient(), l, []abiSource.AbiSource{ipfs, etherscan})
 
 		pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
 

--- a/pkg/abiSource/etherscan/etherscan_test.go
+++ b/pkg/abiSource/etherscan/etherscan_test.go
@@ -49,7 +49,6 @@ func Test_Etherscan(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	mockUrl := "https://api.etherscan.io/api?"
 	mockHttpClient := &http.Client{
 		Transport: httpmock.DefaultTransport,
 	}
@@ -64,7 +63,8 @@ func Test_Etherscan(t *testing.T) {
 			"result": "[{\"constant\":true,\"inputs\":[],\"name\":\"get\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}]"
 		}`
 
-		httpmock.RegisterResponder("GET", mockUrl,
+		// Register the responder with a pattern that matches the full URL with query parameters
+		httpmock.RegisterResponder("GET", `=~^https://api\.etherscan\.io/api\?.*address=0x29a954e9e7f12936db89b183ecdf879fbbb99f14.*`,
 			httpmock.NewStringResponder(200, mockAbiResponse))
 
 		address := "0x29a954e9e7f12936db89b183ecdf879fbbb99f14"
@@ -81,7 +81,8 @@ func Test_Etherscan(t *testing.T) {
 			"result": "Error fetching ABI"
 		}`
 
-		httpmock.RegisterResponder("GET", mockUrl,
+		// Register the responder with a pattern that matches the full URL with query parameters
+		httpmock.RegisterResponder("GET", `=~^https://api\.etherscan\.io/api\?.*address=0x29a954e9e7f12936db89b183ecdf879fbbb99f14.*`,
 			httpmock.NewStringResponder(200, mockErrorResponse))
 
 		address := "0x29a954e9e7f12936db89b183ecdf879fbbb99f14"

--- a/pkg/clients/etherscan/client.go
+++ b/pkg/clients/etherscan/client.go
@@ -42,6 +42,12 @@ func NewEtherscanClient(hc *http.Client, l *zap.Logger, cfg *config.Config) *Eth
 	}
 }
 
+func DefaultHttpClient() *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+	}
+}
+
 func (ec *EtherscanClient) getBaseUrl() (string, error) {
 	var network string
 	switch ec.Config.Chain {
@@ -50,7 +56,7 @@ func (ec *EtherscanClient) getBaseUrl() (string, error) {
 	case config.Chain_Holesky:
 		network = "api-holesky"
 	case config.Chain_Sepolia:
-		network = "sepolia"
+		network = "api-sepolia"
 	case config.Chain_Preprod:
 		network = "api-holesky"
 	default:
@@ -70,7 +76,9 @@ func (ec *EtherscanClient) makeRequest(values url.Values) (*EtherscanResponse, e
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, fullUrl, http.NoBody)
+	fullUrlWithParams := fullUrl + values.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, fullUrlWithParams, http.NoBody)
 	if err != nil {
 		ec.Logger.Sugar().Errorw("Failed to create the Etherscan HTTP request",
 			zap.Error(err),


### PR DESCRIPTION
## Description

Sidecar automatically upgrades for contract addresses that were added manually. However, when corrupted states are deleted, it did not correctly removed rows from proxy_contracts table. This leads to a scenario of "adding proxy contracts twice." Thus, this change makes sure to also delete external contracts during `DeleteCorruptedState`.

Also, etherscan abi fetcher was fixed/added to be fully functional in sepolia.

Fixes #395 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with blocklake-indexer in sepolia env.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
