### PR TITLE
chore: add logs when operatorSetOperatorRegistrations and slashedOperators events are observed

### DIFF
--- a/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
+++ b/pkg/eigenState/operatorSetOperatorRegistrations/operatorSetOperatorRegistrations.go
@@ -115,6 +115,11 @@ func (osor *OperatorSetOperatorRegistrationModel) handleOperatorSetOperatorRegis
 		LogIndex:        log.LogIndex,
 	}
 
+	osor.logger.Sugar().Infow("Detected operator set operator registration event",
+		zap.Uint64("blockNumber", log.BlockNumber),
+		zap.String("transactionHash", log.TransactionHash),
+		zap.Uint64("logIndex", log.LogIndex),
+	)
 	return operatorRegistration, nil
 }
 

--- a/pkg/eigenState/slashedOperators/slashedOperators.go
+++ b/pkg/eigenState/slashedOperators/slashedOperators.go
@@ -3,6 +3,11 @@ package slashedOperators
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
+	"slices"
+	"sort"
+	"strings"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/base"
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/stateManager"
@@ -10,10 +15,6 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"math/big"
-	"slices"
-	"sort"
-	"strings"
 )
 
 type SlashedOperator struct {
@@ -139,6 +140,11 @@ func (so *SlashedOperatorModel) handleSlashedOperatorCreatedEvent(log *storage.T
 		slashedOperators = append(slashedOperators, slashing)
 	}
 
+	so.logger.Sugar().Infow("Detected slashed operator created event",
+		zap.Uint64("blockNumber", log.BlockNumber),
+		zap.String("transactionHash", log.TransactionHash),
+		zap.Uint64("logIndex", log.LogIndex),
+	)
 	return slashedOperators, nil
 }
 


### PR DESCRIPTION
## Description

We want to log when operatorSetOperatorRegistrations and slashedOperators events are observed so that we can monitor DeltaTransport in multichain-transporter

## Type of change

- [x] Chore (non-breaking change which does not add functionality)

## How Has This Been Tested?

Only adding logs. No test needed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
