### PR TITLE
fix: wrong name mapping for ListWithdrawalsForStrategies

### DIFF
--- a/pkg/rpcServer/protocolHandlers.go
+++ b/pkg/rpcServer/protocolHandlers.go
@@ -383,7 +383,7 @@ func (s *RpcServer) ListWithdrawalsForStrategies(ctx context.Context, request *p
 				Strategy:        withdrawal.Strategy,
 				Shares:          withdrawal.Shares,
 				OperatorAddress: withdrawal.Operator,
-				BlockNumber:     withdrawal.BlockHeight,
+				BlockNumber:     withdrawal.BlockNumber,
 			}
 		}),
 		NextPage: nextPage,

--- a/pkg/service/protocolDataService/protocol.go
+++ b/pkg/service/protocolDataService/protocol.go
@@ -440,7 +440,7 @@ type Withdrawal struct {
 	Strategy    string
 	Shares      string
 	Operator    string
-	BlockHeight uint64
+	BlockNumber uint64
 }
 
 func (pds *ProtocolDataService) ListWithdrawalsForStrategies(ctx context.Context, strategies []string, blockHeight uint64, pagination *types.Pagination) ([]*Withdrawal, error) {
@@ -520,8 +520,8 @@ func (pds *ProtocolDataService) ListWithdrawalsForStrategies(ctx context.Context
 				THEN q.shares * COALESCE(m.max_magnitude, 1e18) / 1e18
 				ELSE q.shares
 			END AS shares,
-			q.block_number,
-			q.operator
+			q.operator,
+			q.block_number
 		FROM (
 			SELECT * FROM queued_regular
 			UNION ALL


### PR DESCRIPTION
## Description

`BlockHeight` in the struct vs. `block_number` in the query resulted in the wrong name mapping for ListWithdrawalsForStrategies, causing block number to be 0 in the RPC output. Updating `BlockHeight` to `BlockNumber`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
