### PR TITLE
fix: specifying schema name when restoring snapshot

### DIFF
--- a/pkg/snapshot/createSnapshot.go
+++ b/pkg/snapshot/createSnapshot.go
@@ -165,7 +165,7 @@ func (ss *SnapshotService) performDump(snapshotFile *SnapshotFile, cfg *CreateSn
 
 	flags = append(flags, kindFlags[cfg.Kind](cfg.DBConfig.SchemaName)...)
 
-	cmdFlags := ss.buildCommand(flags, cfg.SnapshotConfig)
+	cmdFlags := ss.buildCommand(flags, cfg.SnapshotConfig, false) // false for create operation
 
 	res := &Result{}
 	fullCmdPath, err := getCmdPath(PgDump)
@@ -176,7 +176,7 @@ func (ss *SnapshotService) performDump(snapshotFile *SnapshotFile, cfg *CreateSn
 	res.FullCommand = fmt.Sprintf("%s %s", fullCmdPath, strings.Join(cmdFlags, " "))
 
 	cmd := exec.Command(fullCmdPath, cmdFlags...)
-	cmd.Env = append(cmd.Env, ss.buildPostgresEnvVars(cfg.DBConfig)...)
+	cmd.Env = append(cmd.Env, ss.buildPostgresEnvVars(cfg.DBConfig, false)...) // false for create operation
 
 	ss.logger.Sugar().Infow("Starting snapshot dump",
 		zap.String("fullCommand", res.FullCommand),

--- a/pkg/snapshot/restoreSnapshot.go
+++ b/pkg/snapshot/restoreSnapshot.go
@@ -2,10 +2,6 @@ package snapshot
 
 import (
 	"fmt"
-	"github.com/Layr-Labs/sidecar/pkg/snapshot/snapshotManifest"
-	"github.com/pkg/errors"
-	"github.com/schollz/progressbar/v3"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,6 +10,11 @@ import (
 	"path"
 	"slices"
 	"strings"
+
+	"github.com/Layr-Labs/sidecar/pkg/snapshot/snapshotManifest"
+	"github.com/pkg/errors"
+	"github.com/schollz/progressbar/v3"
+	"go.uber.org/zap"
 )
 
 // defaultRestoreOptions returns the default command-line options for pg_restore.
@@ -194,7 +195,7 @@ func (ss *SnapshotService) isUrl(input string) bool {
 func (ss *SnapshotService) performRestore(snapshotFile *SnapshotFile, cfg *RestoreSnapshotConfig) (*Result, error) {
 	flags := defaultRestoreOptions()
 
-	cmdFlags := ss.buildCommand(flags, cfg.SnapshotConfig)
+	cmdFlags := ss.buildCommand(flags, cfg.SnapshotConfig, true) // true for restore operation
 	cmdFlags = append(cmdFlags, snapshotFile.FullPath())
 
 	res := &Result{}
@@ -206,7 +207,7 @@ func (ss *SnapshotService) performRestore(snapshotFile *SnapshotFile, cfg *Resto
 	res.FullCommand = fmt.Sprintf("%s %s", fullCmdPath, strings.Join(cmdFlags, " "))
 
 	cmd := exec.Command(fullCmdPath, cmdFlags...)
-	cmd.Env = append(cmd.Env, ss.buildPostgresEnvVars(cfg.DBConfig)...)
+	cmd.Env = append(cmd.Env, ss.buildPostgresEnvVars(cfg.DBConfig, true)...) // true for restore operation
 
 	ss.logger.Sugar().Infow("Starting snapshot restore",
 		zap.String("fullCommand", res.FullCommand),


### PR DESCRIPTION
## Description

For `pg_restore` command, `--schema=SCHEMA` flag restores only objects from the specified schema. Meaning, restoring did not work because it "grabs" from the schema, instead of "to" the schema.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
