### PR TITLE
feat: historical rows for StakerShares api

### DIFF
--- a/docs/docs/public-api/schemas/getstakersharesrequest.schema.mdx
+++ b/docs/docs/public-api/schemas/getstakersharesrequest.schema.mdx
@@ -6,7 +6,7 @@ sidebar_label: "GetStakerSharesRequest"
 hide_title: true
 hide_table_of_contents: true
 schema: true
-sample: {"blockHeight":0,"stakerAddress":"string","strategy":"string","showHistorical":false,"startBlock":0,"endBlock":0}
+sample: {"stakerAddress":"string","strategy":"string","startBlock":0,"endBlock":0}
 custom_edit_url: null
 ---
 
@@ -25,7 +25,7 @@ import Heading from "@theme/Heading";
 
 
 <Schema
-  schema={{"type":"object","properties":{"blockHeight":{"type":"integer","format":"uint64"},"stakerAddress":{"type":"string"},"strategy":{"type":"string"},"showHistorical":{"type":"boolean"},"startBlock":{"type":"integer","format":"uint64"},"endBlock":{"type":"integer","format":"uint64"}},"title":"GetStakerSharesRequest"}}
+  schema={{"type":"object","properties":{"stakerAddress":{"type":"string"},"strategy":{"type":"string"},"startBlock":{"type":"integer","format":"uint64"},"endBlock":{"type":"integer","format":"uint64"}},"title":"GetStakerSharesRequest"}}
   schemaType={"response"}
 >
   

--- a/docs/docs/public-api/schemas/getstakersharesrequest.schema.mdx
+++ b/docs/docs/public-api/schemas/getstakersharesrequest.schema.mdx
@@ -6,7 +6,7 @@ sidebar_label: "GetStakerSharesRequest"
 hide_title: true
 hide_table_of_contents: true
 schema: true
-sample: {"blockHeight":0,"stakerAddress":"string"}
+sample: {"blockHeight":0,"stakerAddress":"string","strategy":"string","showHistorical":false,"startBlock":0,"endBlock":0}
 custom_edit_url: null
 ---
 
@@ -25,7 +25,7 @@ import Heading from "@theme/Heading";
 
 
 <Schema
-  schema={{"type":"object","properties":{"blockHeight":{"type":"integer","format":"uint64"},"stakerAddress":{"type":"string"}},"required":["block_height"],"title":"GetStakerSharesRequest"}}
+  schema={{"type":"object","properties":{"blockHeight":{"type":"integer","format":"uint64"},"stakerAddress":{"type":"string"},"strategy":{"type":"string"},"showHistorical":{"type":"boolean"},"startBlock":{"type":"integer","format":"uint64"},"endBlock":{"type":"integer","format":"uint64"}},"title":"GetStakerSharesRequest"}}
   schemaType={"response"}
 >
   

--- a/docs/openapi/api.json
+++ b/docs/openapi/api.json
@@ -2625,18 +2625,11 @@
       "GetStakerSharesRequest": {
         "type": "object",
         "properties": {
-          "blockHeight": {
-            "type": "integer",
-            "format": "uint64"
-          },
           "stakerAddress": {
             "type": "string"
           },
           "strategy": {
             "type": "string"
-          },
-          "showHistorical": {
-            "type": "boolean"
           },
           "startBlock": {
             "type": "integer",

--- a/docs/openapi/api.json
+++ b/docs/openapi/api.json
@@ -2631,11 +2631,22 @@
           },
           "stakerAddress": {
             "type": "string"
+          },
+          "strategy": {
+            "type": "string"
+          },
+          "showHistorical": {
+            "type": "boolean"
+          },
+          "startBlock": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "endBlock": {
+            "type": "integer",
+            "format": "uint64"
           }
-        },
-        "required": [
-          "block_height"
-        ]
+        }
       },
       "GetStakerSharesResponse": {
         "type": "object",

--- a/docs/openapi/api.public.json
+++ b/docs/openapi/api.public.json
@@ -896,11 +896,22 @@
           },
           "stakerAddress": {
             "type": "string"
+          },
+          "strategy": {
+            "type": "string"
+          },
+          "showHistorical": {
+            "type": "boolean"
+          },
+          "startBlock": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "endBlock": {
+            "type": "integer",
+            "format": "uint64"
           }
