### PR TITLE
refactor: add proper mutex locking to rewards cache

### DIFF
--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -129,7 +129,7 @@ func main() {
 	rcq := rewardsCalculatorQueue.NewRewardsCalculatorQueue(rc, l)
 
 	p := pipeline.NewPipeline(fetchr, idxr, mds, contractStore, cm, sm, msm, rc, rcq, cfg, sdc, eb, l)
-	rps := proofs.NewRewardsProofsStore(rc, l)
+	rps := proofs.NewRewardsProofsStore(rc, sdc, l)
 	pds := protocolDataService.NewProtocolDataService(sm, grm, l, cfg)
 	rds := rewardsDataService.NewRewardsDataService(grm, l, cfg, rc)
 	sds := slashingDataService.NewSlashingDataService(grm, l, cfg)

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -135,7 +135,7 @@ var rpcCmd = &cobra.Command{
 
 		rcq := rewardsCalculatorQueue.NewRewardsCalculatorQueue(rc, l)
 
-		rps := proofs.NewRewardsProofsStore(rc, l)
+		rps := proofs.NewRewardsProofsStore(rc, sink, l)
 
 		pds := protocolDataService.NewProtocolDataService(sm, grm, l, cfg)
 		rds := rewardsDataService.NewRewardsDataService(grm, l, cfg, rc)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -164,7 +164,7 @@ var runCmd = &cobra.Command{
 
 		rcq := rewardsCalculatorQueue.NewRewardsCalculatorQueue(rc, l)
 
-		rps := proofs.NewRewardsProofsStore(rc, l)
+		rps := proofs.NewRewardsProofsStore(rc, sink, l)
 
 		pds := protocolDataService.NewProtocolDataService(sm, grm, l, cfg)
 		rds := rewardsDataService.NewRewardsDataService(grm, l, cfg, rc)

--- a/pkg/metrics/metricsTypes/metrics.go
+++ b/pkg/metrics/metricsTypes/metrics.go
@@ -34,6 +34,9 @@ var (
 	Metric_Incr_RewardsRootVerified        = "indexer.rewardsRootVerified"
 	Metric_Incr_RewardsRootInvalid         = "indexer.rewardsRootInvalid"
 	Metric_Incr_RewardsMerkelizationFailed = "indexer.rewardsWerkelizationFailed"
+	Metric_Incr_ProofDataCacheHit          = "proofData.cache.hit"
+	Metric_Incr_ProofDataCacheMiss         = "proofData.cache.miss"
+	Metric_Incr_ProofDataCacheEvicted      = "proofData.cache.evicted"
 
 	Metric_Gauge_CurrentBlockHeight = "currentBlockHeight"
 	Metric_Gauge_SnapshotSize       = "snapshots.create.size"
@@ -94,6 +97,24 @@ var MetricTypes = map[MetricsType][]MetricsTypeConfig{
 			Name: Metric_Incr_RewardsMerkelizationFailed,
 			Labels: []string{
 				"block_number",
+			},
+		},
+		MetricsTypeConfig{
+			Name: Metric_Incr_ProofDataCacheHit,
+			Labels: []string{
+				"snapshot",
+			},
+		},
+		MetricsTypeConfig{
+			Name: Metric_Incr_ProofDataCacheMiss,
+			Labels: []string{
+				"snapshot",
+			},
+		},
+		MetricsTypeConfig{
+			Name: Metric_Incr_ProofDataCacheEvicted,
+			Labels: []string{
+				"snapshot",
 			},
 		},
 	},

--- a/pkg/proofs/rewardsProofs.go
+++ b/pkg/proofs/rewardsProofs.go
@@ -5,23 +5,30 @@ import (
 	rewardsCoordinator "github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/IRewardsCoordinator"
 	"github.com/Layr-Labs/eigenlayer-rewards-proofs/pkg/claimgen"
 	"github.com/Layr-Labs/eigenlayer-rewards-proofs/pkg/distribution"
+	"github.com/Layr-Labs/sidecar/pkg/metrics"
+	"github.com/Layr-Labs/sidecar/pkg/metrics/metricsTypes"
 	"github.com/Layr-Labs/sidecar/pkg/rewards"
 	"github.com/Layr-Labs/sidecar/pkg/utils"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/wealdtech/go-merkletree/v2"
 	"go.uber.org/zap"
+	"sync"
+	"time"
 )
 
 // RewardsProofsStore manages the generation and caching of Merkle proofs
 // for rewards distributions. It provides functionality to generate proofs
 // that can be used by earners to claim their rewards.
 type RewardsProofsStore struct {
+	mu sync.Mutex // Mutex to protect concurrent access to rewardsData
 	// rewardsCalculator is used to calculate and merkelize rewards
 	rewardsCalculator *rewards.RewardsCalculator
 	// logger for logging operations and errors
 	logger *zap.Logger
 	// rewardsData caches proof data by snapshot date to avoid recalculation
 	rewardsData map[string]*ProofData
+
+	metricsSink *metrics.MetricsSink
 }
 
 // ProofData contains all the Merkle trees and distribution data needed
@@ -35,6 +42,8 @@ type ProofData struct {
 	TokenTree map[gethcommon.Address]*merkletree.MerkleTree
 	// Distribution contains the complete rewards distribution data
 	Distribution *distribution.Distribution
+
+	LastAccessed *time.Time
 }
 
 // NewRewardsProofsStore creates a new RewardsProofsStore instance.
@@ -47,11 +56,13 @@ type ProofData struct {
 //   - *RewardsProofsStore: A new RewardsProofsStore instance
 func NewRewardsProofsStore(
 	rc *rewards.RewardsCalculator,
+	ms *metrics.MetricsSink,
 	l *zap.Logger,
 ) *RewardsProofsStore {
 	return &RewardsProofsStore{
 		rewardsCalculator: rc,
 		logger:            l,
+		metricsSink:       ms,
 		rewardsData:       make(map[string]*ProofData),
 	}
 }
@@ -67,8 +78,16 @@ func NewRewardsProofsStore(
 //   - *ProofData: The proof data for the specified snapshot
 //   - error: Any error encountered during data retrieval or generation
 func (rps *RewardsProofsStore) getRewardsDataForSnapshot(snapshot string) (*ProofData, error) {
+	rps.mu.Lock()
+	defer rps.mu.Unlock()
+
+	now := time.Now()
+
 	data, ok := rps.rewardsData[snapshot]
-	if !ok {
+	if !ok || data == nil {
+		_ = rps.metricsSink.Incr(metricsTypes.Metric_Incr_ProofDataCacheMiss, []metricsTypes.MetricsLabel{
+			{Name: "snapshot", Value: snapshot},
+		}, 1)
 		accountTree, tokenTree, distro, err := rps.rewardsCalculator.MerkelizeRewardsForSnapshot(snapshot)
 		if err != nil {
 			rps.logger.Sugar().Errorw("Failed to fetch rewards for snapshot",
@@ -83,10 +102,38 @@ func (rps *RewardsProofsStore) getRewardsDataForSnapshot(snapshot string) (*Proo
 			AccountTree:  accountTree,
 			TokenTree:    tokenTree,
 			Distribution: distro,
+			LastAccessed: &now,
 		}
 		rps.rewardsData[snapshot] = data
+	} else {
+		_ = rps.metricsSink.Incr(metricsTypes.Metric_Incr_ProofDataCacheHit, []metricsTypes.MetricsLabel{
+			{Name: "snapshot", Value: snapshot},
+		}, 1)
 	}
+	rps.rewardsData[snapshot].LastAccessed = &now
+
+	rps.evictOldRewards()
+
 	return data, nil
+}
+
+func (rps *RewardsProofsStore) evictOldRewards() {
+	for snapshot, data := range rps.rewardsData {
+		if data.LastAccessed == nil {
+			continue
+		}
+		// if the data hasnt been accessed in 3 days, evict it
+		if time.Since(*data.LastAccessed) > 24*time.Hour*3 {
+			rps.logger.Sugar().Infow("Evicting old rewards data",
+				zap.String("snapshot", snapshot),
+				zap.Time("lastAccessed", *data.LastAccessed),
+			)
+			delete(rps.rewardsData, snapshot)
+			_ = rps.metricsSink.Incr(metricsTypes.Metric_Incr_ProofDataCacheEvicted, []metricsTypes.MetricsLabel{
+				{Name: "snapshot", Value: snapshot},
+			}, 1)
+		}
+	}
 }
 
 // GenerateRewardsClaimProof generates a Merkle proof for an earner to claim rewards

--- a/pkg/proofs/rewardsProofs.go
+++ b/pkg/proofs/rewardsProofs.go
@@ -88,6 +88,9 @@ func (rps *RewardsProofsStore) getRewardsDataForSnapshot(snapshot string) (*Proo
 		_ = rps.metricsSink.Incr(metricsTypes.Metric_Incr_ProofDataCacheMiss, []metricsTypes.MetricsLabel{
 			{Name: "snapshot", Value: snapshot},
 		}, 1)
+		rps.logger.Sugar().Infow("rewards data cache miss",
+			zap.String("snapshot", snapshot),
+		)
 		accountTree, tokenTree, distro, err := rps.rewardsCalculator.MerkelizeRewardsForSnapshot(snapshot)
 		if err != nil {
 			rps.logger.Sugar().Errorw("Failed to fetch rewards for snapshot",
@@ -106,6 +109,9 @@ func (rps *RewardsProofsStore) getRewardsDataForSnapshot(snapshot string) (*Proo
 		}
 		rps.rewardsData[snapshot] = data
 	} else {
+		rps.logger.Sugar().Infow("rewards data cache hit",
+			zap.String("snapshot", snapshot),
+		)
 		_ = rps.metricsSink.Incr(metricsTypes.Metric_Incr_ProofDataCacheHit, []metricsTypes.MetricsLabel{
 			{Name: "snapshot", Value: snapshot},
 		}, 1)


### PR DESCRIPTION
## Description

Add proper mutex locking to rewards cache to prevent OOMKilled issues. Also add metrics for cache hits/misses and evictions.

## Type of change

- [x] Refactor (non-breaking change which does not add or remove functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
