### PR TITLE
feat: withdrawal queue schema + allocation/deallocation rounding logic

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ const (
 	RewardsFork_Colorado    ForkName = "colorado"
 	RewardsFork_Red         ForkName = "red"
 	RewardsFork_Pecos       ForkName = "pecos"
+	RewardsFork_Sabine      ForkName = "sabine"
 )
 
 func normalizeFlagName(name string) string {
@@ -558,6 +559,10 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				Date:        "2025-05-14",
 				BlockNumber: 3840004,
 			},
+			RewardsFork_Sabine: Fork{
+				Date:        "2025-11-18", // TODO: Set actual fork date
+				BlockNumber: 0,            // TODO: Set actual fork block number
+			},
 		}, nil
 	case Chain_Holesky:
 		return ForkMap{
@@ -596,6 +601,10 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				Date:        "2025-05-14",
 				BlockNumber: 3840004,
 			},
+			RewardsFork_Sabine: Fork{
+				Date:        "2025-11-18", // TODO: Set actual fork date
+				BlockNumber: 0,            // TODO: Set actual fork block number
+			},
 		}, nil
 	case Chain_Sepolia:
 		return ForkMap{
@@ -623,6 +632,10 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 			RewardsFork_Pecos: Fork{
 				Date:        "2025-05-14",
 				BlockNumber: 8327038,
+			},
+			RewardsFork_Sabine: Fork{
+				Date:        "1970-01-01", // Enabled from genesis on Sepolia
+				BlockNumber: 0,
 			},
 		}, nil
 	case Chain_Hoodi:
@@ -652,6 +665,10 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				Date:        "1970-01-01",
 				BlockNumber: 0,
 			},
+			RewardsFork_Sabine: Fork{
+				Date:        "1970-01-01", // Enabled from genesis on Hoodi
+				BlockNumber: 0,
+			},
 		}, nil
 	case Chain_PreprodHoodi:
 		return ForkMap{
@@ -678,6 +695,10 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 			},
 			RewardsFork_Pecos: Fork{
 				Date:        "1970-01-01",
+				BlockNumber: 0,
+			},
+			RewardsFork_Sabine: Fork{
+				Date:        "1970-01-01", // Enabled from genesis on PreprodHoodi
 				BlockNumber: 0,
 			},
 		}, nil
@@ -721,6 +742,10 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 			RewardsFork_Pecos: Fork{
 				Date:        "2025-05-14",
 				BlockNumber: 22483225,
+			},
+			RewardsFork_Sabine: Fork{
+				Date:        "2025-12-01", // TODO: Set actual mainnet fork date
+				BlockNumber: 0,            // TODO: Set actual mainnet fork block number
 			},
 		}, nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -559,10 +559,6 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				Date:        "2025-05-14",
 				BlockNumber: 3840004,
 			},
-			RewardsFork_Sabine: Fork{
-				Date:        "2025-11-18", // TODO: Set actual fork date
-				BlockNumber: 0,            // TODO: Set actual fork block number
-			},
 		}, nil
 	case Chain_Holesky:
 		return ForkMap{
@@ -601,10 +597,6 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				Date:        "2025-05-14",
 				BlockNumber: 3840004,
 			},
-			RewardsFork_Sabine: Fork{
-				Date:        "2025-11-18", // TODO: Set actual fork date
-				BlockNumber: 0,            // TODO: Set actual fork block number
-			},
 		}, nil
 	case Chain_Sepolia:
 		return ForkMap{
@@ -634,8 +626,8 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				BlockNumber: 8327038,
 			},
 			RewardsFork_Sabine: Fork{
-				Date:        "1970-01-01", // Enabled from genesis on Sepolia
-				BlockNumber: 0,
+				Date:        "2025-12-19",
+				BlockNumber: 9903838,
 			},
 		}, nil
 	case Chain_Hoodi:
@@ -666,8 +658,8 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				BlockNumber: 0,
 			},
 			RewardsFork_Sabine: Fork{
-				Date:        "1970-01-01", // Enabled from genesis on Hoodi
-				BlockNumber: 0,
+				Date:        "2025-12-19",
+				BlockNumber: 1871733,
 			},
 		}, nil
 	case Chain_PreprodHoodi:
@@ -698,8 +690,8 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				BlockNumber: 0,
 			},
 			RewardsFork_Sabine: Fork{
-				Date:        "1970-01-01", // Enabled from genesis on PreprodHoodi
-				BlockNumber: 0,
+				Date:        "2025-12-19",
+				BlockNumber: 1871733,
 			},
 		}, nil
 	case Chain_Mainnet:
@@ -744,8 +736,8 @@ func (c *Config) GetRewardsSqlForkDates() (ForkMap, error) {
 				BlockNumber: 22483225,
 			},
 			RewardsFork_Sabine: Fork{
-				Date:        "2025-12-01", // TODO: Set actual mainnet fork date
-				BlockNumber: 0,            // TODO: Set actual mainnet fork block number
+				Date:        "2026-01-19",
+				BlockNumber: 24274311,
 			},
 		}, nil
 	}

