### PR TITLE
fix: exclude rewards table and create a gold_table on slim snapshot 

### DIFF
--- a/pkg/snapshot/createSnapshot.go
+++ b/pkg/snapshot/createSnapshot.go
@@ -42,8 +42,19 @@ var (
 	kindFlags = map[Kind]func(schema string) []string{
 		Kind_Slim: func(schema string) []string {
 			return []string{
+				// Exclude gold and sot tables
 				"-T", fmt.Sprintf(`%s.gold_*`, schema),
 				"-T", fmt.Sprintf(`%s.sot_*`, schema),
+				// Exclude all rewards-related tables for slim snapshots
+				"-T", fmt.Sprintf(`%s.generated_rewards_snapshots`, schema),
+				"-T", fmt.Sprintf(`%s.combined_rewards`, schema),
+				"-T", fmt.Sprintf(`%s.rewards_claimed`, schema),
+				"-T", fmt.Sprintf(`%s.operator_directed_rewards`, schema),
+				"-T", fmt.Sprintf(`%s.operator_directed_operator_set_rewards`, schema),
+				"-T", fmt.Sprintf(`%s.reward_submissions`, schema),
+				"-T", fmt.Sprintf(`%s.submitted_distribution_roots`, schema),
+				// Exclude new gold tables
+				"-T", fmt.Sprintf(`%s.rewards_gold_*`, schema),
 			}
 		},
 		Kind_Full: func(schema string) []string {


### PR DESCRIPTION
## Description

- exclude all rewards table on `slim` snapshot
- create gold_table automatically for `slim` snapshot

Fixes #410 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
