### PR TITLE
fix: always include schema name for postgres connection

### DIFF
--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -221,6 +221,10 @@ func getPostgresConnectionString(cfg *PostgresConfig) (string, error) {
 		sslMode,
 	)
 
+	if cfg.SchemaName != "" {
+		baseString = fmt.Sprintf("%s search_path=%s", baseString, cfg.SchemaName)
+	}
+
 	if sslMode != defaultSSLMode {
 		if cfg.SSLCert != "" {
 			baseString = fmt.Sprintf("%s sslcert=%s", baseString, cfg.SSLCert)
@@ -230,9 +234,6 @@ func getPostgresConnectionString(cfg *PostgresConfig) (string, error) {
 		}
 		if cfg.SSLRootCert != "" {
 			baseString = fmt.Sprintf("%s sslrootcert=%s", baseString, cfg.SSLRootCert)
-		}
-		if cfg.SchemaName != "" {
-			baseString = fmt.Sprintf("%s search_path=%s", baseString, cfg.SchemaName)
 		}
 	}
 	return baseString, nil


### PR DESCRIPTION
## Description

When initializing postgres, setting a `search_path` was limited to when ssl mode is not disabled. We should always set a search path when schema name is set in the config.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