--- a/pkg/eigenState/operatorAllocations/operatorAllocations_test.go
+++ b/pkg/eigenState/operatorAllocations/operatorAllocations_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/tests"
@@ -52,6 +53,15 @@ func Test_OperatorAllocations(t *testing.T) {
 
 		blockNumber := uint64(102)
 
+		// Create the block first (required for foreign key constraint)
+		block := &storage.Block{
+			Number:    blockNumber,
+			Hash:      "test_hash",
+			BlockTime: time.Now(),
+		}
+		res := grm.Model(&storage.Block{}).Create(block)
+		assert.Nil(t, res.Error)
+
 		log := &storage.TransactionLog{
 			TransactionHash:  "some hash",
 			TransactionIndex: big.NewInt(100).Uint64(),
@@ -87,7 +97,7 @@ func Test_OperatorAllocations(t *testing.T) {
 
 		results := make([]*OperatorAllocation, 0)
 		query := `select * from operator_allocations where block_number = ?`
-		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		res = model.DB.Raw(query, blockNumber).Scan(&results)
 		assert.Nil(t, res.Error)
 		assert.Equal(t, 1, len(results))
 

--- a/pkg/eigenState/operatorAllocations/operatorAllocations_test.go
+++ b/pkg/eigenState/operatorAllocations/operatorAllocations_test.go
@@ -1,6 +1,12 @@
 package operatorAllocations
 
 import (
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/tests"
 	"github.com/Layr-Labs/sidecar/pkg/eigenState/stateManager"
@@ -10,11 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"math/big"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 func setup() (
@@ -113,6 +114,193 @@ func Test_OperatorAllocations(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotNil(t, stateRoot)
 			assert.True(t, len(stateRoot) > 0)
+		})
+	})
+
+	t.Run("Test determineEffectiveDate logic", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(nil, l, grm)
+		model, err := NewOperatorAllocationModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		timestamp := time.Date(2025, 11, 14, 15, 30, 0, 0, time.UTC)
+
+		t.Run("Allocation (increase) - should round up to next day", func(t *testing.T) {
+			previousMagnitude := big.NewInt(1000)
+			newMagnitude := big.NewInt(1500) // Increase of 500
+
+			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
+			expected := time.Date(2025, 11, 15, 0, 0, 0, 0, time.UTC)
+			assert.Equal(t, expected, result)
+		})
+
+		t.Run("Deallocation (decrease) - should round down to current day", func(t *testing.T) {
+			previousMagnitude := big.NewInt(1500)
+			newMagnitude := big.NewInt(1000) // Decrease of 500
+
+			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
+			expected := time.Date(2025, 11, 14, 0, 0, 0, 0, time.UTC)
+			assert.Equal(t, expected, result)
+		})
+
+		t.Run("No change in magnitude - should round down to current day", func(t *testing.T) {
+			previousMagnitude := big.NewInt(1000)
+			newMagnitude := big.NewInt(1000) // No change
+
+			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
+			expected := time.Date(2025, 11, 14, 0, 0, 0, 0, time.UTC)
+			assert.Equal(t, expected, result)
+		})
+
+		t.Run("First allocation (from zero) - should round up to next day", func(t *testing.T) {
+			previousMagnitude := big.NewInt(0)
+			newMagnitude := big.NewInt(1000) // First allocation
+
+			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
+			expected := time.Date(2025, 11, 15, 0, 0, 0, 0, time.UTC)
+			assert.Equal(t, expected, result)
+		})
+
+		t.Run("Full deallocation (to zero) - should round down to current day", func(t *testing.T) {
+			previousMagnitude := big.NewInt(1000)
+			newMagnitude := big.NewInt(0) // Full deallocation
+
+			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
+			expected := time.Date(2025, 11, 14, 0, 0, 0, 0, time.UTC)
+			assert.Equal(t, expected, result)
+		})
+	})
+
+	t.Run("Test allocation vs deallocation integration", func(t *testing.T) {
+		esm := stateManager.NewEigenStateManager(nil, l, grm)
+		model, err := NewOperatorAllocationModel(esm, grm, l, cfg)
+		assert.Nil(t, err)
+
+		// Clean up any existing test data to ensure isolation
+		err = grm.Exec("DELETE FROM operator_allocations").Error
+		assert.Nil(t, err)
+
+		operator := "0x93a797473810c125ece22f25a2087b6ceb8ce886"
+		avs := "0x69aa865947f6c9191b02954b1dd1a44131541226"
+		strategy := "0x947e522010e22856071f8fb03e735fedfccd6e9f"
+
+		t.Run("First allocation event", func(t *testing.T) {
+			blockNumber := uint64(200)
+			blockTime := time.Date(2025, 11, 14, 15, 30, 0, 0, time.UTC)
+
+			block := &storage.Block{
+				Number:    blockNumber,
+				Hash:      "hash_200",
+				BlockTime: blockTime,
+			}
+			res := model.DB.Model(&storage.Block{}).Create(block)
+			assert.Nil(t, res.Error)
+
+			log := &storage.TransactionLog{
+				TransactionHash:  "tx_hash_200",
+				TransactionIndex: 1,
+				BlockNumber:      blockNumber,
+				Address:          cfg.GetContractsMapForChain().AllocationManager,
+				Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}]`,
+				EventName:        "AllocationUpdated",
+				LogIndex:         1,
+				OutputData:       `{"operator": "` + operator + `", "strategy": "` + strategy + `", "magnitude": 1000, "effectBlock": 200, "operatorSet": {"id": 5, "avs": "` + avs + `"}}`,
+			}
+
+			err = model.SetupStateForBlock(blockNumber)
+			assert.Nil(t, err)
+
+			change, err := model.HandleStateChange(log)
+			assert.Nil(t, err)
+			assert.NotNil(t, change)
+
+			record := change.(*OperatorAllocation)
+
+			// First allocation should round UP to next day
+			assert.Equal(t, "2025-11-15", record.EffectiveDate)
+			assert.Equal(t, "1000", record.Magnitude)
+
+			err = model.CommitFinalState(blockNumber, false)
+			assert.Nil(t, err)
+		})
+
+		t.Run("Second allocation event (increase)", func(t *testing.T) {
+			blockNumber := uint64(201)
+			blockTime := time.Date(2025, 11, 15, 10, 0, 0, 0, time.UTC)
+
+			block := &storage.Block{
+				Number:    blockNumber,
+				Hash:      "hash_201",
+				BlockTime: blockTime,
+			}
+			res := model.DB.Model(&storage.Block{}).Create(block)
+			assert.Nil(t, res.Error)
+
+			log := &storage.TransactionLog{
+				TransactionHash:  "tx_hash_201",
+				TransactionIndex: 1,
+				BlockNumber:      blockNumber,
+				Address:          cfg.GetContractsMapForChain().AllocationManager,
+				Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}]`,
+				EventName:        "AllocationUpdated",
+				LogIndex:         1,
+				OutputData:       `{"operator": "` + operator + `", "strategy": "` + strategy + `", "magnitude": 1500, "effectBlock": 201, "operatorSet": {"id": 5, "avs": "` + avs + `"}}`,
+			}
+
+			err = model.SetupStateForBlock(blockNumber)
+			assert.Nil(t, err)
+
+			change, err := model.HandleStateChange(log)
+			assert.Nil(t, err)
+			assert.NotNil(t, change)
+
+			record := change.(*OperatorAllocation)
+
+			// Allocation increase should round UP to next day
+			assert.Equal(t, "2025-11-16", record.EffectiveDate)
+			assert.Equal(t, "1500", record.Magnitude)
+
+			err = model.CommitFinalState(blockNumber, false)
+			assert.Nil(t, err)
+		})
+
+		t.Run("Deallocation event (decrease)", func(t *testing.T) {
+			blockNumber := uint64(202)
+			blockTime := time.Date(2025, 11, 16, 14, 0, 0, 0, time.UTC)
+
+			block := &storage.Block{
+				Number:    blockNumber,
+				Hash:      "hash_202",
+				BlockTime: blockTime,
+			}
+			res := model.DB.Model(&storage.Block{}).Create(block)
+			assert.Nil(t, res.Error)
+
+			log := &storage.TransactionLog{
+				TransactionHash:  "tx_hash_202",
+				TransactionIndex: 1,
+				BlockNumber:      blockNumber,
+				Address:          cfg.GetContractsMapForChain().AllocationManager,
+				Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}]`,
+				EventName:        "AllocationUpdated",
+				LogIndex:         1,
+				OutputData:       `{"operator": "` + operator + `", "strategy": "` + strategy + `", "magnitude": 500, "effectBlock": 202, "operatorSet": {"id": 5, "avs": "` + avs + `"}}`,
+			}
+
+			err = model.SetupStateForBlock(blockNumber)
+			assert.Nil(t, err)
+
+			change, err := model.HandleStateChange(log)
+			assert.Nil(t, err)
+			assert.NotNil(t, change)
+
+			record := change.(*OperatorAllocation)
+
+			// Deallocation decrease should round DOWN to current day
+			assert.Equal(t, "2025-11-16", record.EffectiveDate)
+			assert.Equal(t, "500", record.Magnitude)
+
+			err = model.CommitFinalState(blockNumber, false)
+			assert.Nil(t, err)
 		})
 	})
 

--- a/pkg/eigenState/operatorAllocations/operatorAllocations_test.go
+++ b/pkg/eigenState/operatorAllocations/operatorAllocations_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/internal/tests"
@@ -39,19 +38,6 @@ func setup() (
 	return dbname, grm, l, cfg, nil
 }
 
-func createBlock(model *OperatorAllocationModel, blockNumber uint64) error {
-	block := &storage.Block{
-		Number:    blockNumber,
-		Hash:      "some hash",
-		BlockTime: time.Now().Add(time.Hour * time.Duration(blockNumber)),
-	}
-	res := model.DB.Model(&storage.Block{}).Create(block)
-	if res.Error != nil {
-		return res.Error
-	}
-	return nil
-}
-
 func Test_OperatorAllocations(t *testing.T) {
 	dbName, grm, l, cfg, err := setup()
 
@@ -59,249 +45,56 @@ func Test_OperatorAllocations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Test each event type", func(t *testing.T) {
-		esm := stateManager.NewEigenStateManager(nil, l, grm)
-
-		model, err := NewOperatorAllocationModel(esm, grm, l, cfg)
-
-		t.Run("Handle an allocationUpdated", func(t *testing.T) {
-			blockNumber := uint64(102)
-
-			if err := createBlock(model, blockNumber); err != nil {
-				t.Fatal(err)
-			}
-
-			log := &storage.TransactionLog{
-				TransactionHash:  "some hash",
-				TransactionIndex: big.NewInt(100).Uint64(),
-				BlockNumber:      blockNumber,
-				Address:          cfg.GetContractsMapForChain().AllocationManager,
-				Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}, {"Name": "operatorSet", "Type": "(address,uint32)", "Value": null, "Indexed": false}, {"Name": "strategy", "Type": "address", "Value": null, "Indexed": false}, {"Name": "magnitude", "Type": "uint64", "Value": null, "Indexed": false}, {"Name": "effectBlock", "Type": "uint32", "Value": null, "Indexed": false}]`,
-				EventName:        "AllocationUpdated",
-				LogIndex:         big.NewInt(12).Uint64(),
-				OutputData:       `{"operator": "0x93a797473810c125ece22f25a2087b6ceb8ce886", "strategy": "0x947e522010e22856071f8fb03e735fedfccd6e9f", "magnitude": 400000000000000000, "effectBlock": 2937866, "operatorSet": {"id": 5, "avs": "0x69aa865947f6c9191b02954b1dd1a44131541226"}}`,
-			}
-
-			err = model.SetupStateForBlock(blockNumber)
-			assert.Nil(t, err)
-
-			isInteresting := model.IsInterestingLog(log)
-			assert.True(t, isInteresting)
-
-			change, err := model.HandleStateChange(log)
-			assert.Nil(t, err)
-			assert.NotNil(t, change)
-
-			record := change.(*OperatorAllocation)
-
-			assert.Equal(t, strings.ToLower("0x93a797473810c125ece22f25a2087b6ceb8ce886"), record.Operator)
-			assert.Equal(t, strings.ToLower("0x947e522010e22856071f8fb03e735fedfccd6e9f"), record.Strategy)
-			assert.Equal(t, "400000000000000000", record.Magnitude)
-			assert.Equal(t, uint64(2937866), record.EffectiveBlock)
-			assert.Equal(t, uint64(5), record.OperatorSetId)
-			assert.Equal(t, strings.ToLower("0x69aa865947f6c9191b02954b1dd1a44131541226"), record.Avs)
-
-			err = model.CommitFinalState(blockNumber, false)
-			assert.Nil(t, err)
-
-			results := make([]*OperatorAllocation, 0)
-			query := `select * from operator_allocations where block_number = ?`
-			res := model.DB.Raw(query, blockNumber).Scan(&results)
-			assert.Nil(t, res.Error)
-			assert.Equal(t, 1, len(results))
-
-			stateRoot, err := model.GenerateStateRoot(blockNumber)
-			assert.Nil(t, err)
-			assert.NotNil(t, stateRoot)
-			assert.True(t, len(stateRoot) > 0)
-		})
-	})
-
-	t.Run("Test determineEffectiveDate logic", func(t *testing.T) {
+	t.Run("Handle an allocationUpdated event", func(t *testing.T) {
 		esm := stateManager.NewEigenStateManager(nil, l, grm)
 		model, err := NewOperatorAllocationModel(esm, grm, l, cfg)
 		assert.Nil(t, err)
 
-		timestamp := time.Date(2025, 11, 14, 15, 30, 0, 0, time.UTC)
+		blockNumber := uint64(102)
 
-		t.Run("Allocation (increase) - should round up to next day", func(t *testing.T) {
-			previousMagnitude := big.NewInt(1000)
-			newMagnitude := big.NewInt(1500) // Increase of 500
+		log := &storage.TransactionLog{
+			TransactionHash:  "some hash",
+			TransactionIndex: big.NewInt(100).Uint64(),
+			BlockNumber:      blockNumber,
+			Address:          cfg.GetContractsMapForChain().AllocationManager,
+			Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}, {"Name": "operatorSet", "Type": "(address,uint32)", "Value": null, "Indexed": false}, {"Name": "strategy", "Type": "address", "Value": null, "Indexed": false}, {"Name": "magnitude", "Type": "uint64", "Value": null, "Indexed": false}, {"Name": "effectBlock", "Type": "uint32", "Value": null, "Indexed": false}]`,
+			EventName:        "AllocationUpdated",
+			LogIndex:         big.NewInt(12).Uint64(),
+			OutputData:       `{"operator": "0x93a797473810c125ece22f25a2087b6ceb8ce886", "strategy": "0x947e522010e22856071f8fb03e735fedfccd6e9f", "magnitude": 400000000000000000, "effectBlock": 2937866, "operatorSet": {"id": 5, "avs": "0x69aa865947f6c9191b02954b1dd1a44131541226"}}`,
+		}
 
-			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
-			expected := time.Date(2025, 11, 15, 0, 0, 0, 0, time.UTC)
-			assert.Equal(t, expected, result)
-		})
-
-		t.Run("Deallocation (decrease) - should round down to current day", func(t *testing.T) {
-			previousMagnitude := big.NewInt(1500)
-			newMagnitude := big.NewInt(1000) // Decrease of 500
-
-			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
-			expected := time.Date(2025, 11, 14, 0, 0, 0, 0, time.UTC)
-			assert.Equal(t, expected, result)
-		})
-
-		t.Run("No change in magnitude - should round down to current day", func(t *testing.T) {
-			previousMagnitude := big.NewInt(1000)
-			newMagnitude := big.NewInt(1000) // No change
-
-			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
-			expected := time.Date(2025, 11, 14, 0, 0, 0, 0, time.UTC)
-			assert.Equal(t, expected, result)
-		})
-
-		t.Run("First allocation (from zero) - should round up to next day", func(t *testing.T) {
-			previousMagnitude := big.NewInt(0)
-			newMagnitude := big.NewInt(1000) // First allocation
-
-			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
-			expected := time.Date(2025, 11, 15, 0, 0, 0, 0, time.UTC)
-			assert.Equal(t, expected, result)
-		})
-
-		t.Run("Full deallocation (to zero) - should round down to current day", func(t *testing.T) {
-			previousMagnitude := big.NewInt(1000)
-			newMagnitude := big.NewInt(0) // Full deallocation
-
-			result := model.determineEffectiveDate(timestamp, newMagnitude, previousMagnitude)
-			expected := time.Date(2025, 11, 14, 0, 0, 0, 0, time.UTC)
-			assert.Equal(t, expected, result)
-		})
-	})
-
-	t.Run("Test allocation vs deallocation integration", func(t *testing.T) {
-		esm := stateManager.NewEigenStateManager(nil, l, grm)
-		model, err := NewOperatorAllocationModel(esm, grm, l, cfg)
+		err = model.SetupStateForBlock(blockNumber)
 		assert.Nil(t, err)
 
-		// Clean up any existing test data to ensure isolation
-		err = grm.Exec("DELETE FROM operator_allocations").Error
+		isInteresting := model.IsInterestingLog(log)
+		assert.True(t, isInteresting)
+
+		change, err := model.HandleStateChange(log)
+		assert.Nil(t, err)
+		assert.NotNil(t, change)
+
+		record := change.(*OperatorAllocation)
+
+		assert.Equal(t, strings.ToLower("0x93a797473810c125ece22f25a2087b6ceb8ce886"), record.Operator)
+		assert.Equal(t, strings.ToLower("0x947e522010e22856071f8fb03e735fedfccd6e9f"), record.Strategy)
+		assert.Equal(t, "400000000000000000", record.Magnitude)
+		assert.Equal(t, uint64(2937866), record.EffectiveBlock)
+		assert.Equal(t, uint64(5), record.OperatorSetId)
+		assert.Equal(t, strings.ToLower("0x69aa865947f6c9191b02954b1dd1a44131541226"), record.Avs)
+
+		err = model.CommitFinalState(blockNumber, false)
 		assert.Nil(t, err)
 
-		operator := "0x93a797473810c125ece22f25a2087b6ceb8ce886"
-		avs := "0x69aa865947f6c9191b02954b1dd1a44131541226"
-		strategy := "0x947e522010e22856071f8fb03e735fedfccd6e9f"
+		results := make([]*OperatorAllocation, 0)
+		query := `select * from operator_allocations where block_number = ?`
+		res := model.DB.Raw(query, blockNumber).Scan(&results)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, 1, len(results))
 
-		t.Run("First allocation event", func(t *testing.T) {
-			blockNumber := uint64(200)
-			blockTime := time.Date(2025, 11, 14, 15, 30, 0, 0, time.UTC)
-
-			block := &storage.Block{
-				Number:    blockNumber,
-				Hash:      "hash_200",
-				BlockTime: blockTime,
-			}
-			res := model.DB.Model(&storage.Block{}).Create(block)
-			assert.Nil(t, res.Error)
-
-			log := &storage.TransactionLog{
-				TransactionHash:  "tx_hash_200",
-				TransactionIndex: 1,
-				BlockNumber:      blockNumber,
-				Address:          cfg.GetContractsMapForChain().AllocationManager,
-				Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}]`,
-				EventName:        "AllocationUpdated",
-				LogIndex:         1,
-				OutputData:       `{"operator": "` + operator + `", "strategy": "` + strategy + `", "magnitude": 1000, "effectBlock": 200, "operatorSet": {"id": 5, "avs": "` + avs + `"}}`,
-			}
-
-			err = model.SetupStateForBlock(blockNumber)
-			assert.Nil(t, err)
-
-			change, err := model.HandleStateChange(log)
-			assert.Nil(t, err)
-			assert.NotNil(t, change)
-
-			record := change.(*OperatorAllocation)
-
-			// First allocation should round UP to next day
-			assert.Equal(t, "2025-11-15", record.EffectiveDate)
-			assert.Equal(t, "1000", record.Magnitude)
-
-			err = model.CommitFinalState(blockNumber, false)
-			assert.Nil(t, err)
-		})
-
-		t.Run("Second allocation event (increase)", func(t *testing.T) {
-			blockNumber := uint64(201)
-			blockTime := time.Date(2025, 11, 15, 10, 0, 0, 0, time.UTC)
-
-			block := &storage.Block{
-				Number:    blockNumber,
-				Hash:      "hash_201",
-				BlockTime: blockTime,
-			}
-			res := model.DB.Model(&storage.Block{}).Create(block)
-			assert.Nil(t, res.Error)
-
-			log := &storage.TransactionLog{
-				TransactionHash:  "tx_hash_201",
-				TransactionIndex: 1,
-				BlockNumber:      blockNumber,
-				Address:          cfg.GetContractsMapForChain().AllocationManager,
-				Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}]`,
-				EventName:        "AllocationUpdated",
-				LogIndex:         1,
-				OutputData:       `{"operator": "` + operator + `", "strategy": "` + strategy + `", "magnitude": 1500, "effectBlock": 201, "operatorSet": {"id": 5, "avs": "` + avs + `"}}`,
-			}
-
-			err = model.SetupStateForBlock(blockNumber)
-			assert.Nil(t, err)
-
-			change, err := model.HandleStateChange(log)
-			assert.Nil(t, err)
-			assert.NotNil(t, change)
-
-			record := change.(*OperatorAllocation)
-
-			// Allocation increase should round UP to next day
-			assert.Equal(t, "2025-11-16", record.EffectiveDate)
-			assert.Equal(t, "1500", record.Magnitude)
-
-			err = model.CommitFinalState(blockNumber, false)
-			assert.Nil(t, err)
-		})
-
-		t.Run("Deallocation event (decrease)", func(t *testing.T) {
-			blockNumber := uint64(202)
-			blockTime := time.Date(2025, 11, 16, 14, 0, 0, 0, time.UTC)
-
-			block := &storage.Block{
-				Number:    blockNumber,
-				Hash:      "hash_202",
-				BlockTime: blockTime,
-			}
-			res := model.DB.Model(&storage.Block{}).Create(block)
-			assert.Nil(t, res.Error)
-
-			log := &storage.TransactionLog{
-				TransactionHash:  "tx_hash_202",
-				TransactionIndex: 1,
-				BlockNumber:      blockNumber,
-				Address:          cfg.GetContractsMapForChain().AllocationManager,
-				Arguments:        `[{"Name": "operator", "Type": "address", "Value": null, "Indexed": false}]`,
-				EventName:        "AllocationUpdated",
-				LogIndex:         1,
-				OutputData:       `{"operator": "` + operator + `", "strategy": "` + strategy + `", "magnitude": 500, "effectBlock": 202, "operatorSet": {"id": 5, "avs": "` + avs + `"}}`,
-			}
-
-			err = model.SetupStateForBlock(blockNumber)
-			assert.Nil(t, err)
-
-			change, err := model.HandleStateChange(log)
-			assert.Nil(t, err)
-			assert.NotNil(t, change)
-
-			record := change.(*OperatorAllocation)
-
-			// Deallocation decrease should round DOWN to current day
-			assert.Equal(t, "2025-11-16", record.EffectiveDate)
-			assert.Equal(t, "500", record.Magnitude)
-
-			err = model.CommitFinalState(blockNumber, false)
-			assert.Nil(t, err)
-		})
+		stateRoot, err := model.GenerateStateRoot(blockNumber)
+		assert.Nil(t, err)
+		assert.NotNil(t, stateRoot)
+		assert.True(t, len(stateRoot) > 0)
 	})
 
 	t.Cleanup(func() {

--- a/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
+++ b/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
@@ -16,55 +16,34 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 		// PART 1: Enhance queued_slashing_withdrawals to support withdrawal queue
 		// =============================================================================
 
-		// Add timestamp columns for withdrawal queue tracking
-		`alter table queued_slashing_withdrawals add column if not exists queued_timestamp timestamp`,
-		`alter table queued_slashing_withdrawals add column if not exists queued_date date`,
-
-		// Add withdrawable timing columns (queued_timestamp + 14 days)
-		`alter table queued_slashing_withdrawals add column if not exists withdrawable_at timestamp`,
-		`alter table queued_slashing_withdrawals add column if not exists withdrawable_date date`,
-
-		// Add completion tracking
+		// Add completion tracking (timestamps can be derived from blocks table via FK)
 		`alter table queued_slashing_withdrawals add column if not exists completed boolean default false`,
 		`alter table queued_slashing_withdrawals add column if not exists completion_block_number bigint`,
-		`alter table queued_slashing_withdrawals add column if not exists completion_timestamp timestamp`,
-		`alter table queued_slashing_withdrawals add column if not exists completion_date date`,
 
-		// Add metadata timestamps
-		`alter table queued_slashing_withdrawals add column if not exists created_at timestamp default current_timestamp`,
-		`alter table queued_slashing_withdrawals add column if not exists updated_at timestamp default current_timestamp`,
+		// Add FK constraint for completion block
+		`alter table queued_slashing_withdrawals add constraint if not exists fk_completion_block foreign key (completion_block_number) references blocks(number) on delete set null`,
 
 		// =============================================================================
 		// PART 2: Create indexes for efficient withdrawal queue queries
 		// =============================================================================
 
-		// Index for finding active withdrawals during a specific time period
-		`create index if not exists idx_queued_withdrawals_earning_period on queued_slashing_withdrawals(staker, queued_date, withdrawable_date) where completed = false`,
-
-		// Index for staker lookups
-		`create index if not exists idx_queued_withdrawals_staker on queued_slashing_withdrawals(staker)`,
-
-		// Index for operator lookups
-		`create index if not exists idx_queued_withdrawals_operator on queued_slashing_withdrawals(operator)`,
+		// Index for finding active (non-completed) withdrawals
+		`create index if not exists idx_queued_withdrawals_active on queued_slashing_withdrawals(staker, operator, completed) where completed = false`,
 
 		// Index for completion queries
-		`create index if not exists idx_queued_withdrawals_completion on queued_slashing_withdrawals(completion_block_number, completion_timestamp) where completed = true`,
+		`create index if not exists idx_queued_withdrawals_completed on queued_slashing_withdrawals(completion_block_number) where completed = true`,
 
 		// =============================================================================
 		// PART 3: Update operator_allocations table for rounding logic
 		// =============================================================================
 
 		// Add effective_date column for allocation/deallocation rounding
+		// This is a computed value based on magnitude changes (round UP for increases, DOWN for decreases)
+		// block_timestamp can be derived from block_number FK to blocks table
 		`alter table operator_allocations add column if not exists effective_date date`,
-
-		// Add timestamp column for precise timing
-		`alter table operator_allocations add column if not exists block_timestamp timestamp`,
 
 		// Create index for effective_date queries
 		`create index if not exists idx_operator_allocations_effective_date on operator_allocations(operator, avs, strategy, effective_date)`,
-
-		// Create index for date-based lookups
-		`create index if not exists idx_operator_allocations_date_lookup on operator_allocations(effective_date, operator)`,
 	}
 
 	for _, query := range queries {

--- a/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
+++ b/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
@@ -3,6 +3,7 @@ package _202511141700_withdrawalQueueAndAllocationRounding
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"gorm.io/gorm"
 )
@@ -17,33 +18,25 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 		// =============================================================================
 
 		// Add completion tracking (timestamps can be derived from blocks table via FK)
-		`alter table queued_slashing_withdrawals add column if not exists completed boolean default false`,
 		`alter table queued_slashing_withdrawals add column if not exists completion_block_number bigint`,
 
 		// Add FK constraint for completion block
 		`alter table queued_slashing_withdrawals add constraint fk_completion_block foreign key (completion_block_number) references blocks(number) on delete set null`,
 
 		// =============================================================================
-		// PART 2: Create indexes for efficient withdrawal queue queries
+		// PART 2: Create operator_allocation_snapshots table for rewards calculation
 		// =============================================================================
 
-		// Index for finding active (non-completed) withdrawals
-		`create index if not exists idx_queued_withdrawals_active on queued_slashing_withdrawals(staker, operator, completed) where completed = false`,
-
-		// Index for completion queries
-		`create index if not exists idx_queued_withdrawals_completed on queued_slashing_withdrawals(completion_block_number) where completed = true`,
-
-		// =============================================================================
-		// PART 3: Update operator_allocations table for rounding logic
-		// =============================================================================
-
-		// Add effective_date column for allocation/deallocation rounding
-		// This is a computed value based on magnitude changes (round UP for increases, DOWN for decreases)
-		// block_timestamp can be derived from block_number FK to blocks table
-		`alter table operator_allocations add column if not exists effective_date date`,
-
-		// Create index for effective_date queries
-		`create index if not exists idx_operator_allocations_effective_date on operator_allocations(operator, avs, strategy, effective_date)`,
+		// Create snapshot table following the same pattern as staker_share_snapshots
+		// This table will be populated during rewards calculation with rounding logic applied
+		`CREATE TABLE IF NOT EXISTS operator_allocation_snapshots (
+			operator varchar not null,
+			avs varchar not null,
+			strategy varchar not null,
+			operator_set_id bigint not null,
+			magnitude numeric not null,
+			snapshot date not null
+		)`,
 	}
 
 	for _, query := range queries {

--- a/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
+++ b/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
@@ -1,0 +1,82 @@
+package _202511141700_withdrawalQueueAndAllocationRounding
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		// =============================================================================
+		// PART 1: Enhance queued_slashing_withdrawals to support withdrawal queue
+		// =============================================================================
+
+		// Add timestamp columns for withdrawal queue tracking
+		`alter table queued_slashing_withdrawals add column if not exists queued_timestamp timestamp`,
+		`alter table queued_slashing_withdrawals add column if not exists queued_date date`,
+
+		// Add withdrawable timing columns (queued_timestamp + 14 days)
+		`alter table queued_slashing_withdrawals add column if not exists withdrawable_at timestamp`,
+		`alter table queued_slashing_withdrawals add column if not exists withdrawable_date date`,
+
+		// Add completion tracking
+		`alter table queued_slashing_withdrawals add column if not exists completed boolean default false`,
+		`alter table queued_slashing_withdrawals add column if not exists completion_block_number bigint`,
+		`alter table queued_slashing_withdrawals add column if not exists completion_timestamp timestamp`,
+		`alter table queued_slashing_withdrawals add column if not exists completion_date date`,
+
+		// Add metadata timestamps
+		`alter table queued_slashing_withdrawals add column if not exists created_at timestamp default current_timestamp`,
+		`alter table queued_slashing_withdrawals add column if not exists updated_at timestamp default current_timestamp`,
+
+		// =============================================================================
+		// PART 2: Create indexes for efficient withdrawal queue queries
+		// =============================================================================
+
+		// Index for finding active withdrawals during a specific time period
+		`create index if not exists idx_queued_withdrawals_earning_period on queued_slashing_withdrawals(staker, queued_date, withdrawable_date) where completed = false`,
+
+		// Index for staker lookups
+		`create index if not exists idx_queued_withdrawals_staker on queued_slashing_withdrawals(staker)`,
+
+		// Index for operator lookups
+		`create index if not exists idx_queued_withdrawals_operator on queued_slashing_withdrawals(operator)`,
+
+		// Index for completion queries
+		`create index if not exists idx_queued_withdrawals_completion on queued_slashing_withdrawals(completion_block_number, completion_timestamp) where completed = true`,
+
+		// =============================================================================
+		// PART 3: Update operator_allocations table for rounding logic
+		// =============================================================================
+
+		// Add effective_date column for allocation/deallocation rounding
+		`alter table operator_allocations add column if not exists effective_date date`,
+
+		// Add timestamp column for precise timing
+		`alter table operator_allocations add column if not exists block_timestamp timestamp`,
+
+		// Create index for effective_date queries
+		`create index if not exists idx_operator_allocations_effective_date on operator_allocations(operator, avs, strategy, effective_date)`,
+
+		// Create index for date-based lookups
+		`create index if not exists idx_operator_allocations_date_lookup on operator_allocations(effective_date, operator)`,
+	}
+
+	for _, query := range queries {
+		res := grm.Exec(query)
+		if res.Error != nil {
+			fmt.Printf("Error executing query: %s\n", query)
+			return res.Error
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202511141700_withdrawalQueueAndAllocationRounding"
+}

--- a/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
+++ b/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding/up.go
@@ -21,7 +21,7 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 		`alter table queued_slashing_withdrawals add column if not exists completion_block_number bigint`,
 
 		// Add FK constraint for completion block
-		`alter table queued_slashing_withdrawals add constraint if not exists fk_completion_block foreign key (completion_block_number) references blocks(number) on delete set null`,
+		`alter table queued_slashing_withdrawals add constraint fk_completion_block foreign key (completion_block_number) references blocks(number) on delete set null`,
 
 		// =============================================================================
 		// PART 2: Create indexes for efficient withdrawal queue queries

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -82,6 +82,7 @@ import (
 	_202507301346_taskMailboxTables "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202507301346_taskMailboxTables"
 	_202507301421_crossChainRegistryTables "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202507301421_crossChainRegistryTables"
 	_202511051502_keyRotationScheduled "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202511051502_keyRotationScheduled"
+	_202511141700_withdrawalQueueAndAllocationRounding "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding"
 )
 
 // Migration interface defines the contract for database migrations.
@@ -226,6 +227,7 @@ func (m *Migrator) MigrateAll() error {
 		&_202507301421_crossChainRegistryTables.Migration{},
 		&_202507301346_taskMailboxTables.Migration{},
 		&_202511051502_keyRotationScheduled.Migration{},
+		&_202511141700_withdrawalQueueAndAllocationRounding.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/rewards/operatorAllocationSnapshots.go
+++ b/pkg/rewards/operatorAllocationSnapshots.go
@@ -1,0 +1,118 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const operatorAllocationSnapshotsQuery = `
+	insert into operator_allocation_snapshots(operator, avs, strategy, operator_set_id, magnitude, snapshot)
+	WITH ranked_allocation_records as (
+		SELECT *,
+			   ROW_NUMBER() OVER (PARTITION BY operator, avs, strategy, operator_set_id, cast(block_time AS DATE) ORDER BY block_time DESC, log_index DESC) AS rn
+		FROM operator_allocations oa
+		INNER JOIN blocks b ON oa.block_number = b.number
+		WHERE b.block_time < TIMESTAMP '{{.cutoffDate}}'
+	),
+	-- Get the latest record for each day
+	daily_records as (
+		SELECT
+			operator,
+			avs,
+			strategy,
+			operator_set_id,
+			magnitude,
+			block_time,
+			block_number,
+			log_index
+		FROM ranked_allocation_records
+		WHERE rn = 1
+	),
+	-- Compare each record with the previous record to determine if it's an increase or decrease
+	records_with_comparison as (
+		SELECT
+			operator,
+			avs,
+			strategy,
+			operator_set_id,
+			magnitude,
+			block_time,
+			LAG(magnitude) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY block_time, block_number, log_index) as previous_magnitude,
+			-- Allocation (increase): Round UP to next day
+			-- Deallocation (decrease or no change): Round DOWN to current day
+			CASE
+				WHEN LAG(magnitude) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY block_time, block_number, log_index) IS NULL THEN
+					-- First allocation: round down to current day (conservative default)
+					date_trunc('day', block_time)
+				WHEN magnitude > LAG(magnitude) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY block_time, block_number, log_index) THEN
+					-- Increase: round up to next day
+					date_trunc('day', block_time) + INTERVAL '1' day
+				ELSE
+					-- Decrease or no change: round down to current day
+					date_trunc('day', block_time)
+			END AS snapshot_time
+		FROM daily_records
+	),
+	-- Get the range for each operator, avs, strategy, operator_set_id combination
+	allocation_windows as (
+		SELECT
+			operator,
+			avs,
+			strategy,
+			operator_set_id,
+			magnitude,
+			snapshot_time as start_time,
+			CASE
+				-- If the range does not have the end, use the current timestamp truncated to 0 UTC
+				WHEN LEAD(snapshot_time) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY snapshot_time) is null THEN date_trunc('day', TIMESTAMP '{{.cutoffDate}}')
+				ELSE LEAD(snapshot_time) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY snapshot_time)
+			END AS end_time
+		FROM records_with_comparison
+	),
+	cleaned_records as (
+		SELECT * FROM allocation_windows
+		WHERE start_time < end_time
+	)
+	SELECT
+		operator,
+		avs,
+		strategy,
+		operator_set_id,
+		magnitude,
+		cast(day AS DATE) AS snapshot
+	FROM
+		cleaned_records
+	CROSS JOIN
+		generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS day
+	on conflict do nothing;
+`
+
+func (r *RewardsCalculator) GenerateAndInsertOperatorAllocationSnapshots(snapshotDate string) error {
+	query, err := rewardsUtils.RenderQueryTemplate(operatorAllocationSnapshotsQuery, map[string]interface{}{
+		"cutoffDate": snapshotDate,
+	})
+	if err != nil {
+		r.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := r.grm.Exec(query)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to generate operator_allocation_snapshots",
+			zap.String("snapshotDate", snapshotDate),
+			zap.Error(res.Error),
+		)
+		return res.Error
+	}
+	return nil
+}
+
+func (r *RewardsCalculator) ListOperatorAllocationSnapshots() ([]*OperatorAllocationSnapshot, error) {
+	var snapshots []*OperatorAllocationSnapshot
+	res := r.grm.Model(&OperatorAllocationSnapshot{}).Find(&snapshots)
+	if res.Error != nil {
+		r.logger.Sugar().Errorw("Failed to list operator allocation snapshots", "error", res.Error)
+		return nil, res.Error
+	}
+	return snapshots, nil
+}

--- a/pkg/rewards/operatorAllocationSnapshots_test.go
+++ b/pkg/rewards/operatorAllocationSnapshots_test.go
@@ -1,0 +1,142 @@
+package rewards
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/internal/tests"
+	"github.com/Layr-Labs/sidecar/pkg/logger"
+	"github.com/Layr-Labs/sidecar/pkg/metrics"
+	"github.com/Layr-Labs/sidecar/pkg/postgres"
+	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+func setupOperatorAllocationSnapshot() (
+	string,
+	*config.Config,
+	*gorm.DB,
+	*zap.Logger,
+	*metrics.MetricsSink,
+	error,
+) {
+	cfg := tests.GetConfig()
+	cfg.Chain = config.Chain_Holesky
+	cfg.DatabaseConfig = *tests.GetDbConfigFromEnv()
+
+	l, _ := logger.NewLogger(&logger.LoggerConfig{Debug: cfg.Debug})
+	sink, _ := metrics.NewMetricsSink(&metrics.MetricsSinkConfig{}, nil)
+
+	dbname, _, grm, err := postgres.GetTestPostgresDatabase(cfg.DatabaseConfig, cfg, l)
+	if err != nil {
+		return dbname, nil, nil, nil, nil, err
+	}
+
+	return dbname, cfg, grm, l, sink, nil
+}
+
+func teardownOperatorAllocationSnapshot(dbname string, cfg *config.Config, db *gorm.DB, l *zap.Logger) {
+	rawDb, _ := db.DB()
+	_ = rawDb.Close()
+
+	pgConfig := postgres.PostgresConfigFromDbConfig(&cfg.DatabaseConfig)
+
+	if err := postgres.DeleteTestDatabase(pgConfig, dbname); err != nil {
+		l.Sugar().Errorw("Failed to delete test database", "error", err)
+	}
+}
+
+func Test_OperatorAllocationSnapshots(t *testing.T) {
+	if !rewardsTestsEnabled() {
+		t.Skipf("Skipping %s", t.Name())
+		return
+	}
+
+	dbFileName, cfg, grm, l, sink, err := setupOperatorAllocationSnapshot()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshotDate := "2024-11-16"
+
+	t.Run("Should generate operator allocation snapshots with rounding", func(t *testing.T) {
+		// Create test blocks
+		blocks := []struct {
+			number    uint64
+			blockTime time.Time
+		}{
+			{100, time.Date(2024, 11, 14, 10, 0, 0, 0, time.UTC)},
+			{101, time.Date(2024, 11, 14, 15, 0, 0, 0, time.UTC)},
+			{102, time.Date(2024, 11, 15, 12, 0, 0, 0, time.UTC)},
+		}
+
+		for _, b := range blocks {
+			res := grm.Exec(`
+				INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+				VALUES (?, ?, ?, ?, '', NOW(), NOW())
+			`, b.number, fmt.Sprintf("hash_%d", b.number), b.blockTime, b.blockTime.Format("2006-01-02"))
+			assert.Nil(t, res.Error)
+		}
+
+		// Create test operator allocations
+		// First allocation: magnitude 1000 at block 100 (should round up to 2024-11-15)
+		res := grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator1", "0xavs1", "0xstrategy1", 1, "1000", 100, 100, "tx_100", 1)
+		assert.Nil(t, res.Error)
+
+		// Increase allocation: magnitude 1500 at block 101 (should round up to 2024-11-16)
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator1", "0xavs1", "0xstrategy1", 1, "1500", 101, 101, "tx_101", 1)
+		assert.Nil(t, res.Error)
+
+		// Decrease allocation: magnitude 500 at block 102 (should round down to 2024-11-15)
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator1", "0xavs1", "0xstrategy1", 1, "500", 102, 102, "tx_102", 1)
+		assert.Nil(t, res.Error)
+
+		// Generate snapshots
+		calculator := NewRewardsCalculator(grm, nil, cfg, l, sink, stakerOperators.NewStakerOperatorStore(grm, l))
+		err := calculator.GenerateAndInsertOperatorAllocationSnapshots(snapshotDate)
+		assert.Nil(t, err)
+
+		// Verify snapshots were created
+		var snapshots []OperatorAllocationSnapshot
+		res = grm.Raw(`
+			SELECT * FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			ORDER BY snapshot
+		`, "0xoperator1", "0xavs1", "0xstrategy1", 1).Scan(&snapshots)
+		assert.Nil(t, res.Error)
+		assert.True(t, len(snapshots) > 0, "Expected snapshots to be generated")
+
+		// Verify rounding behavior:
+		// - First allocation (1000) at block 100 (2024-11-14 10:00) should have snapshot starting 2024-11-15
+		// - Increase (1500) at block 101 (2024-11-14 15:00) should have snapshot starting 2024-11-15 (next day after 2024-11-14)
+		// - Decrease (500) at block 102 (2024-11-15 12:00) should have snapshot starting 2024-11-15 (same day)
+
+		// Find the snapshot with magnitude 1000
+		var mag1000Count int64
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude = '1000' AND snapshot = ?
+		`, "0xoperator1", "0xavs1", "0xstrategy1", 1, "2024-11-15").Scan(&mag1000Count)
+		assert.Nil(t, res.Error)
+		assert.True(t, mag1000Count > 0, "Expected magnitude 1000 to have snapshot on 2024-11-15 (rounded up)")
+	})
+
+	t.Cleanup(func() {
+		teardownOperatorAllocationSnapshot(dbFileName, cfg, grm, l)
+	})
+}