-        },
-        "required": [
-          "block_height"
-        ]
+        }
       },
       "GetStakerSharesResponse": {
         "type": "object",

--- a/docs/openapi/api.public.json
+++ b/docs/openapi/api.public.json
@@ -890,18 +890,11 @@
       "GetStakerSharesRequest": {
         "type": "object",
         "properties": {
-          "blockHeight": {
-            "type": "integer",
-            "format": "uint64"
-          },
           "stakerAddress": {
             "type": "string"
           },
           "strategy": {
             "type": "string"
-          },
-          "showHistorical": {
-            "type": "boolean"
           },
           "startBlock": {
             "type": "integer",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c
+	github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626210013-5bbac7665a49
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.16.0
+	github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626210013-5bbac7665a49
+	github.com/Layr-Labs/protocol-apis v1.16.1-0.20250630131958-e3532387fd03
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89

--- a/go.sum
+++ b/go.sum
@@ -28,12 +28,8 @@ github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQA
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
 github.com/Layr-Labs/protobuf-libs v0.1.0 h1:hfawlutriLq1i7cI2kXH8o2N+mx02cJTVlKrwAMazBY=
 github.com/Layr-Labs/protobuf-libs v0.1.0/go.mod h1:Om3Qb39NrWwald+08yTIj/VexKmocIMsMXXIM/iRcW8=
-github.com/Layr-Labs/protocol-apis v1.16.0 h1:JXchrhqdwVjmNHXV/l70n32n9/hvzDaVxlX1bzv7V1Q=
-github.com/Layr-Labs/protocol-apis v1.16.0/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
-github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c h1:RXr7ENZP7UkJD97D+CpICQV3OTPITGsci0I3IjePbBw=
-github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
-github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626210013-5bbac7665a49 h1:c/He01yN3KvfT+FJ8b+piOO7TKZeqP5dIBoJ5NI+0tw=
-github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626210013-5bbac7665a49/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
+github.com/Layr-Labs/protocol-apis v1.16.1-0.20250630131958-e3532387fd03 h1:FgcEfg/Y0B8x93+dCg1sb7S9sNPcKOzlgSqso0g6tIE=
+github.com/Layr-Labs/protocol-apis v1.16.1-0.20250630131958-e3532387fd03/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/Layr-Labs/protobuf-libs v0.1.0 h1:hfawlutriLq1i7cI2kXH8o2N+mx02cJTVlK
 github.com/Layr-Labs/protobuf-libs v0.1.0/go.mod h1:Om3Qb39NrWwald+08yTIj/VexKmocIMsMXXIM/iRcW8=
 github.com/Layr-Labs/protocol-apis v1.16.0 h1:JXchrhqdwVjmNHXV/l70n32n9/hvzDaVxlX1bzv7V1Q=
 github.com/Layr-Labs/protocol-apis v1.16.0/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
+github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c h1:RXr7ENZP7UkJD97D+CpICQV3OTPITGsci0I3IjePbBw=
+github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/Layr-Labs/protocol-apis v1.16.0 h1:JXchrhqdwVjmNHXV/l70n32n9/hvzDaVxl
 github.com/Layr-Labs/protocol-apis v1.16.0/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
 github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c h1:RXr7ENZP7UkJD97D+CpICQV3OTPITGsci0I3IjePbBw=
 github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626192844-97c1494a771c/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
+github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626210013-5bbac7665a49 h1:c/He01yN3KvfT+FJ8b+piOO7TKZeqP5dIBoJ5NI+0tw=
+github.com/Layr-Labs/protocol-apis v1.16.1-0.20250626210013-5bbac7665a49/go.mod h1:0w24becRYehW1AbwIFRF6wsfOlFJAcqBPAMAinB0y+c=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/pkg/rpcServer/protocolHandlers.go
+++ b/pkg/rpcServer/protocolHandlers.go
@@ -104,7 +104,7 @@ func (rpc *RpcServer) GetDelegatedStakersForOperator(ctx context.Context, reques
 
 func (rpc *RpcServer) GetStakerShares(ctx context.Context, request *protocolV1.GetStakerSharesRequest) (*protocolV1.GetStakerSharesResponse, error) {
 	showHistorical := request.GetShowHistorical()
-	shares, err := rpc.protocolDataService.ListStakerShares(ctx, request.GetStakerAddress(), request.GetBlockHeight(), showHistorical)
+	shares, err := rpc.protocolDataService.ListStakerShares(ctx, request.GetStakerAddress(), request.GetStrategy(), request.GetBlockHeight(), showHistorical)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpcServer/protocolHandlers.go
+++ b/pkg/rpcServer/protocolHandlers.go
@@ -104,7 +104,10 @@ func (rpc *RpcServer) GetDelegatedStakersForOperator(ctx context.Context, reques
 
 func (rpc *RpcServer) GetStakerShares(ctx context.Context, request *protocolV1.GetStakerSharesRequest) (*protocolV1.GetStakerSharesResponse, error) {
 	showHistorical := request.GetShowHistorical()
-	shares, err := rpc.protocolDataService.ListStakerShares(ctx, request.GetStakerAddress(), request.GetStrategy(), request.GetBlockHeight(), showHistorical)
+	startBlock := request.GetStartBlock()
+	endBlock := request.GetEndBlock()
+
+	shares, err := rpc.protocolDataService.ListStakerShares(ctx, request.GetStakerAddress(), request.GetStrategy(), request.GetBlockHeight(), showHistorical, startBlock, endBlock)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/protocolDataService/protocol.go
+++ b/pkg/service/protocolDataService/protocol.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/stateManager"
@@ -364,38 +365,65 @@ func (aa *AvsAddresses) Scan(value interface{}) error {
 }
 
 type StakerShares struct {
-	Staker       string
-	Strategy     string
-	Shares       string
-	BlockHeight  uint64
-	Operator     *string
-	Delegated    bool
-	AvsAddresses AvsAddresses `gorm:"type:jsonb"`
+	Staker          string
+	Strategy        string
+	Shares          string
+	BlockHeight     uint64
+	BlockTime       *time.Time
+	TransactionHash *string
+	LogIndex        *uint64
+	Operator        *string
+	Delegated       bool
+	AvsAddresses    AvsAddresses `gorm:"type:jsonb"`
 }
 
 // ListStakerShares returns the shares of a staker at a given block height, including the operator they were delegated to
 // and the addresses of the AVSs the operator was registered to.
 //
 // If not blockHeight is provided, the most recently indexed block will be used.
-func (pds *ProtocolDataService) ListStakerShares(ctx context.Context, staker string, blockHeight uint64) ([]*StakerShares, error) {
+// If showHistorical is true, returns all historical share records; otherwise returns aggregated current state.
+func (pds *ProtocolDataService) ListStakerShares(ctx context.Context, staker string, blockHeight uint64, showHistorical bool) ([]*StakerShares, error) {
 
 	bh, err := pds.BaseDataService.GetCurrentBlockHeightIfNotPresent(ctx, blockHeight)
 	if err != nil {
 		return nil, err
 	}
 
-	query := `
-		with distinct_staker_strategies as (
-			select
-				ssd.staker,
-				ssd.strategy,
-				sum(ssd.shares) as shares
-			from staker_share_deltas as ssd
-			where
-				ssd.staker = @staker
-				and block_number <= @blockHeight
-			group by ssd.staker, ssd.strategy
-		)
+	var query string
+
+	if showHistorical {
+		query = `
+		    with distinct_staker_strategies as (
+				select
+					ssd.staker,
+					ssd.strategy,
+					ssd.shares,
+					ssd.block_number,
+					ssd.block_time,
+					ssd.transaction_hash,
+					ssd.log_index
+				from staker_share_deltas as ssd
+				where
+					ssd.staker = @staker
+					and ssd.block_number <= @blockHeight
+				order by ssd.block_number desc, ssd.log_index desc
+			)`
+	} else {
+		query = `
+		    with distinct_staker_strategies as (
+				select
+					ssd.staker,
+					ssd.strategy,
+					sum(ssd.shares) as shares
+				from staker_share_deltas as ssd
+				where
+					ssd.staker = @staker
+					and block_number <= @blockHeight
+				group by ssd.staker, ssd.strategy
+			)`
+	}
+
+	query += `
 		select
 			dss.*,
 			dsc.operator,
@@ -424,6 +452,7 @@ func (pds *ProtocolDataService) ListStakerShares(ctx context.Context, staker str
 				and aosc.registered = true
 		) as aosc on true
 	`
+
 	shares := make([]*StakerShares, 0)
 	res := pds.db.Raw(query,
 		sql.Named("staker", staker),

--- a/pkg/service/protocolDataService/protocol_test.go
+++ b/pkg/service/protocolDataService/protocol_test.go
@@ -2,6 +2,10 @@ package protocolDataService
 
 import (
 	"context"
+	"log"
+	"os"
+	"testing"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/tests"
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/stateManager"
@@ -11,9 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"log"
-	"os"
-	"testing"
 )
 
 func setup(dataSourceName string) (
@@ -117,7 +118,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0x130c646e1224d979ff23523308abb6012ce04b0a"
 			blockNumber := uint64(3204391)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, blockNumber)
+			shares, err := pds.ListStakerShares(context.Background(), staker, blockNumber, false)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {
@@ -128,7 +129,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0xbc9dec48f305167bb8ee593e44893acf65ad3f36"
 			blockNumber := uint64(3240224)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, blockNumber)
+			shares, err := pds.ListStakerShares(context.Background(), staker, blockNumber, false)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {

--- a/pkg/service/protocolDataService/protocol_test.go
+++ b/pkg/service/protocolDataService/protocol_test.go
@@ -118,7 +118,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0x130c646e1224d979ff23523308abb6012ce04b0a"
 			blockNumber := uint64(3204391)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, blockNumber, false)
+			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {
@@ -129,7 +129,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0xbc9dec48f305167bb8ee593e44893acf65ad3f36"
 			blockNumber := uint64(3240224)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, blockNumber, false)
+			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {

--- a/pkg/service/protocolDataService/protocol_test.go
+++ b/pkg/service/protocolDataService/protocol_test.go
@@ -118,7 +118,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0x130c646e1224d979ff23523308abb6012ce04b0a"
 			blockNumber := uint64(3204391)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false)
+			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false, 0, 0)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {
@@ -129,7 +129,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0xbc9dec48f305167bb8ee593e44893acf65ad3f36"
 			blockNumber := uint64(3240224)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false)
+			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false, 0, 0)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {

--- a/pkg/service/protocolDataService/protocol_test.go
+++ b/pkg/service/protocolDataService/protocol_test.go
@@ -118,7 +118,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0x130c646e1224d979ff23523308abb6012ce04b0a"
 			blockNumber := uint64(3204391)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false, 0, 0)
+			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, blockNumber)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {
@@ -129,7 +129,7 @@ func Test_ProtocolDataService(t *testing.T) {
 			staker := "0xbc9dec48f305167bb8ee593e44893acf65ad3f36"
 			blockNumber := uint64(3240224)
 
-			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, false, 0, 0)
+			shares, err := pds.ListStakerShares(context.Background(), staker, "", blockNumber, blockNumber)
 			assert.Nil(t, err)
 			assert.True(t, len(shares) > 0)
 			for _, share := range shares {


### PR DESCRIPTION
## Description

Currently, [GetStakerShares](https://sidecar-docs.eigenlayer.xyz/docs/public-api/protocol-get-staker-shares) show the latest shares of a staker. We want to add an option to see the historical values of staked tokens.

Fixes #411 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

tested locally 
```
sidecar=> with distinct_staker_strategies as (
                                select
                                        ssd.staker,
                                        ssd.strategy,
                                        ssd.shares,
                                        ssd.block_number,
                                        ssd.block_time,
                                        ssd.transaction_hash,
                                        ssd.log_index
                                from staker_share_deltas as ssd
                                where
                                        ssd.staker = '0x00000002f32c0886ee65d68059fbdb76ef6a6996'
                                and ssd.block_number <= 20468025
                                order by ssd.block_number desc, ssd.log_index desc
                        ) select
                        dss.*,
                        dsc.operator,
                        dsc.delegated,
                        coalesce(aosc.avs_list, '[]'::jsonb) as avs_addresses
                from distinct_staker_strategies as dss
                left join lateral (
                        select
                                sdc.staker,
                                sdc.operator,
                                sdc.delegated,
                                row_number() over (partition by sdc.staker order by sdc.block_number desc, sdc.log_index) as rn
                        from staker_delegation_changes as sdc
                        where
                                sdc.staker = dss.staker
                                and sdc.block_number <= 20468025
                        order by block_number desc
                ) as dsc on (dsc.rn = 1)
                left join lateral (
                        select
                                jsonb_agg(distinct aosc.avs) as avs_list
                        from avs_operator_state_changes aosc
                        where
                                aosc.operator = dsc.operator
                                and aosc.block_number <= 20468025
                                and aosc.registered = true
                ) as aosc on true;
                   staker                   |                  strategy                  |         shares         | block_number |     block_time      |                          transaction_hash                          | log_index | operator | delegated | avs_addresses 
--------------------------------------------+--------------------------------------------+------------------------+--------------+---------------------+--------------------------------------------------------------------+-----------+----------+-----------+---------------
 0x00000002f32c0886ee65d68059fbdb76ef6a6996 | 0xacb55c530acdb2849e6d4f36992cd8c9d50ed8f7 | -110000000000000000000 |     20468024 | 2024-08-06 07:25:47 | 0xbd691d9a308c68f22b769873755e0d40d17ac7d559a87c57243bb87cffc1260a |       196 |          |           | []
 0x00000002f32c0886ee65d68059fbdb76ef6a6996 | 0xacb55c530acdb2849e6d4f36992cd8c9d50ed8f7 |  110000000000000000000 |     19842748 | 2024-05-10 22:54:11 | 0x61cc902ac06b6750536c288056f82da96e26edef3aec0c5a5d1aab7e2ba6a6c2 |       597 |          |           | []
 0x00000002f32c0886ee65d68059fbdb76ef6a6996 | 0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6 |     -95653239182155230 |     19141905 | 2024-02-02 16:29:11 | 0x5390a4396b8b0809128677ada0de39a16a7ed290ba028eca25741506ebb4bf90 |       461 |          |           | []
 0x00000002f32c0886ee65d68059fbdb76ef6a6996 | 0x0fe4f44bee93503346a3ac9ee5a26b130a5796d6 |      95653239182155230 |     18814818 | 2023-12-18 19:01:23 | 0xa23eaf08ac82f547219c8522471e17b4340c1c75b8de5eb5120037a565656310 |       200 |          |           | []
(4 rows)
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
