### PR TITLE
fix(SEC-53): security fix remove hostPath volume mount injected for APM trace collection

### DIFF
--- a/charts/sidecar/values.yaml
+++ b/charts/sidecar/values.yaml
@@ -17,6 +17,9 @@ sidecar:
     SIDECAR_DATABASE_USER: "sidecar"
     SIDECAR_DATABASE_DB_NAME: "sidecar"
     # SIDECAR_STATSD_URL: ""
+    # Datadog APM - using TCP instead of Unix socket for security Finding.
+    DD_AGENT_HOST: "datadog-agent"
+    DD_TRACE_AGENT_PORT: "8126"
   additionalEnv: []
   #  - name: ENV_NAME
   #    value: "env value"

--- a/charts/sidecar/values.yaml
+++ b/charts/sidecar/values.yaml
@@ -16,7 +16,8 @@ sidecar:
     SIDECAR_DATABASE_PORT: "5432"
     SIDECAR_DATABASE_USER: "sidecar"
     SIDECAR_DATABASE_DB_NAME: "sidecar"
-    # SIDECAR_STATSD_URL: ""
+    DATADOG_STATSD_ENABLED: "true"
+    DATADOG_STATSD_URL: "datadog-agent:8125"
     # Datadog APM - using TCP instead of Unix socket for security Finding.
     DD_AGENT_HOST: "datadog-agent"
     DD_TRACE_AGENT_PORT: "8126"


### PR DESCRIPTION
- Remove Datadog Unix Socket to send the APM traces to datadog.
- Use TCP and operator can collect it fine.
- Enable statsd for collecting metrics over the same service and standard port.