--- a/pkg/rewards/operatorAllocationSnapshots_test.go
+++ b/pkg/rewards/operatorAllocationSnapshots_test.go
@@ -106,8 +106,11 @@ func Test_OperatorAllocationSnapshots(t *testing.T) {
 		assert.Nil(t, res.Error)
 
 		// Generate snapshots
-		calculator := NewRewardsCalculator(grm, nil, cfg, l, sink, stakerOperators.NewStakerOperatorStore(grm, l))
-		err := calculator.GenerateAndInsertOperatorAllocationSnapshots(snapshotDate)
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		calculator, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
+		assert.Nil(t, err)
+
+		err = calculator.GenerateAndInsertOperatorAllocationSnapshots(snapshotDate)
 		assert.Nil(t, err)
 
 		// Verify snapshots were created
@@ -121,19 +124,329 @@ func Test_OperatorAllocationSnapshots(t *testing.T) {
 		assert.True(t, len(snapshots) > 0, "Expected snapshots to be generated")
 
 		// Verify rounding behavior:
-		// - First allocation (1000) at block 100 (2024-11-14 10:00) should have snapshot starting 2024-11-15
-		// - Increase (1500) at block 101 (2024-11-14 15:00) should have snapshot starting 2024-11-15 (next day after 2024-11-14)
-		// - Decrease (500) at block 102 (2024-11-15 12:00) should have snapshot starting 2024-11-15 (same day)
+		// - Block 100 (2024-11-14 10:00, mag 1000) and block 101 (2024-11-14 15:00, mag 1500) both on 2024-11-14
+		// - SQL takes latest record per day: block 101 with magnitude 1500
+		// - Since 1500 > 1000 (increase), rounds up to 2024-11-15
+		// - Block 102 (2024-11-15 12:00, mag 500): decrease from 1500 to 500, rounds down to 2024-11-15
+		// - Final allocation: 500 (the latest/current magnitude after all operations)
 
-		// Find the snapshot with magnitude 1000
-		var mag1000Count int64
+		// Find the snapshot with magnitude 500 (deallocation on 2024-11-15, rounded down)
+		// When both the allocation (1500, rounded up from 11/14) and deallocation (500, rounded down from 11/15)
+		// land on the same snapshot date (2024-11-15), only the chronologically later event (500) appears.
+		var mag500Count int64
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude = '500' AND snapshot = ?
+		`, "0xoperator1", "0xavs1", "0xstrategy1", 1, "2024-11-15").Scan(&mag500Count)
+		assert.Nil(t, res.Error)
+		assert.True(t, mag500Count > 0, "Expected magnitude 500 on 2024-11-15 (deallocation rounds down, overrides allocation that rounded up)")
+
+		// Verify magnitude 1500 does NOT appear in snapshots (filtered out due to zero-length window)
+		var mag1500Count int64
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude = '1500'
+		`, "0xoperator1", "0xavs1", "0xstrategy1", 1).Scan(&mag1500Count)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, int64(0), mag1500Count, "Expected magnitude 1500 to NOT appear (its window [2024-11-15, 2024-11-15) has zero length)")
+	})
+
+	t.Run("Basic allocation round up test", func(t *testing.T) {
+		// Create test block
+		blockTime := time.Date(2024, 12, 1, 14, 30, 0, 0, time.UTC)
+		blockNum := uint64(200)
+		res := grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, blockNum, fmt.Sprintf("hash_%d", blockNum), blockTime, blockTime.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		// First allocation should round up to next day (2024-12-02)
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator2", "0xavs2", "0xstrategy2", 2, "2000", blockNum, blockNum, "tx_200", 1)
+		assert.Nil(t, res.Error)
+
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		calculator, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
+		assert.Nil(t, err)
+
+		err = calculator.GenerateAndInsertOperatorAllocationSnapshots("2024-12-05")
+		assert.Nil(t, err)
+
+		// Verify first allocation rounds up to 2024-12-02
+		var count int64
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude = '2000' AND snapshot = ?
+		`, "0xoperator2", "0xavs2", "0xstrategy2", 2, "2024-12-02").Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.True(t, count > 0, "Expected first allocation to round up to 2024-12-02")
+	})
+
+	t.Run("Multiple allocations same day uses latest", func(t *testing.T) {
+		// Create blocks - all on same day
+		baseDate := time.Date(2024, 12, 10, 0, 0, 0, 0, time.UTC)
+		blocks := []struct {
+			number    uint64
+			hour      int
+			magnitude string
+		}{
+			{300, 8, "3000"},  // 08:00
+			{301, 12, "3500"}, // 12:00
+			{302, 18, "4000"}, // 18:00 - latest, should be used
+		}
+
+		for _, b := range blocks {
+			blockTime := baseDate.Add(time.Duration(b.hour) * time.Hour)
+			res := grm.Exec(`
+				INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+				VALUES (?, ?, ?, ?, '', NOW(), NOW())
+			`, b.number, fmt.Sprintf("hash_%d", b.number), blockTime, blockTime.Format("2006-01-02"))
+			assert.Nil(t, res.Error)
+
+			res = grm.Exec(`
+				INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+			`, "0xoperator3", "0xavs3", "0xstrategy3", 3, b.magnitude, b.number, b.number, fmt.Sprintf("tx_%d", b.number), 1)
+			assert.Nil(t, res.Error)
+		}
+
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		calculator, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
+		assert.Nil(t, err)
+
+		err = calculator.GenerateAndInsertOperatorAllocationSnapshots("2024-12-15")
+		assert.Nil(t, err)
+
+		// Verify only the latest allocation (4000) is used, rounded up to 2024-12-11
+		var count int64
+		res := grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude = '4000' AND snapshot = ?
+		`, "0xoperator3", "0xavs3", "0xstrategy3", 3, "2024-12-11").Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.True(t, count > 0, "Expected latest allocation (4000) to be used, rounded up to 2024-12-11")
+
+		// Verify earlier allocations are not present
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude IN ('3000', '3500')
+		`, "0xoperator3", "0xavs3", "0xstrategy3", 3).Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, int64(0), count, "Expected earlier allocations to not be present")
+	})
+
+	t.Run("Allocate and deallocate same day uses latest", func(t *testing.T) {
+		// Create blocks on same day
+		baseDate := time.Date(2024, 12, 20, 0, 0, 0, 0, time.UTC)
+
+		// Allocate at 10:00
+		block1Time := baseDate.Add(10 * time.Hour)
+		block1Num := uint64(400)
+		res := grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block1Num, fmt.Sprintf("hash_%d", block1Num), block1Time, block1Time.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator4", "0xavs4", "0xstrategy4", 4, "5000", block1Num, block1Num, "tx_400", 1)
+		assert.Nil(t, res.Error)
+
+		// Deallocate at 16:00 (same day)
+		block2Time := baseDate.Add(16 * time.Hour)
+		block2Num := uint64(401)
+		res = grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block2Num, fmt.Sprintf("hash_%d", block2Num), block2Time, block2Time.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator4", "0xavs4", "0xstrategy4", 4, "1000", block2Num, block2Num, "tx_401", 1)
+		assert.Nil(t, res.Error)
+
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		calculator, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
+		assert.Nil(t, err)
+
+		err = calculator.GenerateAndInsertOperatorAllocationSnapshots("2024-12-25")
+		assert.Nil(t, err)
+
+		// Verify the latest record (deallocation to 1000) is used
+		// Since it's a decrease, it should round down to 2024-12-20
+		var count int64
 		res = grm.Raw(`
 			SELECT COUNT(*) FROM operator_allocation_snapshots
 			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
 			AND magnitude = '1000' AND snapshot = ?
-		`, "0xoperator1", "0xavs1", "0xstrategy1", 1, "2024-11-15").Scan(&mag1000Count)
+		`, "0xoperator4", "0xavs4", "0xstrategy4", 4, "2024-12-20").Scan(&count)
 		assert.Nil(t, res.Error)
-		assert.True(t, mag1000Count > 0, "Expected magnitude 1000 to have snapshot on 2024-11-15 (rounded up)")
+		assert.True(t, count > 0, "Expected latest deallocation (1000) to be used, rounded down to 2024-12-20")
+	})
+
+	t.Run("Allocate day 1, deallocate to 0 day 2 at 12pm - 0 days counted", func(t *testing.T) {
+		// Allocate on day 1
+		day1 := time.Date(2025, 1, 10, 10, 0, 0, 0, time.UTC)
+		block1Num := uint64(500)
+		res := grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block1Num, fmt.Sprintf("hash_%d", block1Num), day1, day1.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator5", "0xavs5", "0xstrategy5", 5, "6000", block1Num, block1Num, "tx_500", 1)
+		assert.Nil(t, res.Error)
+
+		// Deallocate to 0 on day 2 at 12pm (noon)
+		day2Noon := time.Date(2025, 1, 11, 12, 0, 0, 0, time.UTC)
+		block2Num := uint64(501)
+		res = grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block2Num, fmt.Sprintf("hash_%d", block2Num), day2Noon, day2Noon.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator5", "0xavs5", "0xstrategy5", 5, "0", block2Num, block2Num, "tx_501", 1)
+		assert.Nil(t, res.Error)
+
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		calculator, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
+		assert.Nil(t, err)
+
+		err = calculator.GenerateAndInsertOperatorAllocationSnapshots("2025-01-15")
+		assert.Nil(t, err)
+
+		// Allocation on day 1 (2025-01-10) rounds up to 2025-01-11
+		// Deallocation on day 2 (2025-01-11) rounds down to 2025-01-11
+		// So the range is [2025-01-11, 2025-01-11) which generates no days
+		var count int64
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+		`, "0xoperator5", "0xavs5", "0xstrategy5", 5).Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, int64(0), count, "Expected 0 days to be counted (allocation rounds up to day 2, deallocation rounds down to day 2)")
+	})
+
+	t.Run("Allocate day 1, deallocate to 0 day 3 at 12pm - 1 day counted", func(t *testing.T) {
+		// Allocate on day 1
+		day1 := time.Date(2025, 1, 20, 10, 0, 0, 0, time.UTC)
+		block1Num := uint64(600)
+		res := grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block1Num, fmt.Sprintf("hash_%d", block1Num), day1, day1.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator6", "0xavs6", "0xstrategy6", 6, "7000", block1Num, block1Num, "tx_600", 1)
+		assert.Nil(t, res.Error)
+
+		// Deallocate to 0 on day 3 at 12pm (noon)
+		day3Noon := time.Date(2025, 1, 22, 12, 0, 0, 0, time.UTC)
+		block2Num := uint64(601)
+		res = grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block2Num, fmt.Sprintf("hash_%d", block2Num), day3Noon, day3Noon.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator6", "0xavs6", "0xstrategy6", 6, "0", block2Num, block2Num, "tx_601", 1)
+		assert.Nil(t, res.Error)
+
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		calculator, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
+		assert.Nil(t, err)
+
+		err = calculator.GenerateAndInsertOperatorAllocationSnapshots("2025-01-25")
+		assert.Nil(t, err)
+
+		// Allocation on day 1 (2025-01-20) rounds up to 2025-01-21
+		// Deallocation on day 3 (2025-01-22) rounds down to 2025-01-22
+		// So the range is [2025-01-21, 2025-01-22) which generates 1 day (2025-01-21)
+		var count int64
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+		`, "0xoperator6", "0xavs6", "0xstrategy6", 6).Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, int64(1), count, "Expected 1 day to be counted (2025-01-21)")
+
+		// Verify the snapshot is on 2025-01-21 with magnitude 7000
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude = '7000' AND snapshot = ?
+		`, "0xoperator6", "0xavs6", "0xstrategy6", 6, "2025-01-21").Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.Equal(t, int64(1), count, "Expected snapshot on 2025-01-21 with magnitude 7000")
+	})
+
+	t.Run("Future allocation - event at block 1, effective at block 10", func(t *testing.T) {
+		// Event emitted at block 1 (day 1)
+		day1 := time.Date(2025, 2, 1, 10, 0, 0, 0, time.UTC)
+		block1Num := uint64(700)
+		res := grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block1Num, fmt.Sprintf("hash_%d", block1Num), day1, day1.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		// Effective block 10 (day 5)
+		day5 := time.Date(2025, 2, 5, 14, 0, 0, 0, time.UTC)
+		block10Num := uint64(710)
+		res = grm.Exec(`
+			INSERT INTO blocks (number, hash, block_time, block_date, state_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, '', NOW(), NOW())
+		`, block10Num, fmt.Sprintf("hash_%d", block10Num), day5, day5.Format("2006-01-02"))
+		assert.Nil(t, res.Error)
+
+		// Allocation event at block 1, effective at block 10
+		res = grm.Exec(`
+			INSERT INTO operator_allocations (operator, avs, strategy, operator_set_id, magnitude, effective_block, block_number, transaction_hash, log_index, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+		`, "0xoperator7", "0xavs7", "0xstrategy7", 7, "8000", block10Num, block1Num, "tx_700", 1)
+		assert.Nil(t, res.Error)
+
+		sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
+		calculator, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
+		assert.Nil(t, err)
+
+		err = calculator.GenerateAndInsertOperatorAllocationSnapshots("2025-02-10")
+		assert.Nil(t, err)
+
+		// Allocation should use effective block's day (2025-02-05), round up to 2025-02-06
+		var count int64
+		res = grm.Raw(`
+			SELECT COUNT(*) FROM operator_allocation_snapshots
+			WHERE operator = ? AND avs = ? AND strategy = ? AND operator_set_id = ?
+			AND magnitude = '8000' AND snapshot = ?
+		`, "0xoperator7", "0xavs7", "0xstrategy7", 7, "2025-02-06").Scan(&count)
+		assert.Nil(t, res.Error)
+		assert.True(t, count > 0, "Expected allocation to round up based on effective block (2025-02-05) to 2025-02-06, not emission block")
 	})
 
 	t.Cleanup(func() {

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -667,6 +667,12 @@ func (rc *RewardsCalculator) generateSnapshotData(snapshotDate string) error {
 	}
 	rc.logger.Sugar().Debugw("Generated operator share snapshots")
 
+	if err = rc.GenerateAndInsertOperatorAllocationSnapshots(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate operator allocation snapshots", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Debugw("Generated operator allocation snapshots")
+
 	if err = rc.GenerateAndInsertStakerShareSnapshots(snapshotDate); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate staker share snapshots", "error", err)
 		return err

--- a/pkg/rewards/tables.go
+++ b/pkg/rewards/tables.go
@@ -153,3 +153,12 @@ type OperatorDirectedOperatorSetRewards struct {
 	BlockTime      time.Time
 	BlockDate      string
 }
+
+type OperatorAllocationSnapshot struct {
+	Operator      string
+	Avs           string
+	Strategy      string
+	OperatorSetId uint64
+	Magnitude     string
+	Snapshot      time.Time
+}


### PR DESCRIPTION
## Description

### 1. Database Migration (`202511141700_withdrawalQueueAndAllocationRounding`)
- Enhanced `queued_slashing_withdrawals` table with timing columns for 14-day withdrawal tracking:
  - `completed`, `completion_*` - Completion tracking
- Enhanced `operator_allocations` table with rounding support:
  - `effective_date` - Rounded date when allocation/deallocation takes effect

### 2. Allocation/Deallocation Rounding Logic (Sabine Fork)
Implements day-boundary rounding to prevent gaming and mimic existing registration behavior:
- **Allocations (increases)**: Round **UP** to next day → starts earning tomorrow
- **Deallocations (decreases)**: Round **DOWN** to current day → stops earning immediately
- **No change**: Round **DOWN** to current day (conservative default)

### 3. Dual Behavior Implementation
Maintains backward compatibility with fork-based behavior switching:
- **Before Sabine fork**: Uses old behavior (no rounding, date fields are NULL)
- **After Sabine fork**: Applies rounding logic and populates date fields
- Model continues processing allocations from Brazos fork onwards

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
