### PR TITLE
feat: implement Rewards v2.2 - Operator Set Rewards with Unique & Total Stake

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -907,13 +907,12 @@ func (c *Config) IsRewardsV2_2EnabledForCutoffDate(cutoffDate string) (bool, err
 	if err != nil {
 		return false, errors.Join(fmt.Errorf("failed to parse cutoff date %s", cutoffDate), err)
 	}
-	// TODO: Need to change to fork sabine
-	pecosForkDateTime, err := time.Parse(time.DateOnly, forks[RewardsFork_Pecos].Date)
+	sabineForkDateTime, err := time.Parse(time.DateOnly, forks[RewardsFork_Sabine].Date)
 	if err != nil {
-		return false, errors.Join(fmt.Errorf("failed to parse Pecos fork date %s", forks[RewardsFork_Pecos].Date), err)
+		return false, errors.Join(fmt.Errorf("failed to parse Sabine fork date %s", forks[RewardsFork_Sabine].Date), err)
 	}
 
-	return cutoffDateTime.Compare(pecosForkDateTime) >= 0, nil
+	return cutoffDateTime.Compare(sabineForkDateTime) >= 0, nil
 }
 
 // CanIgnoreIncorrectRewardsRoot returns true if the rewards root can be ignored for the given block number

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,7 @@ type RewardsConfig struct {
 	GenerateStakerOperatorsTable bool
 	CalculateRewardsDaily        bool
 	WithdrawalQueueWindow        float64 // Duration in days for withdrawal queue period (14.0 for mainnet, 0.0069 for testnet/preprod ~10 min)
+	RewardsV2_2Enabled           bool
 }
 
 type StatsdConfig struct {
@@ -241,6 +242,7 @@ var (
 	RewardsGenerateStakerOperatorsTable = "rewards.generate_staker_operators_table"
 	RewardsCalculateRewardsDaily        = "rewards.calculate_rewards_daily"
 	RewardsWithdrawalQueueWindow        = "rewards.withdrawal_queue_window"
+	RewardsV2_2Enabled                  = "rewards.v2_2_enabled"
 
 	EthereumRpcBaseUrl               = "ethereum.rpc_url"
 	EthereumRpcContractCallBatchSize = "ethereum.contract_call_batch_size"
@@ -329,6 +331,7 @@ func NewConfig() *Config {
 			GenerateStakerOperatorsTable: viper.GetBool(normalizeFlagName(RewardsGenerateStakerOperatorsTable)),
 			CalculateRewardsDaily:        viper.GetBool(normalizeFlagName(RewardsCalculateRewardsDaily)),
 			WithdrawalQueueWindow:        FloatWithDefault(viper.GetFloat64(normalizeFlagName(RewardsWithdrawalQueueWindow)), getDefaultWithdrawalQueueDuration(chain)),
+			RewardsV2_2Enabled:           viper.GetBool(normalizeFlagName(RewardsV2_2Enabled)),
 		},
 
 		DataDogConfig: DataDogConfig{
@@ -893,6 +896,28 @@ func (c *Config) IsRewardsV2_1EnabledForCutoffDate(cutoffDate string) (bool, err
 	}
 
 	return cutoffDateTime.Compare(mississippiForkDateTime) >= 0, nil
+}
+
+func (c *Config) IsRewardsV2_2EnabledForCutoffDate(cutoffDate string) (bool, error) {
+	// Check global flag first - if disabled, return false regardless of date
+	if !c.Rewards.RewardsV2_2Enabled {
+		return false, nil
+	}
+
+	forks, err := c.GetRewardsSqlForkDates()
+	if err != nil {
+		return false, err
+	}
+	cutoffDateTime, err := time.Parse(time.DateOnly, cutoffDate)
+	if err != nil {
+		return false, errors.Join(fmt.Errorf("failed to parse cutoff date %s", cutoffDate), err)
+	}
+	pecosForkDateTime, err := time.Parse(time.DateOnly, forks[RewardsFork_Pecos].Date)
+	if err != nil {
+		return false, errors.Join(fmt.Errorf("failed to parse Pecos fork date %s", forks[RewardsFork_Pecos].Date), err)
+	}
+
+	return cutoffDateTime.Compare(pecosForkDateTime) >= 0, nil
 }
 
 // CanIgnoreIncorrectRewardsRoot returns true if the rewards root can be ignored for the given block number

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -899,11 +899,6 @@ func (c *Config) IsRewardsV2_1EnabledForCutoffDate(cutoffDate string) (bool, err
 }
 
 func (c *Config) IsRewardsV2_2EnabledForCutoffDate(cutoffDate string) (bool, error) {
-	// Check global flag first - if disabled, return false regardless of date
-	if !c.Rewards.RewardsV2_2Enabled {
-		return false, nil
-	}
-
 	forks, err := c.GetRewardsSqlForkDates()
 	if err != nil {
 		return false, err
@@ -912,6 +907,7 @@ func (c *Config) IsRewardsV2_2EnabledForCutoffDate(cutoffDate string) (bool, err
 	if err != nil {
 		return false, errors.Join(fmt.Errorf("failed to parse cutoff date %s", cutoffDate), err)
 	}
+	// TODO: Need to change to fork sabine
 	pecosForkDateTime, err := time.Parse(time.DateOnly, forks[RewardsFork_Pecos].Date)
 	if err != nil {
 		return false, errors.Join(fmt.Errorf("failed to parse Pecos fork date %s", forks[RewardsFork_Pecos].Date), err)

--- a/pkg/postgres/migrations/202512160000_addSlashableUntilToOperatorRegistrationSnapshots/up.go
+++ b/pkg/postgres/migrations/202512160000_addSlashableUntilToOperatorRegistrationSnapshots/up.go
@@ -2,6 +2,7 @@ package _202512160000_addSlashableUntilToOperatorRegistrationSnapshots
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/Layr-Labs/sidecar/internal/config"
 	"gorm.io/gorm"
@@ -11,20 +12,24 @@ type Migration struct {
 }
 
 func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	// Get the withdrawal queue window from config (14 days on mainnet, ~10 minutes on testnets)
+	withdrawalQueueWindow := cfg.Rewards.WithdrawalQueueWindow
+
 	queries := []string{
 		// Step 1: Add nullable column
 		`ALTER TABLE operator_set_operator_registration_snapshots
 		 ADD COLUMN IF NOT EXISTS slashable_until DATE`,
+	}
 
-		// Step 2: Backfill accurate slashable_until dates for deregistered operators
-		// NULL = operator is still active, DATE = deregistration_date + 14 days
-		`WITH deregistration_events AS (
+	// Step 2: Backfill accurate slashable_until dates for deregistered operators
+	// NULL = operator is still active, DATE = deregistration_date + withdrawal_queue_window
+	backfillQuery := fmt.Sprintf(`WITH deregistration_events AS (
 			SELECT
 				osor.operator,
 				osor.avs,
 				osor.operator_set_id,
 				DATE(b.block_time) as deregistration_date,
-				DATE(b.block_time) + INTERVAL '14 days' as slashable_until_date
+				DATE(b.block_time) + (%f * INTERVAL '1 day') as slashable_until_date
 			FROM operator_set_operator_registrations osor
 			JOIN blocks b ON osor.block_number = b.number
 			WHERE osor.is_active = FALSE
@@ -46,8 +51,9 @@ func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
 		WHERE osors.operator = ld.operator
 		  AND osors.avs = ld.avs
 		  AND osors.operator_set_id = ld.operator_set_id
-		  AND osors.snapshot <= ld.deregistration_date`,
-	}
+		  AND osors.snapshot <= ld.deregistration_date`, withdrawalQueueWindow)
+
+	queries = append(queries, backfillQuery)
 
 	for _, query := range queries {
 		if _, err := db.Exec(query); err != nil {

--- a/pkg/postgres/migrations/202512160000_addSlashableUntilToOperatorRegistrationSnapshots/up.go
+++ b/pkg/postgres/migrations/202512160000_addSlashableUntilToOperatorRegistrationSnapshots/up.go
@@ -1,0 +1,62 @@
+package _202512160000_addSlashableUntilToOperatorRegistrationSnapshots
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		// Step 1: Add nullable column
+		`ALTER TABLE operator_set_operator_registration_snapshots
+		 ADD COLUMN IF NOT EXISTS slashable_until DATE`,
+
+		// Step 2: Backfill accurate slashable_until dates for deregistered operators
+		// NULL = operator is still active, DATE = deregistration_date + 14 days
+		`WITH deregistration_events AS (
+			SELECT
+				osor.operator,
+				osor.avs,
+				osor.operator_set_id,
+				DATE(b.block_time) as deregistration_date,
+				DATE(b.block_time) + INTERVAL '14 days' as slashable_until_date
+			FROM operator_set_operator_registrations osor
+			JOIN blocks b ON osor.block_number = b.number
+			WHERE osor.is_active = FALSE
+		),
+		last_deregistration AS (
+			-- Get the most recent deregistration for each (operator, avs, operator_set_id)
+			SELECT DISTINCT ON (operator, avs, operator_set_id)
+				operator,
+				avs,
+				operator_set_id,
+				deregistration_date,
+				slashable_until_date
+			FROM deregistration_events
+			ORDER BY operator, avs, operator_set_id, deregistration_date DESC
+		)
+		UPDATE operator_set_operator_registration_snapshots osors
+		SET slashable_until = ld.slashable_until_date
+		FROM last_deregistration ld
+		WHERE osors.operator = ld.operator
+		  AND osors.avs = ld.avs
+		  AND osors.operator_set_id = ld.operator_set_id
+		  AND osors.snapshot <= ld.deregistration_date`,
+	}
+
+	for _, query := range queries {
+		if _, err := db.Exec(query); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202512160000_addSlashableUntilToOperatorRegistrationSnapshots"
+}

--- a/pkg/postgres/migrations/202512161200_addMaxMagnitudeToAllocationSnapshots/up.go
+++ b/pkg/postgres/migrations/202512161200_addMaxMagnitudeToAllocationSnapshots/up.go
@@ -1,0 +1,38 @@
+package _202512161200_addMaxMagnitudeToAllocationSnapshots
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+}
+
+func (m *Migration) Up(db *sql.DB, grm *gorm.DB, cfg *config.Config) error {
+	queries := []string{
+		// Add max_magnitude column to operator_allocation_snapshots table
+		// This combines allocation magnitude with max magnitude in the snapshot
+		// following the pattern of operator_share_snapshots and staker_share_snapshots
+		// which combine data from multiple sources that are consumed together in calculations
+		`ALTER TABLE operator_allocation_snapshots
+		 ADD COLUMN IF NOT EXISTS max_magnitude NUMERIC NOT NULL DEFAULT 0`,
+
+		// Create index for max_magnitude queries for performance
+		`CREATE INDEX IF NOT EXISTS idx_operator_allocation_snapshots_max_magnitude
+		 ON operator_allocation_snapshots(operator, strategy, snapshot)
+		 WHERE max_magnitude > 0`,
+	}
+
+	for _, query := range queries {
+		if _, err := db.Exec(query); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migration) GetName() string {
+	return "202512161200_addMaxMagnitudeToAllocationSnapshots"
+}

--- a/pkg/postgres/migrations/migrator.go
+++ b/pkg/postgres/migrations/migrator.go
@@ -83,6 +83,9 @@ import (
 	_202507301421_crossChainRegistryTables "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202507301421_crossChainRegistryTables"
 	_202511051502_keyRotationScheduled "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202511051502_keyRotationScheduled"
 	_202511141700_withdrawalQueueAndAllocationRounding "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202511141700_withdrawalQueueAndAllocationRounding"
+	_202512101500_queuedWithdrawalSlashingAdjustments "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202512101500_queuedWithdrawalSlashingAdjustments"
+	_202512160000_addSlashableUntilToOperatorRegistrationSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202512160000_addSlashableUntilToOperatorRegistrationSnapshots"
+	_202512161200_addMaxMagnitudeToAllocationSnapshots "github.com/Layr-Labs/sidecar/pkg/postgres/migrations/202512161200_addMaxMagnitudeToAllocationSnapshots"
 )
 
 // Migration interface defines the contract for database migrations.
@@ -228,6 +231,9 @@ func (m *Migrator) MigrateAll() error {
 		&_202507301346_taskMailboxTables.Migration{},
 		&_202511051502_keyRotationScheduled.Migration{},
 		&_202511141700_withdrawalQueueAndAllocationRounding.Migration{},
+		&_202512101500_queuedWithdrawalSlashingAdjustments.Migration{},
+		&_202512160000_addSlashableUntilToOperatorRegistrationSnapshots.Migration{},
+		&_202512161200_addMaxMagnitudeToAllocationSnapshots.Migration{},
 	}
 
 	for _, migration := range migrations {

--- a/pkg/rewards/12_goldOperatorODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/12_goldOperatorODOperatorSetRewardAmounts.go
@@ -78,7 +78,6 @@ func (rc *RewardsCalculator) GenerateGold12OperatorODOperatorSetRewardAmountsTab
 		rc.logger.Sugar().Infow("Rewards v2.1 is not enabled for this cutoff date, skipping GenerateGold12OperatorODOperatorSetRewardAmountsTable")
 		return nil
 	}
-
 	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
 	destTableName := allTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts]
 

--- a/pkg/rewards/12_goldOperatorODOperatorSetRewardAmounts.go
+++ b/pkg/rewards/12_goldOperatorODOperatorSetRewardAmounts.go
@@ -78,6 +78,7 @@ func (rc *RewardsCalculator) GenerateGold12OperatorODOperatorSetRewardAmountsTab
 		rc.logger.Sugar().Infow("Rewards v2.1 is not enabled for this cutoff date, skipping GenerateGold12OperatorODOperatorSetRewardAmountsTable")
 		return nil
 	}
+
 	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
 	destTableName := allTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts]
 

--- a/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
@@ -36,9 +36,9 @@ operators_with_allocated_stake AS (
         oas.max_magnitude,
         oss.shares as operator_total_shares,
         -- Calculate effective allocated stake for this strategy
-        CAST(oss.shares AS DECIMAL(78,0)) *
-        CAST(oas.magnitude AS DECIMAL(78,0)) /
-        CAST(oas.max_magnitude AS DECIMAL(78,0)) as allocated_stake
+        CAST(oss.shares AS NUMERIC(78,0)) *
+        CAST(oas.magnitude AS NUMERIC(78,0)) /
+        CAST(oas.max_magnitude AS NUMERIC(78,0)) as allocated_stake
     FROM reward_snapshot_operators rso
     JOIN {{.operatorAllocationSnapshotsTable}} oas
         ON rso.operator = oas.operator
@@ -99,8 +99,8 @@ distinct_operators AS (
 operator_splits AS (
     SELECT 
         dop.*,
-        COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL) AS split_pct,
-        FLOOR(dop.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS operator_tokens
+        COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS NUMERIC) AS split_pct,
+        FLOOR(dop.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS NUMERIC)) AS operator_tokens
     FROM distinct_operators dop
     LEFT JOIN operator_set_split_snapshots oss
         ON dop.operator = oss.operator 

--- a/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
@@ -29,7 +29,6 @@ WITH reward_snapshot_operators AS (
        AND ap.operator = osor.operator
 ),
 
--- V2.2: Calculate effective allocated stake using formula: operatorStake * magnitude / maxMagnitude
 operators_with_allocated_stake AS (
     SELECT
         rso.*,
@@ -118,7 +117,6 @@ SELECT * FROM operator_splits
 `
 
 func (rc *RewardsCalculator) GenerateGold15OperatorOperatorSetUniqueStakeRewardsTable(snapshotDate string) error {
-	// Skip if v2.2 is not enabled
 	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)

--- a/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
@@ -36,11 +36,9 @@ operators_with_allocated_stake AS (
         oas.max_magnitude,
         oss.shares as operator_total_shares,
         -- Calculate effective allocated stake for this strategy
-        CAST(
-            CAST(oss.shares AS DECIMAL(78,0)) *
-            CAST(oas.magnitude AS DECIMAL(78,0)) /
-            CAST(oas.max_magnitude AS DECIMAL(78,0))
-        AS VARCHAR) as allocated_stake
+        CAST(oss.shares AS DECIMAL(78,0)) *
+        CAST(oas.magnitude AS DECIMAL(78,0)) /
+        CAST(oas.max_magnitude AS DECIMAL(78,0)) as allocated_stake
     FROM reward_snapshot_operators rso
     JOIN {{.operatorAllocationSnapshotsTable}} oas
         ON rso.operator = oas.operator
@@ -71,7 +69,7 @@ operators_with_unique_stake AS (
         multiplier,
         reward_submission_date,
         -- Sum the weighted allocated stake across strategies
-        SUM(CAST(allocated_stake AS DECIMAL(78,0)) * multiplier) OVER (
+        SUM(allocated_stake * multiplier) OVER (
             PARTITION BY reward_hash, snapshot, operator
         ) as operator_allocated_weight
     FROM operators_with_allocated_stake

--- a/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/15_goldOperatorOperatorSetUniqueStakeRewards.go
@@ -1,0 +1,157 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _15_goldOperatorOperatorSetUniqueStakeRewardsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- Step 1: Get registered operators for the operator set
+WITH reward_snapshot_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot AS snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs AS avs,
+        ap.operator_set_id AS operator_set_id,
+        ap.operator AS operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    JOIN operator_set_operator_registration_snapshots osor
+        ON ap.avs = osor.avs
+       AND ap.operator_set_id = osor.operator_set_id
+       AND ap.snapshot = osor.snapshot
+       AND ap.operator = osor.operator
+),
+
+-- V2.2: Calculate effective allocated stake using formula: operatorStake * magnitude / maxMagnitude
+operators_with_allocated_stake AS (
+    SELECT
+        rso.*,
+        oas.magnitude,
+        oas.max_magnitude,
+        oss.shares as operator_total_shares,
+        -- Calculate effective allocated stake for this strategy
+        CAST(
+            CAST(oss.shares AS DECIMAL(78,0)) *
+            CAST(oas.magnitude AS DECIMAL(78,0)) /
+            CAST(oas.max_magnitude AS DECIMAL(78,0))
+        AS VARCHAR) as allocated_stake
+    FROM reward_snapshot_operators rso
+    JOIN {{.operatorAllocationSnapshotsTable}} oas
+        ON rso.operator = oas.operator
+        AND rso.avs = oas.avs
+        AND rso.strategy = oas.strategy
+        AND rso.operator_set_id = oas.operator_set_id
+        AND rso.snapshot = oas.snapshot
+    JOIN {{.operatorShareSnapshotsTable}} oss
+        ON rso.operator = oss.operator
+        AND rso.strategy = oss.strategy
+        AND rso.snapshot = oss.snapshot
+    WHERE oas.magnitude > 0
+        AND oas.max_magnitude > 0
+        AND oss.shares > 0
+),
+
+-- Calculate weighted allocated stake per operator (sum across strategies)
+operators_with_unique_stake AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        tokens_per_registered_snapshot_decimal,
+        avs,
+        operator_set_id,
+        operator,
+        strategy,
+        multiplier,
+        reward_submission_date,
+        -- Sum the weighted allocated stake across strategies
+        SUM(CAST(allocated_stake AS DECIMAL(78,0)) * multiplier) OVER (
+            PARTITION BY reward_hash, snapshot, operator
+        ) as operator_allocated_weight
+    FROM operators_with_allocated_stake
+),
+
+-- Step 2: Dedupe the operator tokens across strategies for each (operator, reward hash, snapshot)
+-- Since the above result is a flattened operator-directed reward submission across strategies.
+distinct_operators AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            -- We can use an arbitrary order here since the operator_tokens is the same for each (operator, strategy, hash, snapshot)
+            -- We use strategy ASC for better debuggability
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM operators_with_unique_stake
+    ) t
+    -- Keep only the first row for each (operator, reward hash, snapshot)
+    WHERE rn = 1
+),
+
+-- Step 3: Calculate the tokens for each operator with dynamic split logic
+-- If no split is found, default to 1000 (10%)
+operator_splits AS (
+    SELECT 
+        dop.*,
+        COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL) AS split_pct,
+        FLOOR(dop.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS operator_tokens
+    FROM distinct_operators dop
+    LEFT JOIN operator_set_split_snapshots oss
+        ON dop.operator = oss.operator 
+       AND dop.avs = oss.avs
+       AND dop.operator_set_id = oss.operator_set_id 
+       AND dop.snapshot = oss.snapshot
+    LEFT JOIN default_operator_split_snapshots dos ON (dop.snapshot = dos.snapshot)
+)
+
+-- Step 4: Output the final table with operator splits
+SELECT * FROM operator_splits
+`
+
+func (rc *RewardsCalculator) GenerateGold15OperatorOperatorSetUniqueStakeRewardsTable(snapshotDate string) error {
+	// Skip if v2.2 is not enabled
+	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_2Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.2 is not enabled, skipping v2.2 table 15")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_15_OperatorOperatorSetUniqueStakeRewards]
+
+	rc.logger.Sugar().Infow("Generating v2.2 Operator operator set unique stake rewards",
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_15_goldOperatorOperatorSetUniqueStakeRewardsQuery, map[string]interface{}{
+		"destTableName":                    destTableName,
+		"activeODRewardsTable":             allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+		"operatorAllocationSnapshotsTable": allTableNames[rewardsUtils.Table_OperatorAllocationSnapshots],
+		"operatorShareSnapshotsTable":      "operator_share_snapshots",
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to create gold_operator_operator_set_unique_stake_rewards v2.2", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/16_goldStakerOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/16_goldStakerOperatorSetUniqueStakeRewards.go
@@ -1,0 +1,140 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _16_goldStakerOperatorSetUniqueStakeRewardsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- V2.2: Simplified Staker Rewards Calculation
+-- Approach (per Yash's suggestion):
+-- 1. Get operator rewards from file 15 (already stake-weighted based on unique allocated stake)
+-- 2. Calculate each staker's proportion of operator's total delegated stake
+-- 3. Multiply proportion by operator's staker_split amount
+
+-- Step 1: Get operator rewards and staker splits from previous table (file 15)
+WITH operator_rewards AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        operator,
+        avs,
+        operator_set_id,
+        strategy,
+        tokens_per_registered_snapshot_decimal,
+        -- Calculate staker split (total rewards minus operator split)
+        tokens_per_registered_snapshot_decimal - operator_tokens as staker_split_total
+    FROM {{.operatorRewardsTable}}
+),
+
+-- Step 2: Get stakers delegated to each operator
+staker_delegations AS (
+    SELECT
+        or.*,
+        sds.staker
+    FROM operator_rewards or
+    JOIN staker_delegation_snapshots sds
+        ON or.operator = sds.operator
+        AND or.snapshot = sds.snapshot
+),
+
+-- Step 3: Get each staker's shares for the strategy
+staker_strategy_shares AS (
+    SELECT
+        sd.*,
+        sss.shares,
+        sd.multiplier
+    FROM staker_delegations sd
+    JOIN staker_share_snapshots sss
+        ON sd.staker = sss.staker
+        AND sd.strategy = sss.strategy
+        AND sd.snapshot = sss.snapshot
+    WHERE sss.shares > 0
+        AND sd.multiplier != 0
+),
+
+-- Step 4: Calculate each staker's weighted shares
+staker_weights AS (
+    SELECT
+        *,
+        CAST(shares AS DECIMAL(78,0)) * multiplier as staker_weight
+    FROM staker_strategy_shares
+),
+
+-- Step 5: Calculate total weight per operator
+staker_weight_with_totals AS (
+    SELECT
+        *,
+        SUM(staker_weight) OVER (PARTITION BY reward_hash, operator, snapshot) as total_operator_weight
+    FROM staker_weights
+),
+
+-- Step 6: Calculate staker proportions and rewards
+staker_rewards AS (
+    SELECT
+        *,
+        -- Staker's proportion of operator's total delegated stake
+        CASE
+            WHEN total_operator_weight > 0 THEN
+                staker_weight / total_operator_weight
+            ELSE 0
+        END as staker_proportion,
+        -- Staker's reward = proportion * operator's staker_split_total
+        CASE
+            WHEN total_operator_weight > 0 THEN
+                FLOOR((staker_weight / total_operator_weight) * staker_split_total)
+            ELSE 0
+        END as staker_tokens
+    FROM staker_weight_with_totals
+)
+
+-- Output the final table
+SELECT * FROM staker_rewards
+`
+
+func (rc *RewardsCalculator) GenerateGold16StakerOperatorSetUniqueStakeRewardsTable(snapshotDate string) error {
+	// Skip if v2.2 is not enabled
+	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_2Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.2 is not enabled, skipping v2.2 table 16")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_16_StakerOperatorSetUniqueStakeRewards]
+	operatorRewardsTable := allTableNames[rewardsUtils.Table_15_OperatorOperatorSetUniqueStakeRewards]
+
+	rc.logger.Sugar().Infow("Generating v2.2 staker operator set unique stake rewards",
+		zap.String("snapshotDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_16_goldStakerOperatorSetUniqueStakeRewardsQuery, map[string]interface{}{
+		"destTableName":        destTableName,
+		"operatorRewardsTable": operatorRewardsTable,
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render v2.2 query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 staker operator set unique stake rewards", "error", res.Error)
+		return res.Error
+	}
+
+	rc.logger.Sugar().Infow("Successfully generated v2.2 unique stake rewards",
+		zap.String("snapshotDate", snapshotDate),
+		zap.Int64("rowsAffected", res.RowsAffected),
+	)
+
+	return nil
+}

--- a/pkg/rewards/16_goldStakerOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/16_goldStakerOperatorSetUniqueStakeRewards.go
@@ -8,13 +8,7 @@ import (
 const _16_goldStakerOperatorSetUniqueStakeRewardsQuery = `
 CREATE TABLE {{.destTableName}} AS
 
--- V2.2: Simplified Staker Rewards Calculation
--- Approach (per Yash's suggestion):
--- 1. Get operator rewards from file 15 (already stake-weighted based on unique allocated stake)
--- 2. Calculate each staker's proportion of operator's total delegated stake
--- 3. Multiply proportion by operator's staker_split amount
-
--- Step 1: Get operator rewards and staker splits from previous table (file 15)
+-- Step 1: Get operator rewards and staker splits from previous table 15
 WITH operator_rewards AS (
     SELECT
         reward_hash,
@@ -96,7 +90,6 @@ SELECT * FROM staker_rewards
 `
 
 func (rc *RewardsCalculator) GenerateGold16StakerOperatorSetUniqueStakeRewardsTable(snapshotDate string) error {
-	// Skip if v2.2 is not enabled
 	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)

--- a/pkg/rewards/17_goldAvsOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/17_goldAvsOperatorSetUniqueStakeRewards.go
@@ -11,44 +11,8 @@ import (
 const _17_goldAvsOperatorSetUniqueStakeRewardsQuery = `
 CREATE TABLE {{.destTableName}} AS
 
--- Step 1: Get the rows where operators have not registered for the AVS or if the AVS does not exist
-WITH not_registered_operators AS (
-    SELECT
-        ap.reward_hash,
-        ap.snapshot AS snapshot,
-        ap.token,
-        ap.tokens_per_registered_snapshot_decimal,
-        ap.avs AS avs,
-        ap.operator_set_id AS operator_set_id,
-        ap.operator AS operator,
-        ap.strategy,
-        ap.multiplier
-    FROM {{.activeODRewardsTable}} ap
-    WHERE
-        ap.num_registered_snapshots = 0
-),
-
--- Step 2: Dedupe the operator tokens across strategies for each (operator, reward hash, snapshot)
--- Since the above result is a flattened operator-directed reward submission across strategies
-distinct_not_registered_operators AS (
-    SELECT *
-    FROM (
-        SELECT 
-            *,
-            -- We can use an arbitrary order here since the avs_tokens is the same for each (operator, strategy, hash, snapshot)
-            -- We use strategy ASC for better debuggability
-            ROW_NUMBER() OVER (
-                PARTITION BY reward_hash, snapshot, operator 
-                ORDER BY strategy ASC
-            ) AS rn
-        FROM not_registered_operators
-    ) t
-    WHERE rn = 1
-),
-
--- Step 3: Sum the operator tokens for each (reward hash, snapshot)
--- Since we want to refund the sum of those operator amounts to the AVS in that reward submission for that snapshot
-avs_operator_refund_sums AS (
+-- Step 1: Calculate total tokens available per (reward_hash, snapshot)
+WITH total_available_tokens AS (
     SELECT
         reward_hash,
         snapshot,
@@ -56,86 +20,39 @@ avs_operator_refund_sums AS (
         avs,
         operator_set_id,
         operator,
-        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
-    FROM distinct_not_registered_operators
+        SUM(tokens_per_registered_snapshot_decimal) as total_tokens
+    FROM {{.activeODRewardsTable}}
+    GROUP BY reward_hash, snapshot, token, avs, operator_set_id, operator
 ),
 
--- Step 4: Get operators who ARE registered but have NO allocated stake with magnitude > 0
--- This combines the previous scenarios of "no unique stake" and "strategies not registered"
--- If the operator doesn't have allocated stake with magnitude > 0, they get no rewards, so refund
-registered_operators AS (
-    SELECT
-        ap.reward_hash,
-        ap.snapshot,
-        ap.token,
-        ap.tokens_per_registered_snapshot_decimal,
-        ap.avs,
-        ap.operator_set_id,
-        ap.operator,
-        ap.strategy,
-        ap.multiplier
-    FROM {{.activeODRewardsTable}} ap
-    JOIN operator_set_operator_registration_snapshots osor
-        ON ap.avs = osor.avs
-        AND ap.operator_set_id = osor.operator_set_id
-        AND ap.snapshot = osor.snapshot
-        AND ap.operator = osor.operator
-    WHERE ap.num_registered_snapshots != 0
-),
-
--- Step 5: Find operators without allocated stake (magnitude > 0)
-operators_without_allocated_stake AS (
-    SELECT
-        ro.*
-    FROM registered_operators ro
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM {{.operatorAllocationSnapshotsTable}} oas
-        WHERE oas.operator = ro.operator
-            AND oas.avs = ro.avs
-            AND oas.operator_set_id = ro.operator_set_id
-            AND oas.snapshot = ro.snapshot
-            AND oas.magnitude > 0
-    )
-),
-
--- Step 6: Dedupe and calculate refunds for operators without allocated stake
-distinct_operators_without_allocated_stake AS (
-    SELECT *
-    FROM (
-        SELECT
-            *,
-            ROW_NUMBER() OVER (
-                PARTITION BY reward_hash, snapshot, operator
-                ORDER BY strategy ASC
-            ) AS rn
-        FROM operators_without_allocated_stake
-    ) t
-    WHERE rn = 1
-),
-
--- Step 7: Calculate total refund for operators without allocated stake
-avs_no_allocated_stake_refund_sums AS (
+-- Step 2: Calculate total tokens actually distributed from the operator rewards table
+total_distributed_tokens AS (
     SELECT
         reward_hash,
         snapshot,
-        token,
-        avs,
-        operator_set_id,
-        operator,
-        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
-    FROM distinct_operators_without_allocated_stake
+        COALESCE(SUM(operator_tokens), 0) as distributed_tokens
+    FROM {{.operatorRewardsTable}}
+    GROUP BY reward_hash, snapshot
 ),
 
--- Step 8: Combine all refund cases into one result
-combined_avs_refund_amounts AS (
-    SELECT * FROM avs_operator_refund_sums
-    UNION ALL
-    SELECT * FROM avs_no_allocated_stake_refund_sums
+-- Step 3: Identify snapshots where distributed tokens = 0, refund all available tokens to AVS
+snapshots_requiring_refund AS (
+    SELECT
+        tat.reward_hash,
+        tat.snapshot,
+        tat.token,
+        tat.avs,
+        tat.operator_set_id,
+        tat.operator,
+        tat.total_tokens as avs_tokens
+    FROM total_available_tokens tat
+    LEFT JOIN total_distributed_tokens tdt
+        ON tat.reward_hash = tdt.reward_hash
+        AND tat.snapshot = tdt.snapshot
+    WHERE COALESCE(tdt.distributed_tokens, 0) = 0
 )
 
--- Output the final table
-SELECT * FROM combined_avs_refund_amounts
+SELECT * FROM snapshots_requiring_refund
 `
 
 func (rc *RewardsCalculator) GenerateGold17AvsOperatorSetUniqueStakeRewardsTable(snapshotDate string, forks config.ForkMap) error {
@@ -159,9 +76,9 @@ func (rc *RewardsCalculator) GenerateGold17AvsOperatorSetUniqueStakeRewardsTable
 	)
 
 	query, err := rewardsUtils.RenderQueryTemplate(_17_goldAvsOperatorSetUniqueStakeRewardsQuery, map[string]interface{}{
-		"destTableName":                    destTableName,
-		"activeODRewardsTable":             allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
-		"operatorAllocationSnapshotsTable": allTableNames[rewardsUtils.Table_OperatorAllocationSnapshots],
+		"destTableName":        destTableName,
+		"activeODRewardsTable": allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+		"operatorRewardsTable": allTableNames[rewardsUtils.Table_15_OperatorOperatorSetUniqueStakeRewards],
 	})
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)

--- a/pkg/rewards/17_goldAvsOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/17_goldAvsOperatorSetUniqueStakeRewards.go
@@ -22,8 +22,7 @@ WITH not_registered_operators AS (
         ap.operator_set_id AS operator_set_id,
         ap.operator AS operator,
         ap.strategy,
-        ap.multiplier,
-        ap.reward_submission_date
+        ap.multiplier
     FROM {{.activeODRewardsTable}} ap
     WHERE
         ap.num_registered_snapshots = 0
@@ -61,7 +60,7 @@ avs_operator_refund_sums AS (
     FROM distinct_not_registered_operators
 ),
 
--- V2.2: Step 4a - Get operators who ARE registered but have NOT allocated unique stake
+-- Step 4a: Get operators who ARE registered but have NOT allocated unique stake
 -- These operators should have their rewards refunded to the AVS
 registered_operators AS (
     SELECT
@@ -73,8 +72,7 @@ registered_operators AS (
         ap.operator_set_id,
         ap.operator,
         ap.strategy,
-        ap.multiplier,
-        ap.reward_submission_date
+        ap.multiplier
     FROM {{.activeODRewardsTable}} ap
     JOIN operator_set_operator_registration_snapshots osor
         ON ap.avs = osor.avs 
@@ -82,10 +80,9 @@ registered_operators AS (
         AND ap.snapshot = osor.snapshot 
         AND ap.operator = osor.operator
     WHERE ap.num_registered_snapshots != 0
-      AND ap.reward_submission_date >= @coloradoHardforkDate
 ),
 
--- V2.2: Step 4b - Find operators without unique stake allocations
+-- Step 4b: Find operators without unique stake allocations
 operators_without_unique_stake AS (
     SELECT
         ro.*
@@ -98,7 +95,7 @@ operators_without_unique_stake AS (
     WHERE oas.operator IS NULL OR oas.magnitude = 0
 ),
 
--- V2.2: Step 4c - Dedupe and calculate refunds for operators without unique stake
+-- Step 4c: Dedupe and calculate refunds for operators without unique stake
 distinct_operators_without_unique_stake AS (
     SELECT *
     FROM (
@@ -113,7 +110,7 @@ distinct_operators_without_unique_stake AS (
     WHERE rn = 1
 ),
 
--- V2.2: Step 4d - Calculate total refund for operators without unique stake
+-- Step 4d: Calculate total refund for operators without unique stake
 avs_no_unique_stake_refund_sums AS (
     SELECT
         reward_hash,
@@ -216,7 +213,7 @@ avs_staker_refund_sums AS (
 combined_avs_refund_amounts AS (
     SELECT * FROM avs_operator_refund_sums
     UNION ALL
-    SELECT * FROM avs_no_unique_stake_refund_sums  -- V2.2: New refund case
+    SELECT * FROM avs_no_unique_stake_refund_sums
     UNION ALL
     SELECT * FROM avs_staker_refund_sums
 )
@@ -226,7 +223,6 @@ SELECT * FROM combined_avs_refund_amounts
 `
 
 func (rc *RewardsCalculator) GenerateGold17AvsOperatorSetUniqueStakeRewardsTable(snapshotDate string, forks config.ForkMap) error {
-	// Skip if v2.2 is not enabled
 	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)

--- a/pkg/rewards/17_goldAvsOperatorSetUniqueStakeRewards.go
+++ b/pkg/rewards/17_goldAvsOperatorSetUniqueStakeRewards.go
@@ -1,0 +1,265 @@
+package rewards
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _17_goldAvsOperatorSetUniqueStakeRewardsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- Step 1: Get the rows where operators have not registered for the AVS or if the AVS does not exist
+WITH not_registered_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot AS snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs AS avs,
+        ap.operator_set_id AS operator_set_id,
+        ap.operator AS operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    WHERE
+        ap.num_registered_snapshots = 0
+),
+
+-- Step 2: Dedupe the operator tokens across strategies for each (operator, reward hash, snapshot)
+-- Since the above result is a flattened operator-directed reward submission across strategies
+distinct_not_registered_operators AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            -- We can use an arbitrary order here since the avs_tokens is the same for each (operator, strategy, hash, snapshot)
+            -- We use strategy ASC for better debuggability
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM not_registered_operators
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 3: Sum the operator tokens for each (reward hash, snapshot)
+-- Since we want to refund the sum of those operator amounts to the AVS in that reward submission for that snapshot
+avs_operator_refund_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_not_registered_operators
+),
+
+-- V2.2: Step 4a - Get operators who ARE registered but have NOT allocated unique stake
+-- These operators should have their rewards refunded to the AVS
+registered_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs,
+        ap.operator_set_id,
+        ap.operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    JOIN operator_set_operator_registration_snapshots osor
+        ON ap.avs = osor.avs 
+        AND ap.operator_set_id = osor.operator_set_id
+        AND ap.snapshot = osor.snapshot 
+        AND ap.operator = osor.operator
+    WHERE ap.num_registered_snapshots != 0
+      AND ap.reward_submission_date >= @coloradoHardforkDate
+),
+
+-- V2.2: Step 4b - Find operators without unique stake allocations
+operators_without_unique_stake AS (
+    SELECT
+        ro.*
+    FROM registered_operators ro
+    LEFT JOIN {{.operatorAllocationSnapshotsTable}} oas
+        ON ro.operator = oas.operator
+        AND ro.avs = oas.avs
+        AND ro.operator_set_id = oas.operator_set_id
+        AND ro.snapshot = oas.snapshot
+    WHERE oas.operator IS NULL OR oas.magnitude = 0
+),
+
+-- V2.2: Step 4c - Dedupe and calculate refunds for operators without unique stake
+distinct_operators_without_unique_stake AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM operators_without_unique_stake
+    ) t
+    WHERE rn = 1
+),
+
+-- V2.2: Step 4d - Calculate total refund for operators without unique stake
+avs_no_unique_stake_refund_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_operators_without_unique_stake
+),
+
+-- Step 5: Find rows where operators are registered WITH unique stake but strategies are not registered for the operator set
+-- First, get all rows where operators are registered AND have unique stake
+registered_operators_with_unique_stake AS (
+    SELECT
+        ro.*
+    FROM registered_operators ro
+    JOIN {{.operatorAllocationSnapshotsTable}} oas
+        ON ro.operator = oas.operator
+        AND ro.avs = oas.avs
+        AND ro.operator_set_id = oas.operator_set_id
+        AND ro.snapshot = oas.snapshot
+    WHERE oas.magnitude > 0
+),
+
+-- Step 6: For each reward/snapshot/operator_set, check if any strategies are registered
+strategies_registered AS (
+    SELECT DISTINCT
+        ro.reward_hash,
+        ro.snapshot,
+        ro.avs,
+        ro.operator_set_id
+    FROM registered_operators_with_unique_stake ro
+    JOIN operator_set_strategy_registration_snapshots ossr
+        ON ro.avs = ossr.avs
+        AND ro.operator_set_id = ossr.operator_set_id
+        AND ro.snapshot = ossr.snapshot
+        AND ro.strategy = ossr.strategy
+),
+
+-- Step 7: Find reward/snapshot combinations where operators registered WITH unique stake but no strategies registered
+strategies_not_registered AS (
+    SELECT 
+        ro.*
+    FROM registered_operators_with_unique_stake ro
+    LEFT JOIN strategies_registered sr
+        ON ro.reward_hash = sr.reward_hash
+        AND ro.snapshot = sr.snapshot
+        AND ro.avs = sr.avs
+        AND ro.operator_set_id = sr.operator_set_id
+    WHERE sr.reward_hash IS NULL
+),
+
+-- Step 8: Calculate the staker split for each reward with dynamic split logic
+-- If no split is found, default to 1000 (10%)
+staker_splits AS (
+    SELECT 
+        snr.*,
+        snr.tokens_per_registered_snapshot_decimal - FLOOR(snr.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS staker_split
+    FROM strategies_not_registered snr
+    LEFT JOIN operator_set_split_snapshots oss
+        ON snr.operator = oss.operator 
+        AND snr.avs = oss.avs 
+        AND snr.operator_set_id = oss.operator_set_id
+        AND snr.snapshot = oss.snapshot
+    LEFT JOIN default_operator_split_snapshots dos ON (snr.snapshot = dos.snapshot)
+),
+
+-- Step 9: Dedupe the staker splits across across strategies for each (operator, reward hash, snapshot)
+-- Since the above result is a flattened operator-directed reward submission across strategies.
+distinct_staker_splits AS (
+    SELECT *
+    FROM (
+        SELECT 
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator 
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM staker_splits
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 10: Sum the staker tokens for each (reward hash, snapshot) that should be refunded
+avs_staker_refund_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(staker_split) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_staker_splits
+),
+
+-- Step 11: Combine all refund cases into one result
+combined_avs_refund_amounts AS (
+    SELECT * FROM avs_operator_refund_sums
+    UNION ALL
+    SELECT * FROM avs_no_unique_stake_refund_sums  -- V2.2: New refund case
+    UNION ALL
+    SELECT * FROM avs_staker_refund_sums
+)
+
+-- Output the final table
+SELECT * FROM combined_avs_refund_amounts
+`
+
+func (rc *RewardsCalculator) GenerateGold17AvsOperatorSetUniqueStakeRewardsTable(snapshotDate string, forks config.ForkMap) error {
+	// Skip if v2.2 is not enabled
+	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_2Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.2 is not enabled, skipping v2.2 table 17")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_17_AvsOperatorSetUniqueStakeRewards]
+
+	rc.logger.Sugar().Infow("Generating v2.2 AVS operator set unique stake rewards (refunds)",
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+		zap.String("coloradoHardforkDate", forks[config.RewardsFork_Colorado].Date),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_17_goldAvsOperatorSetUniqueStakeRewardsQuery, map[string]interface{}{
+		"destTableName":                    destTableName,
+		"activeODRewardsTable":             allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+		"operatorAllocationSnapshotsTable": allTableNames[rewardsUtils.Table_OperatorAllocationSnapshots],
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query, sql.Named("coloradoHardforkDate", forks[config.RewardsFork_Colorado].Date))
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to create gold_avs_operator_set_unique_stake_rewards v2.2", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/18_goldOperatorOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/18_goldOperatorOperatorSetTotalStakeRewards.go
@@ -57,7 +57,7 @@ operators_with_total_stake_weight AS (
         reward_submission_date,
         operator_total_shares,
         -- Sum the weighted total stake across strategies
-        SUM(CAST(operator_total_shares AS DECIMAL(78,0)) * multiplier) OVER (
+        SUM(CAST(operator_total_shares AS NUMERIC(78,0)) * multiplier) OVER (
             PARTITION BY reward_hash, snapshot, operator
         ) as operator_total_weight
     FROM operators_with_total_stake
@@ -82,8 +82,8 @@ distinct_operators AS (
 operator_splits AS (
     SELECT
         dop.*,
-        COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL) AS split_pct,
-        FLOOR(dop.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS operator_tokens
+        COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS NUMERIC) AS split_pct,
+        FLOOR(dop.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS NUMERIC)) AS operator_tokens
     FROM distinct_operators dop
     LEFT JOIN operator_set_split_snapshots oss
         ON dop.operator = oss.operator

--- a/pkg/rewards/18_goldOperatorOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/18_goldOperatorOperatorSetTotalStakeRewards.go
@@ -1,0 +1,140 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _18_goldOperatorOperatorSetTotalStakeRewardsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- V2.2: Total Stake Weighted Rewards for Operator Sets
+-- Key difference from Unique Stake: Uses total delegated stake instead of allocated unique stake
+-- No allocation validation required - just operator registration to set
+
+-- Step 1: Get registered operators for the operator set
+WITH reward_snapshot_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot AS snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs AS avs,
+        ap.operator_set_id AS operator_set_id,
+        ap.operator AS operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    JOIN operator_set_operator_registration_snapshots osor
+        ON ap.avs = osor.avs
+       AND ap.operator_set_id = osor.operator_set_id
+       AND ap.snapshot = osor.snapshot
+       AND ap.operator = osor.operator
+),
+
+-- Step 2: Get operator's total delegated stake per strategy
+operators_with_total_stake AS (
+    SELECT
+        rso.*,
+        oss.shares as operator_total_shares
+    FROM reward_snapshot_operators rso
+    JOIN {{.operatorShareSnapshotsTable}} oss
+        ON rso.operator = oss.operator
+        AND rso.strategy = oss.strategy
+        AND rso.snapshot = oss.snapshot
+    WHERE oss.shares > 0
+),
+
+-- Step 3: Calculate weighted total stake per operator (sum across strategies with multiplier)
+operators_with_total_stake_weight AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        tokens_per_registered_snapshot_decimal,
+        avs,
+        operator_set_id,
+        operator,
+        strategy,
+        multiplier,
+        reward_submission_date,
+        operator_total_shares,
+        -- Sum the weighted total stake across strategies
+        SUM(CAST(operator_total_shares AS DECIMAL(78,0)) * multiplier) OVER (
+            PARTITION BY reward_hash, snapshot, operator
+        ) as operator_total_weight
+    FROM operators_with_total_stake
+),
+
+-- Step 4: Dedupe across strategies (take first strategy, they all have same operator_total_weight)
+distinct_operators AS (
+    SELECT *
+    FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM operators_with_total_stake_weight
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 5: Calculate operator splits with dynamic split logic
+operator_splits AS (
+    SELECT
+        dop.*,
+        COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL) AS split_pct,
+        FLOOR(dop.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS operator_tokens
+    FROM distinct_operators dop
+    LEFT JOIN operator_set_split_snapshots oss
+        ON dop.operator = oss.operator
+       AND dop.avs = oss.avs
+       AND dop.operator_set_id = oss.operator_set_id
+       AND dop.snapshot = oss.snapshot
+    LEFT JOIN default_operator_split_snapshots dos ON (dop.snapshot = dos.snapshot)
+)
+
+-- Output the final table
+SELECT * FROM operator_splits
+`
+
+func (rc *RewardsCalculator) GenerateGold18OperatorOperatorSetTotalStakeRewardsTable(snapshotDate string) error {
+	// Skip if v2.2 is not enabled
+	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_2Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.2 is not enabled, skipping v2.2 table 18")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_18_OperatorOperatorSetTotalStakeRewards]
+
+	rc.logger.Sugar().Infow("Generating v2.2 Operator operator set reward amounts with total stake",
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_18_goldOperatorOperatorSetTotalStakeRewardsQuery, map[string]interface{}{
+		"destTableName":               destTableName,
+		"activeODRewardsTable":        allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+		"operatorShareSnapshotsTable": "operator_share_snapshots",
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to create gold_operator_operator_set_total_stake_rewards v2.2", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/18_goldOperatorOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/18_goldOperatorOperatorSetTotalStakeRewards.go
@@ -8,10 +8,6 @@ import (
 const _18_goldOperatorOperatorSetTotalStakeRewardsQuery = `
 CREATE TABLE {{.destTableName}} AS
 
--- V2.2: Total Stake Weighted Rewards for Operator Sets
--- Key difference from Unique Stake: Uses total delegated stake instead of allocated unique stake
--- No allocation validation required - just operator registration to set
-
 -- Step 1: Get registered operators for the operator set
 WITH reward_snapshot_operators AS (
     SELECT
@@ -102,7 +98,6 @@ SELECT * FROM operator_splits
 `
 
 func (rc *RewardsCalculator) GenerateGold18OperatorOperatorSetTotalStakeRewardsTable(snapshotDate string) error {
-	// Skip if v2.2 is not enabled
 	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)

--- a/pkg/rewards/19_goldStakerOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/19_goldStakerOperatorSetTotalStakeRewards.go
@@ -1,0 +1,140 @@
+package rewards
+
+import (
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _19_goldStakerOperatorSetTotalStakeRewardsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- V2.2: Staker Rewards for Total Stake Weighted Operator Set Rewards
+-- Simplified approach (same as file 16):
+-- 1. Get operator rewards from file 18 (already stake-weighted based on total delegated stake)
+-- 2. Calculate each staker's proportion of operator's total delegated stake
+-- 3. Multiply proportion by operator's staker_split amount
+
+-- Step 1: Get operator rewards and staker splits from previous table (file 18)
+WITH operator_rewards AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        operator,
+        avs,
+        operator_set_id,
+        strategy,
+        tokens_per_registered_snapshot_decimal,
+        -- Calculate staker split (total rewards minus operator split)
+        tokens_per_registered_snapshot_decimal - operator_tokens as staker_split_total
+    FROM {{.operatorRewardsTable}}
+),
+
+-- Step 2: Get stakers delegated to each operator
+staker_delegations AS (
+    SELECT
+        or.*,
+        sds.staker
+    FROM operator_rewards or
+    JOIN staker_delegation_snapshots sds
+        ON or.operator = sds.operator
+        AND or.snapshot = sds.snapshot
+),
+
+-- Step 3: Get each staker's shares for the strategy
+staker_strategy_shares AS (
+    SELECT
+        sd.*,
+        sss.shares,
+        sd.multiplier
+    FROM staker_delegations sd
+    JOIN staker_share_snapshots sss
+        ON sd.staker = sss.staker
+        AND sd.strategy = sss.strategy
+        AND sd.snapshot = sss.snapshot
+    WHERE sss.shares > 0
+        AND sd.multiplier != 0
+),
+
+-- Step 4: Calculate each staker's weighted shares
+staker_weights AS (
+    SELECT
+        *,
+        CAST(shares AS DECIMAL(78,0)) * multiplier as staker_weight
+    FROM staker_strategy_shares
+),
+
+-- Step 5: Calculate total weight per operator
+staker_weight_with_totals AS (
+    SELECT
+        *,
+        SUM(staker_weight) OVER (PARTITION BY reward_hash, operator, snapshot) as total_operator_weight
+    FROM staker_weights
+),
+
+-- Step 6: Calculate staker proportions and rewards
+staker_rewards AS (
+    SELECT
+        *,
+        -- Staker's proportion of operator's total delegated stake
+        CASE
+            WHEN total_operator_weight > 0 THEN
+                staker_weight / total_operator_weight
+            ELSE 0
+        END as staker_proportion,
+        -- Staker's reward = proportion * operator's staker_split_total
+        CASE
+            WHEN total_operator_weight > 0 THEN
+                FLOOR((staker_weight / total_operator_weight) * staker_split_total)
+            ELSE 0
+        END as staker_tokens
+    FROM staker_weight_with_totals
+)
+
+-- Output the final table
+SELECT * FROM staker_rewards
+`
+
+func (rc *RewardsCalculator) GenerateGold19StakerOperatorSetTotalStakeRewardsTable(snapshotDate string) error {
+	// Skip if v2.2 is not enabled
+	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_2Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.2 is not enabled, skipping v2.2 table 19")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_19_StakerOperatorSetTotalStakeRewards]
+	operatorRewardsTable := allTableNames[rewardsUtils.Table_18_OperatorOperatorSetTotalStakeRewards]
+
+	rc.logger.Sugar().Infow("Generating v2.2 staker operator set reward amounts with total stake",
+		zap.String("snapshotDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_19_goldStakerOperatorSetTotalStakeRewardsQuery, map[string]interface{}{
+		"destTableName":        destTableName,
+		"operatorRewardsTable": operatorRewardsTable,
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render v2.2 query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query)
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 staker operator set total stake rewards", "error", res.Error)
+		return res.Error
+	}
+
+	rc.logger.Sugar().Infow("Successfully generated v2.2 total stake rewards",
+		zap.String("snapshotDate", snapshotDate),
+		zap.Int64("rowsAffected", res.RowsAffected),
+	)
+
+	return nil
+}

--- a/pkg/rewards/19_goldStakerOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/19_goldStakerOperatorSetTotalStakeRewards.go
@@ -54,7 +54,7 @@ staker_strategy_shares AS (
 staker_weights AS (
     SELECT
         *,
-        CAST(shares AS DECIMAL(78,0)) * multiplier as staker_weight
+        CAST(shares AS NUMERIC(78,0)) * multiplier as staker_weight
     FROM staker_strategy_shares
 ),
 

--- a/pkg/rewards/19_goldStakerOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/19_goldStakerOperatorSetTotalStakeRewards.go
@@ -8,13 +8,7 @@ import (
 const _19_goldStakerOperatorSetTotalStakeRewardsQuery = `
 CREATE TABLE {{.destTableName}} AS
 
--- V2.2: Staker Rewards for Total Stake Weighted Operator Set Rewards
--- Simplified approach (same as file 16):
--- 1. Get operator rewards from file 18 (already stake-weighted based on total delegated stake)
--- 2. Calculate each staker's proportion of operator's total delegated stake
--- 3. Multiply proportion by operator's staker_split amount
-
--- Step 1: Get operator rewards and staker splits from previous table (file 18)
+-- Step 1: Get operator rewards and staker splits from previous table 18
 WITH operator_rewards AS (
     SELECT
         reward_hash,
@@ -96,7 +90,6 @@ SELECT * FROM staker_rewards
 `
 
 func (rc *RewardsCalculator) GenerateGold19StakerOperatorSetTotalStakeRewardsTable(snapshotDate string) error {
-	// Skip if v2.2 is not enabled
 	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)

--- a/pkg/rewards/20_goldAvsOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/20_goldAvsOperatorSetTotalStakeRewards.go
@@ -161,7 +161,7 @@ strategies_not_registered AS (
 staker_splits AS (
     SELECT
         snr.*,
-        snr.tokens_per_registered_snapshot_decimal - FLOOR(snr.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS staker_split
+        snr.tokens_per_registered_snapshot_decimal - FLOOR(snr.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS NUMERIC)) AS staker_split
     FROM strategies_not_registered snr
     LEFT JOIN operator_set_split_snapshots oss
         ON snr.operator = oss.operator

--- a/pkg/rewards/20_goldAvsOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/20_goldAvsOperatorSetTotalStakeRewards.go
@@ -11,40 +11,8 @@ import (
 const _20_goldAvsOperatorSetTotalStakeRewardsQuery = `
 CREATE TABLE {{.destTableName}} AS
 
--- Step 1: Get operators not registered for the operator set
-WITH not_registered_operators AS (
-    SELECT
-        ap.reward_hash,
-        ap.snapshot AS snapshot,
-        ap.token,
-        ap.tokens_per_registered_snapshot_decimal,
-        ap.avs AS avs,
-        ap.operator_set_id AS operator_set_id,
-        ap.operator AS operator,
-        ap.strategy,
-        ap.multiplier
-    FROM {{.activeODRewardsTable}} ap
-    WHERE
-        ap.num_registered_snapshots = 0
-),
-
--- Step 2: Dedupe and sum refunds for non-registered operators
-distinct_not_registered_operators AS (
-    SELECT *
-    FROM (
-        SELECT
-            *,
-            ROW_NUMBER() OVER (
-                PARTITION BY reward_hash, snapshot, operator
-                ORDER BY strategy ASC
-            ) AS rn
-        FROM not_registered_operators
-    ) t
-    WHERE rn = 1
-),
-
--- Step 3: Calculate refund amounts for non-registered operators
-avs_operator_refund_sums AS (
+-- Step 1: Calculate total tokens available per (reward_hash, snapshot)
+WITH total_available_tokens AS (
     SELECT
         reward_hash,
         snapshot,
@@ -52,164 +20,39 @@ avs_operator_refund_sums AS (
         avs,
         operator_set_id,
         operator,
-        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
-    FROM distinct_not_registered_operators
+        SUM(tokens_per_registered_snapshot_decimal) as total_tokens
+    FROM {{.activeODRewardsTable}}
+    GROUP BY reward_hash, snapshot, token, avs, operator_set_id, operator
 ),
 
--- Step 4: Get registered operators
-registered_operators AS (
-    SELECT
-        ap.reward_hash,
-        ap.snapshot,
-        ap.token,
-        ap.tokens_per_registered_snapshot_decimal,
-        ap.avs,
-        ap.operator_set_id,
-        ap.operator,
-        ap.strategy,
-        ap.multiplier
-    FROM {{.activeODRewardsTable}} ap
-    JOIN operator_set_operator_registration_snapshots osor
-        ON ap.avs = osor.avs
-        AND ap.operator_set_id = osor.operator_set_id
-        AND ap.snapshot = osor.snapshot
-        AND ap.operator = osor.operator
-    WHERE ap.num_registered_snapshots != 0
-),
-
--- Step 5: Find operators without sufficient total stake
-operators_without_total_stake AS (
-    SELECT
-        ro.*
-    FROM registered_operators ro
-    LEFT JOIN {{.operatorShareSnapshotsTable}} oss
-        ON ro.operator = oss.operator
-        AND ro.strategy = oss.strategy
-        AND ro.snapshot = oss.snapshot
-    WHERE oss.operator IS NULL OR oss.shares = 0
-),
-
--- Step 6: Dedupe and calculate refunds for operators without total stake
-distinct_operators_without_stake AS (
-    SELECT *
-    FROM (
-        SELECT
-            *,
-            ROW_NUMBER() OVER (
-                PARTITION BY reward_hash, snapshot, operator
-                ORDER BY strategy ASC
-            ) AS rn
-        FROM operators_without_total_stake
-    ) t
-    WHERE rn = 1
-),
-
--- Step 7: Calculate total refund for operators without stake
-avs_no_stake_refund_sums AS (
+-- Step 2: Calculate total tokens actually distributed from the operator rewards table
+total_distributed_tokens AS (
     SELECT
         reward_hash,
         snapshot,
-        token,
-        avs,
-        operator_set_id,
-        operator,
-        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
-    FROM distinct_operators_without_stake
+        COALESCE(SUM(operator_tokens), 0) as distributed_tokens
+    FROM {{.operatorRewardsTable}}
+    GROUP BY reward_hash, snapshot
 ),
 
--- Step 8: Find registered operators WITH stake
-registered_operators_with_stake AS (
+-- Step 3: Identify snapshots where distributed tokens = 0, refund all available tokens to AVS
+snapshots_requiring_refund AS (
     SELECT
-        ro.*
-    FROM registered_operators ro
-    JOIN {{.operatorShareSnapshotsTable}} oss
-        ON ro.operator = oss.operator
-        AND ro.strategy = oss.strategy
-        AND ro.snapshot = oss.snapshot
-    WHERE oss.shares > 0
-),
-
--- Step 9: Check if strategies are registered for the operator set
-strategies_registered AS (
-    SELECT DISTINCT
-        ro.reward_hash,
-        ro.snapshot,
-        ro.avs,
-        ro.operator_set_id
-    FROM registered_operators_with_stake ro
-    JOIN operator_set_strategy_registration_snapshots ossr
-        ON ro.avs = ossr.avs
-        AND ro.operator_set_id = ossr.operator_set_id
-        AND ro.snapshot = ossr.snapshot
-        AND ro.strategy = ossr.strategy
-),
-
--- Step 10: Find operators with stake but no strategies registered
-strategies_not_registered AS (
-    SELECT
-        ro.*
-    FROM registered_operators_with_stake ro
-    LEFT JOIN strategies_registered sr
-        ON ro.reward_hash = sr.reward_hash
-        AND ro.snapshot = sr.snapshot
-        AND ro.avs = sr.avs
-        AND ro.operator_set_id = sr.operator_set_id
-    WHERE sr.reward_hash IS NULL
-),
-
--- Step 11: Calculate staker splits for refunds
-staker_splits AS (
-    SELECT
-        snr.*,
-        snr.tokens_per_registered_snapshot_decimal - FLOOR(snr.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS NUMERIC)) AS staker_split
-    FROM strategies_not_registered snr
-    LEFT JOIN operator_set_split_snapshots oss
-        ON snr.operator = oss.operator
-        AND snr.avs = oss.avs
-        AND snr.operator_set_id = oss.operator_set_id
-        AND snr.snapshot = oss.snapshot
-    LEFT JOIN default_operator_split_snapshots dos ON (snr.snapshot = dos.snapshot)
-),
-
--- Step 12: Dedupe staker splits
-distinct_staker_splits AS (
-    SELECT *
-    FROM (
-        SELECT
-            *,
-            ROW_NUMBER() OVER (
-                PARTITION BY reward_hash, snapshot, operator
-                ORDER BY strategy ASC
-            ) AS rn
-        FROM staker_splits
-    ) t
-    WHERE rn = 1
-),
-
--- Step 13: Sum staker refunds
-avs_staker_refund_sums AS (
-    SELECT
-        reward_hash,
-        snapshot,
-        token,
-        avs,
-        operator_set_id,
-        operator,
-        SUM(staker_split) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
-    FROM distinct_staker_splits
-),
-
--- Step 14: Combine all refund cases
-combined_avs_refund_amounts AS (
-    SELECT * FROM avs_operator_refund_sums
-    UNION ALL
-    SELECT * FROM avs_no_stake_refund_sums
-    UNION ALL
-    SELECT * FROM avs_staker_refund_sums
+        tat.reward_hash,
+        tat.snapshot,
+        tat.token,
+        tat.avs,
+        tat.operator_set_id,
+        tat.operator,
+        tat.total_tokens as avs_tokens
+    FROM total_available_tokens tat
+    LEFT JOIN total_distributed_tokens tdt
+        ON tat.reward_hash = tdt.reward_hash
+        AND tat.snapshot = tdt.snapshot
+    WHERE COALESCE(tdt.distributed_tokens, 0) = 0
 )
 
--- Output the final table
-SELECT * FROM combined_avs_refund_amounts
+SELECT * FROM snapshots_requiring_refund
 `
 
 func (rc *RewardsCalculator) GenerateGold20AvsOperatorSetTotalStakeRewardsTable(snapshotDate string, forks config.ForkMap) error {
@@ -233,9 +76,9 @@ func (rc *RewardsCalculator) GenerateGold20AvsOperatorSetTotalStakeRewardsTable(
 	)
 
 	query, err := rewardsUtils.RenderQueryTemplate(_20_goldAvsOperatorSetTotalStakeRewardsQuery, map[string]interface{}{
-		"destTableName":               destTableName,
-		"activeODRewardsTable":        allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
-		"operatorShareSnapshotsTable": "operator_share_snapshots",
+		"destTableName":        destTableName,
+		"activeODRewardsTable": allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+		"operatorRewardsTable": allTableNames[rewardsUtils.Table_18_OperatorOperatorSetTotalStakeRewards],
 	})
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)

--- a/pkg/rewards/20_goldAvsOperatorSetTotalStakeRewards.go
+++ b/pkg/rewards/20_goldAvsOperatorSetTotalStakeRewards.go
@@ -1,0 +1,258 @@
+package rewards
+
+import (
+	"database/sql"
+
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
+	"go.uber.org/zap"
+)
+
+const _20_goldAvsOperatorSetTotalStakeRewardsQuery = `
+CREATE TABLE {{.destTableName}} AS
+
+-- V2.2: AVS Refunds for Total Stake Rewards
+-- Refund scenarios for total stake weighted rewards
+
+-- Step 1: Get operators not registered for the operator set
+WITH not_registered_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot AS snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs AS avs,
+        ap.operator_set_id AS operator_set_id,
+        ap.operator AS operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    WHERE
+        ap.num_registered_snapshots = 0
+),
+
+-- Step 2: Dedupe and sum refunds for non-registered operators
+distinct_not_registered_operators AS (
+    SELECT *
+    FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM not_registered_operators
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 3: Calculate refund amounts for non-registered operators
+avs_operator_refund_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_not_registered_operators
+),
+
+-- Step 4: Get registered operators
+registered_operators AS (
+    SELECT
+        ap.reward_hash,
+        ap.snapshot,
+        ap.token,
+        ap.tokens_per_registered_snapshot_decimal,
+        ap.avs,
+        ap.operator_set_id,
+        ap.operator,
+        ap.strategy,
+        ap.multiplier,
+        ap.reward_submission_date
+    FROM {{.activeODRewardsTable}} ap
+    JOIN operator_set_operator_registration_snapshots osor
+        ON ap.avs = osor.avs
+        AND ap.operator_set_id = osor.operator_set_id
+        AND ap.snapshot = osor.snapshot
+        AND ap.operator = osor.operator
+    WHERE ap.num_registered_snapshots != 0
+      AND ap.reward_submission_date >= @coloradoHardforkDate
+),
+
+-- Step 5: Find operators without sufficient total stake
+operators_without_total_stake AS (
+    SELECT
+        ro.*
+    FROM registered_operators ro
+    LEFT JOIN {{.operatorShareSnapshotsTable}} oss
+        ON ro.operator = oss.operator
+        AND ro.strategy = oss.strategy
+        AND ro.snapshot = oss.snapshot
+    WHERE oss.operator IS NULL OR oss.shares = 0
+),
+
+-- Step 6: Dedupe and calculate refunds for operators without total stake
+distinct_operators_without_stake AS (
+    SELECT *
+    FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM operators_without_total_stake
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 7: Calculate total refund for operators without stake
+avs_no_stake_refund_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(tokens_per_registered_snapshot_decimal) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_operators_without_stake
+),
+
+-- Step 8: Find registered operators WITH stake
+registered_operators_with_stake AS (
+    SELECT
+        ro.*
+    FROM registered_operators ro
+    JOIN {{.operatorShareSnapshotsTable}} oss
+        ON ro.operator = oss.operator
+        AND ro.strategy = oss.strategy
+        AND ro.snapshot = oss.snapshot
+    WHERE oss.shares > 0
+),
+
+-- Step 9: Check if strategies are registered for the operator set
+strategies_registered AS (
+    SELECT DISTINCT
+        ro.reward_hash,
+        ro.snapshot,
+        ro.avs,
+        ro.operator_set_id
+    FROM registered_operators_with_stake ro
+    JOIN operator_set_strategy_registration_snapshots ossr
+        ON ro.avs = ossr.avs
+        AND ro.operator_set_id = ossr.operator_set_id
+        AND ro.snapshot = ossr.snapshot
+        AND ro.strategy = ossr.strategy
+),
+
+-- Step 10: Find operators with stake but no strategies registered
+strategies_not_registered AS (
+    SELECT
+        ro.*
+    FROM registered_operators_with_stake ro
+    LEFT JOIN strategies_registered sr
+        ON ro.reward_hash = sr.reward_hash
+        AND ro.snapshot = sr.snapshot
+        AND ro.avs = sr.avs
+        AND ro.operator_set_id = sr.operator_set_id
+    WHERE sr.reward_hash IS NULL
+),
+
+-- Step 11: Calculate staker splits for refunds
+staker_splits AS (
+    SELECT
+        snr.*,
+        snr.tokens_per_registered_snapshot_decimal - FLOOR(snr.tokens_per_registered_snapshot_decimal * COALESCE(oss.split, dos.split, 1000) / CAST(10000 AS DECIMAL)) AS staker_split
+    FROM strategies_not_registered snr
+    LEFT JOIN operator_set_split_snapshots oss
+        ON snr.operator = oss.operator
+        AND snr.avs = oss.avs
+        AND snr.operator_set_id = oss.operator_set_id
+        AND snr.snapshot = oss.snapshot
+    LEFT JOIN default_operator_split_snapshots dos ON (snr.snapshot = dos.snapshot)
+),
+
+-- Step 12: Dedupe staker splits
+distinct_staker_splits AS (
+    SELECT *
+    FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY reward_hash, snapshot, operator
+                ORDER BY strategy ASC
+            ) AS rn
+        FROM staker_splits
+    ) t
+    WHERE rn = 1
+),
+
+-- Step 13: Sum staker refunds
+avs_staker_refund_sums AS (
+    SELECT
+        reward_hash,
+        snapshot,
+        token,
+        avs,
+        operator_set_id,
+        operator,
+        SUM(staker_split) OVER (PARTITION BY reward_hash, snapshot) AS avs_tokens
+    FROM distinct_staker_splits
+),
+
+-- Step 14: Combine all refund cases
+combined_avs_refund_amounts AS (
+    SELECT * FROM avs_operator_refund_sums
+    UNION ALL
+    SELECT * FROM avs_no_stake_refund_sums
+    UNION ALL
+    SELECT * FROM avs_staker_refund_sums
+)
+
+-- Output the final table
+SELECT * FROM combined_avs_refund_amounts
+`
+
+func (rc *RewardsCalculator) GenerateGold20AvsOperatorSetTotalStakeRewardsTable(snapshotDate string, forks config.ForkMap) error {
+	// Skip if v2.2 is not enabled
+	rewardsV2_2Enabled, err := rc.globalConfig.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to check if rewards v2.2 is enabled", "error", err)
+		return err
+	}
+	if !rewardsV2_2Enabled {
+		rc.logger.Sugar().Infow("Rewards v2.2 is not enabled, skipping v2.2 table 20")
+		return nil
+	}
+
+	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
+	destTableName := allTableNames[rewardsUtils.Table_20_AvsOperatorSetTotalStakeRewards]
+
+	rc.logger.Sugar().Infow("Generating v2.2 AVS operator set reward refunds with total stake validation",
+		zap.String("cutoffDate", snapshotDate),
+		zap.String("destTableName", destTableName),
+		zap.String("coloradoHardforkDate", forks[config.RewardsFork_Colorado].Date),
+	)
+
+	query, err := rewardsUtils.RenderQueryTemplate(_20_goldAvsOperatorSetTotalStakeRewardsQuery, map[string]interface{}{
+		"destTableName":               destTableName,
+		"activeODRewardsTable":        allTableNames[rewardsUtils.Table_11_ActiveODOperatorSetRewards],
+		"operatorShareSnapshotsTable": "operator_share_snapshots",
+	})
+	if err != nil {
+		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)
+		return err
+	}
+
+	res := rc.grm.Exec(query, sql.Named("coloradoHardforkDate", forks[config.RewardsFork_Colorado].Date))
+	if res.Error != nil {
+		rc.logger.Sugar().Errorw("Failed to create gold_avs_operator_set_total_stake_rewards v2.2", "error", res.Error)
+		return res.Error
+	}
+	return nil
+}

--- a/pkg/rewards/21_goldStaging.go
+++ b/pkg/rewards/21_goldStaging.go
@@ -204,11 +204,11 @@ combined_rewards AS (
 {{ end }}
 {{ if .enableRewardsV2_2 }}
   UNION ALL
-  SELECT * FROM operator_od_operator_set_rewards_v2_2_unique_stake
+  SELECT * FROM operator_operator_set_unique_stake_rewards
   UNION ALL
-  SELECT * FROM staker_od_operator_set_rewards_v2_2_unique_stake
+  SELECT * FROM staker_operator_set_unique_stake_rewards
   UNION ALL
-  SELECT * FROM avs_od_operator_set_rewards_v2_2_unique_stake
+  SELECT * FROM avs_operator_set_unique_stake_rewards
   UNION ALL
   SELECT * FROM operator_operator_set_total_stake_rewards
   UNION ALL
@@ -267,27 +267,27 @@ func (rc *RewardsCalculator) GenerateGold21StagingTable(snapshotDate string) err
 	rc.logger.Sugar().Infow("Is RewardsV2_2 enabled?", "enabled", isRewardsV2_2Enabled)
 
 	query, err := rewardsUtils.RenderQueryTemplate(_18_goldStagingQuery, map[string]interface{}{
-		"destTableName":                               destTableName,
-		"stakerRewardAmountsTable":                    allTableNames[rewardsUtils.Table_2_StakerRewardAmounts],
-		"operatorRewardAmountsTable":                  allTableNames[rewardsUtils.Table_3_OperatorRewardAmounts],
-		"rewardsForAllTable":                          allTableNames[rewardsUtils.Table_4_RewardsForAll],
-		"rfaeStakerTable":                             allTableNames[rewardsUtils.Table_5_RfaeStakers],
-		"rfaeOperatorTable":                           allTableNames[rewardsUtils.Table_6_RfaeOperators],
-		"operatorODRewardAmountsTable":                allTableNames[rewardsUtils.Table_8_OperatorODRewardAmounts],
-		"stakerODRewardAmountsTable":                  allTableNames[rewardsUtils.Table_9_StakerODRewardAmounts],
-		"avsODRewardAmountsTable":                     allTableNames[rewardsUtils.Table_10_AvsODRewardAmounts],
-		"enableRewardsV2":                             isRewardsV2Enabled,
-		"operatorODOperatorSetRewardAmountsTable":     allTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts],
-		"stakerODOperatorSetRewardAmountsTable":       allTableNames[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts],
-		"avsODOperatorSetRewardAmountsTable":          allTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts],
-		"enableRewardsV2_1":                           isRewardsV2_1Enabled,
-		"operatorODOperatorSetRewardAmountsTableV2_2": allTableNames[rewardsUtils.Table_15_OperatorOperatorSetUniqueStakeRewards],
-		"stakerODOperatorSetRewardAmountsTableV2_2":   allTableNames[rewardsUtils.Table_16_StakerOperatorSetUniqueStakeRewards],
-		"avsODOperatorSetRewardAmountsTableV2_2":      allTableNames[rewardsUtils.Table_17_AvsOperatorSetUniqueStakeRewards],
-		"operatorOperatorSetTotalStakeRewardsTable":   allTableNames[rewardsUtils.Table_18_OperatorOperatorSetTotalStakeRewards],
-		"stakerOperatorSetTotalStakeRewardsTable":     allTableNames[rewardsUtils.Table_19_StakerOperatorSetTotalStakeRewards],
-		"avsOperatorSetTotalStakeRewardsTable":        allTableNames[rewardsUtils.Table_20_AvsOperatorSetTotalStakeRewards],
-		"enableRewardsV2_2":                           isRewardsV2_2Enabled,
+		"destTableName":                              destTableName,
+		"stakerRewardAmountsTable":                   allTableNames[rewardsUtils.Table_2_StakerRewardAmounts],
+		"operatorRewardAmountsTable":                 allTableNames[rewardsUtils.Table_3_OperatorRewardAmounts],
+		"rewardsForAllTable":                         allTableNames[rewardsUtils.Table_4_RewardsForAll],
+		"rfaeStakerTable":                            allTableNames[rewardsUtils.Table_5_RfaeStakers],
+		"rfaeOperatorTable":                          allTableNames[rewardsUtils.Table_6_RfaeOperators],
+		"operatorODRewardAmountsTable":               allTableNames[rewardsUtils.Table_8_OperatorODRewardAmounts],
+		"stakerODRewardAmountsTable":                 allTableNames[rewardsUtils.Table_9_StakerODRewardAmounts],
+		"avsODRewardAmountsTable":                    allTableNames[rewardsUtils.Table_10_AvsODRewardAmounts],
+		"enableRewardsV2":                            isRewardsV2Enabled,
+		"operatorODOperatorSetRewardAmountsTable":    allTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts],
+		"stakerODOperatorSetRewardAmountsTable":      allTableNames[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts],
+		"avsODOperatorSetRewardAmountsTable":         allTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts],
+		"enableRewardsV2_1":                          isRewardsV2_1Enabled,
+		"operatorOperatorSetUniqueStakeRewardsTable": allTableNames[rewardsUtils.Table_15_OperatorOperatorSetUniqueStakeRewards],
+		"stakerOperatorSetUniqueStakeRewardsTable":   allTableNames[rewardsUtils.Table_16_StakerOperatorSetUniqueStakeRewards],
+		"avsOperatorSetUniqueStakeRewardsTable":      allTableNames[rewardsUtils.Table_17_AvsOperatorSetUniqueStakeRewards],
+		"operatorOperatorSetTotalStakeRewardsTable":  allTableNames[rewardsUtils.Table_18_OperatorOperatorSetTotalStakeRewards],
+		"stakerOperatorSetTotalStakeRewardsTable":    allTableNames[rewardsUtils.Table_19_StakerOperatorSetTotalStakeRewards],
+		"avsOperatorSetTotalStakeRewardsTable":       allTableNames[rewardsUtils.Table_20_AvsOperatorSetTotalStakeRewards],
+		"enableRewardsV2_2":                          isRewardsV2_2Enabled,
 	})
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)

--- a/pkg/rewards/22_goldFinal.go
+++ b/pkg/rewards/22_goldFinal.go
@@ -26,7 +26,7 @@ type GoldRow struct {
 	Amount     string
 }
 
-func (rc *RewardsCalculator) GenerateGold16FinalTable(snapshotDate string) error {
+func (rc *RewardsCalculator) GenerateGold22FinalTable(snapshotDate string) error {
 	allTableNames := rewardsUtils.GetGoldTableNames(snapshotDate)
 
 	rc.logger.Sugar().Infow("Generating gold final table",
@@ -34,7 +34,7 @@ func (rc *RewardsCalculator) GenerateGold16FinalTable(snapshotDate string) error
 	)
 
 	query, err := rewardsUtils.RenderQueryTemplate(_16_goldFinalQuery, map[string]interface{}{
-		"goldStagingTable": allTableNames[rewardsUtils.Table_15_GoldStaging],
+		"goldStagingTable": allTableNames[rewardsUtils.Table_21_GoldStaging],
 	})
 	if err != nil {
 		rc.logger.Sugar().Errorw("Failed to render query template", "error", err)

--- a/pkg/rewards/operatorAllocationSnapshots.go
+++ b/pkg/rewards/operatorAllocationSnapshots.go
@@ -1,7 +1,6 @@
 package rewards
 
 import (
-	"github.com/Layr-Labs/sidecar/internal/config"
 	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
 	"go.uber.org/zap"
 )
@@ -16,7 +15,20 @@ const operatorAllocationSnapshotsQuery = `
 		INNER JOIN blocks b ON COALESCE(oa.effective_block, oa.block_number) = b.number
 		WHERE b.block_time < TIMESTAMP '{{.cutoffDate}}'
 	),
-	-- Get max magnitudes from operator_max_magnitudes table
+	-- Get the latest record for each day
+	daily_records as (
+		SELECT
+			operator,
+			avs,
+			strategy,
+			operator_set_id,
+			magnitude,
+			block_time,
+			block_number,
+			log_index
+		FROM ranked_allocation_records
+		WHERE rn = 1
+	),
 	ranked_max_magnitude_records as (
 		SELECT
 			omm.operator,
@@ -42,21 +54,6 @@ const operatorAllocationSnapshotsQuery = `
 		FROM ranked_max_magnitude_records
 		WHERE rn = 1
 	),
-	-- Get the latest record for each day
-	daily_records as (
-		SELECT
-			operator,
-			avs,
-			strategy,
-			operator_set_id,
-			magnitude,
-			block_time,
-			block_number,
-			log_index
-		FROM ranked_allocation_records
-		WHERE rn = 1
-	),
-	-- Compare each record with the previous record to determine if it's an increase or decrease
 	records_with_comparison as (
 		SELECT
 			operator,
@@ -66,12 +63,8 @@ const operatorAllocationSnapshotsQuery = `
 			magnitude,
 			block_time,
 			LAG(magnitude) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY block_time, block_number, log_index) as previous_magnitude,
-			-- Backward compatibility: Apply new rounding logic only after Sabine fork
-			-- Pre-Sabine: Always round down to current day (old behavior)
-			-- Post-Sabine: Allocation (increase) rounds UP, deallocation rounds DOWN
+			-- Allocation (increase) rounds UP, deallocation (decrease) rounds DOWN
 			CASE
-				{{ if .useSabineRounding }}
-				-- Post-Sabine fork rounding logic
 				WHEN LAG(magnitude) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY block_time, block_number, log_index) IS NULL THEN
 					-- First allocation: round up to next day
 					date_trunc('day', block_time) + INTERVAL '1' day
@@ -81,19 +74,9 @@ const operatorAllocationSnapshotsQuery = `
 				ELSE
 					-- Decrease or no change: round down to current day
 					date_trunc('day', block_time)
-				{{ else }}
-				-- Pre-Sabine fork rounding logic (backward compatibility)
-				WHEN LAG(magnitude) OVER (PARTITION BY operator, avs, strategy, operator_set_id ORDER BY block_time, block_number, log_index) IS NULL THEN
-					-- First allocation: round down to current day (old behavior)
-					date_trunc('day', block_time)
-				ELSE
-					-- All other cases: round down to current day
-					date_trunc('day', block_time)
-				{{ end }}
 			END AS snapshot_time
 		FROM daily_records
 	),
-	-- Get the range for each operator, avs, strategy, operator_set_id combination
 	allocation_windows as (
 		SELECT
 			operator,
@@ -113,7 +96,6 @@ const operatorAllocationSnapshotsQuery = `
 		SELECT * FROM allocation_windows
 		WHERE start_time < end_time
 	),
-	-- Generate daily snapshots from allocation windows
 	daily_allocation_snapshots as (
 		SELECT
 			operator,
@@ -127,7 +109,6 @@ const operatorAllocationSnapshotsQuery = `
 		CROSS JOIN
 			generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS day
 	),
-	-- Create windows for max_magnitude similar to allocations
 	max_magnitude_windows as (
 		SELECT
 			operator,
@@ -140,7 +121,6 @@ const operatorAllocationSnapshotsQuery = `
 			END AS end_time
 		FROM daily_max_magnitude_records
 	),
-	-- Generate daily snapshots for max_magnitude
 	daily_max_magnitude_snapshots as (
 		SELECT
 			operator,
@@ -153,14 +133,14 @@ const operatorAllocationSnapshotsQuery = `
 		CROSS JOIN
 			generate_series(DATE(start_time), DATE(end_time) - interval '1' day, interval '1' day) AS day
 	)
-	-- Join allocation snapshots with max_magnitude snapshots
 	SELECT
 		das.operator,
 		das.avs,
 		das.strategy,
 		das.operator_set_id,
 		das.magnitude,
-		COALESCE(dmms.max_magnitude, '0') as max_magnitude,
+		-- Default to 1e18 (contract initialization value) when no MagnitudeUpdated event exists
+		COALESCE(dmms.max_magnitude, '1000000000000000000') as max_magnitude,
 		das.snapshot
 	FROM
 		daily_allocation_snapshots das
@@ -172,36 +152,8 @@ const operatorAllocationSnapshotsQuery = `
 `
 
 func (r *RewardsCalculator) GenerateAndInsertOperatorAllocationSnapshots(snapshotDate string) error {
-	// Determine if we should use Sabine fork rounding logic based on snapshot date
-	forks, err := r.globalConfig.GetRewardsSqlForkDates()
-	if err != nil {
-		r.logger.Sugar().Errorw("Failed to get rewards fork dates", "error", err)
-		return err
-	}
-
-	// Get the block number for the cutoff date to make block-based fork decision
-	var cutoffBlockNumber uint64
-	err = r.grm.Raw(`
-		SELECT number
-		FROM blocks
-		WHERE block_time <= ?
-		ORDER BY number DESC
-		LIMIT 1
-	`, snapshotDate).Scan(&cutoffBlockNumber).Error
-	if err != nil {
-		r.logger.Sugar().Errorw("Failed to get cutoff block number", "error", err, "snapshotDate", snapshotDate)
-		return err
-	}
-
-	// Use block-based fork check for backwards compatibility
-	useSabineRounding := false
-	if sabineFork, exists := forks[config.RewardsFork_Sabine]; exists {
-		useSabineRounding = cutoffBlockNumber >= sabineFork.BlockNumber
-	}
-
 	query, err := rewardsUtils.RenderQueryTemplate(operatorAllocationSnapshotsQuery, map[string]interface{}{
-		"cutoffDate":        snapshotDate,
-		"useSabineRounding": useSabineRounding,
+		"cutoffDate": snapshotDate,
 	})
 	if err != nil {
 		r.logger.Sugar().Errorw("Failed to render query template", "error", err)
@@ -210,7 +162,6 @@ func (r *RewardsCalculator) GenerateAndInsertOperatorAllocationSnapshots(snapsho
 
 	r.logger.Sugar().Debugw("Generating operator allocation snapshots",
 		zap.String("snapshotDate", snapshotDate),
-		zap.Bool("useSabineRounding", useSabineRounding),
 	)
 
 	res := r.grm.Exec(query)

--- a/pkg/rewards/rewards.go
+++ b/pkg/rewards/rewards.go
@@ -741,6 +741,15 @@ func (rc *RewardsCalculator) generateSnapshotData(snapshotDate string) error {
 	}
 	rc.logger.Sugar().Debugw("Generated operator set strategy registration snapshots")
 
+	// ------------------------------------------------------------------------
+	// Rewards V2.2 snapshots (Unique Stake)
+	// ------------------------------------------------------------------------
+	if err = rc.GenerateAndInsertOperatorAllocationSnapshots(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate operator allocation snapshots", "error", err)
+		return err
+	}
+	rc.logger.Sugar().Debugw("Generated operator allocation snapshots")
+
 	return nil
 }
 
@@ -754,6 +763,8 @@ func (rc *RewardsCalculator) generateGoldTables(snapshotDate string) error {
 		return err
 	}
 
+	// V2.2 uses v1 AVS rewards logic - unique stake is only for operator set rewards
+	// The main v2.2 unique stake logic is in operator set rewards (table 13)
 	if err := rc.GenerateGold2StakerRewardAmountsTable(snapshotDate, forks); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate staker reward amounts", "error", err)
 		return err
@@ -804,6 +815,11 @@ func (rc *RewardsCalculator) generateGoldTables(snapshotDate string) error {
 		return err
 	}
 
+	// ------------------------------------------------------------------------
+	// Rewards V2.1 & V2.2 - Operator Set Rewards
+	// Each function internally checks if it should run based on v2.2 config
+	// ------------------------------------------------------------------------
+
 	if err := rc.GenerateGold12OperatorODOperatorSetRewardAmountsTable(snapshotDate); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate operator od operator set rewards", "error", err)
 		return err
@@ -819,12 +835,47 @@ func (rc *RewardsCalculator) generateGoldTables(snapshotDate string) error {
 		return err
 	}
 
-	if err := rc.GenerateGold15StagingTable(snapshotDate); err != nil {
+	if err := rc.GenerateGold15OperatorOperatorSetUniqueStakeRewardsTable(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 operator unique stake rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold16StakerOperatorSetUniqueStakeRewardsTable(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 staker unique stake rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold17AvsOperatorSetUniqueStakeRewardsTable(snapshotDate, forks); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 avs unique stake rewards", "error", err)
+		return err
+	}
+
+	// ------------------------------------------------------------------------
+	// Rewards V2.2 - Total Stake Weighted Rewards
+	// Each function internally checks if it should run based on v2.2 config
+	// ------------------------------------------------------------------------
+
+	if err := rc.GenerateGold18OperatorOperatorSetTotalStakeRewardsTable(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 operator total stake rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold19StakerOperatorSetTotalStakeRewardsTable(snapshotDate); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 staker total stake rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold20AvsOperatorSetTotalStakeRewardsTable(snapshotDate, forks); err != nil {
+		rc.logger.Sugar().Errorw("Failed to generate v2.2 avs total stake rewards", "error", err)
+		return err
+	}
+
+	if err := rc.GenerateGold21StagingTable(snapshotDate); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate gold staging", "error", err)
 		return err
 	}
 
-	if err := rc.GenerateGold16FinalTable(snapshotDate); err != nil {
+	if err := rc.GenerateGold22FinalTable(snapshotDate); err != nil {
 		rc.logger.Sugar().Errorw("Failed to generate final table", "error", err)
 		return err
 	}

--- a/pkg/rewards/rewardsV2_1_test.go
+++ b/pkg/rewards/rewardsV2_1_test.go
@@ -253,15 +253,15 @@ func Test_RewardsV2_1(t *testing.T) {
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_15_staging\n")
-			err = rc.GenerateGold15StagingTable(snapshotDate)
+			err = rc.GenerateGold21StagingTable(snapshotDate)
 			assert.Nil(t, err)
-			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_18_GoldStaging])
+			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_21_GoldStaging])
 			assert.Nil(t, err)
 			fmt.Printf("\tRows in gold_15_staging: %v - [time: %v]\n", rows, time.Since(testStart))
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_final_table\n")
-			err = rc.GenerateGold16FinalTable(snapshotDate)
+			err = rc.GenerateGold22FinalTable(snapshotDate)
 			assert.Nil(t, err)
 			rows, err = getRowCountForTable(grm, "gold_table")
 			assert.Nil(t, err)

--- a/pkg/rewards/rewardsV2_2_test.go
+++ b/pkg/rewards/rewardsV2_2_test.go
@@ -1,6 +1,7 @@
 package rewards
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,9 +10,11 @@ import (
 	"github.com/Layr-Labs/sidecar/pkg/rewards/stakerOperators"
 	"github.com/Layr-Labs/sidecar/pkg/rewardsUtils"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
 )
 
-func Test_RewardsV2_1(t *testing.T) {
+func Test_RewardsV2_2(t *testing.T) {
 	if !rewardsTestsEnabled() {
 		t.Skipf("Skipping %s", t.Name())
 		return
@@ -24,9 +27,12 @@ func Test_RewardsV2_1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Enable v2.2 for testing
+	cfg.Rewards.RewardsV2_2Enabled = true
+
 	sog := stakerOperators.NewStakerOperatorGenerator(grm, l, cfg)
 
-	t.Run("Should initialize the rewards calculator", func(t *testing.T) {
+	t.Run("Should initialize the rewards calculator with v2.2", func(t *testing.T) {
 		rc, err := NewRewardsCalculator(cfg, grm, nil, sog, sink, l)
 		assert.Nil(t, err)
 		if err != nil {
@@ -83,10 +89,14 @@ func Test_RewardsV2_1(t *testing.T) {
 		err = hydrateOperatorDirectedOperatorSetRewardSubmissionsTable(grm, l)
 		assert.Nil(t, err)
 
+		// RewardsV2_2 tables - Operator allocations for unique stake
+		err = hydrateOperatorAllocations(grm, l)
+		assert.Nil(t, err)
+
 		t.Log("Hydrated tables")
 
 		snapshotDates := []string{
-			"2025-02-05",
+			"2025-02-10", // Date after Pecos fork for v2.2
 		}
 
 		fmt.Printf("Hydration duration: %v\n", time.Since(testStart))
@@ -206,7 +216,7 @@ func Test_RewardsV2_1(t *testing.T) {
 			testStart = time.Now()
 
 			// ------------------------------------------------------------------------
-			// Rewards V2.1
+			// Rewards V2.1 (Should be skipped when v2.2 is enabled)
 			// ------------------------------------------------------------------------
 
 			rewardsV2_1Enabled, err := cfg.IsRewardsV2_1EnabledForCutoffDate(snapshotDate)
@@ -222,42 +232,50 @@ func Test_RewardsV2_1(t *testing.T) {
 			}
 			testStart = time.Now()
 
-			fmt.Printf("Running gold_12_operator_od_operator_set_rewards\n")
-			err = rc.GenerateGold12OperatorODOperatorSetRewardAmountsTable(snapshotDate)
+			// ------------------------------------------------------------------------
+			// Rewards V2.2 (Unique Stake)
+			// ------------------------------------------------------------------------
+
+			rewardsV2_2Enabled, err := cfg.IsRewardsV2_2EnabledForCutoffDate(snapshotDate)
 			assert.Nil(t, err)
-			if rewardsV2_1Enabled {
-				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_12_OperatorODOperatorSetRewardAmounts])
+			assert.True(t, rewardsV2_2Enabled, "v2.2 should be enabled for this test")
+
+			fmt.Printf("Running gold_15_operator_od_operator_set_rewards_v2_2\n")
+			err = rc.GenerateGold15OperatorODOperatorSetRewardAmountsV2_2Table(snapshotDate)
+			assert.Nil(t, err)
+			if rewardsV2_2Enabled {
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_15_OperatorODOperatorSetRewardAmountsV2_2])
 				assert.Nil(t, err)
-				fmt.Printf("\tRows in gold_12_operator_od_operator_set_rewards: %v - [time: %v]\n", rows, time.Since(testStart))
+				fmt.Printf("\tRows in gold_15_operator_od_operator_set_rewards_v2_2: %v - [time: %v]\n", rows, time.Since(testStart))
 			}
 			testStart = time.Now()
 
-			fmt.Printf("Running gold_13_staker_od_operator_set_rewards\n")
-			err = rc.GenerateGold13StakerODOperatorSetRewardAmountsTable(snapshotDate)
+			fmt.Printf("Running gold_16_staker_od_operator_set_rewards_v2_2\n")
+			err = rc.GenerateGold16StakerODOperatorSetRewardAmountsV2_2Table(snapshotDate)
 			assert.Nil(t, err)
-			if rewardsV2_1Enabled {
-				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_13_StakerODOperatorSetRewardAmounts])
+			if rewardsV2_2Enabled {
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_16_StakerODOperatorSetRewardAmountsV2_2])
 				assert.Nil(t, err)
-				fmt.Printf("\tRows in gold_13_staker_od_operator_set_rewards: %v - [time: %v]\n", rows, time.Since(testStart))
+				fmt.Printf("\tRows in gold_16_staker_od_operator_set_rewards_v2_2: %v - [time: %v]\n", rows, time.Since(testStart))
 			}
 			testStart = time.Now()
 
-			fmt.Printf("Running gold_14_avs_od_operator_set_rewards\n")
-			err = rc.GenerateGold14AvsODOperatorSetRewardAmountsTable(snapshotDate, forks)
+			fmt.Printf("Running gold_17_avs_od_operator_set_rewards_v2_2\n")
+			err = rc.GenerateGold17AvsODOperatorSetRewardAmountsV2_2Table(snapshotDate, forks)
 			assert.Nil(t, err)
-			if rewardsV2_1Enabled {
-				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_14_AvsODOperatorSetRewardAmounts])
+			if rewardsV2_2Enabled {
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_17_AvsODOperatorSetRewardAmountsV2_2])
 				assert.Nil(t, err)
-				fmt.Printf("\tRows in gold_14_avs_od_operator_set_rewards: %v - [time: %v]\n", rows, time.Since(testStart))
+				fmt.Printf("\tRows in gold_17_avs_od_operator_set_rewards_v2_2: %v - [time: %v]\n", rows, time.Since(testStart))
 			}
 			testStart = time.Now()
 
-			fmt.Printf("Running gold_15_staging\n")
+			fmt.Printf("Running gold_18_staging\n")
 			err = rc.GenerateGold15StagingTable(snapshotDate)
 			assert.Nil(t, err)
 			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_18_GoldStaging])
 			assert.Nil(t, err)
-			fmt.Printf("\tRows in gold_15_staging: %v - [time: %v]\n", rows, time.Since(testStart))
+			fmt.Printf("\tRows in gold_18_staging: %v - [time: %v]\n", rows, time.Since(testStart))
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_final_table\n")
@@ -276,12 +294,18 @@ func Test_RewardsV2_1(t *testing.T) {
 					strings.EqualFold(row.Earner, strings.ToLower("0xaFF71569D30ED876987088a62E0EA881EBc761E6")) {
 					t.Logf("%d: %s %s %s %s %s", i, row.Earner, row.Snapshot.String(), row.RewardHash, row.Token, row.Amount)
 				}
-				// t.Logf("%d: %s %s %s %s %s", i, row.Earner, row.Snapshot.String(), row.RewardHash, row.Token, row.Amount)
 			}
 
 			t.Logf("Generating staker operators table")
 			err = rc.sog.GenerateStakerOperatorsTable(snapshotDate)
 			assert.Nil(t, err)
+
+			// V2.2 specific validation - ensure operator allocations snapshot was created
+			operatorAllocSnapshotTable := goldTableNames[rewardsUtils.Table_OperatorAllocationSnapshots]
+			rows, err = getRowCountForTable(grm, operatorAllocSnapshotTable)
+			assert.Nil(t, err)
+			t.Logf("Operator allocation snapshots: %v", rows)
+			assert.True(t, rows > 0, "Operator allocation snapshots should be created for v2.2")
 
 			fmt.Printf("Total duration for rewards compute %s: %v\n", snapshotDate, time.Since(snapshotStartTime))
 			testStart = time.Now()
@@ -292,4 +316,64 @@ func Test_RewardsV2_1(t *testing.T) {
 			// teardownRewards(dbFileName, cfg, grm, l)
 		})
 	})
+}
+
+// hydrateOperatorAllocations creates test data for operator allocations (unique stake)
+func hydrateOperatorAllocations(grm *gorm.DB, l *zap.Logger) error {
+	records := []map[string]interface{}{
+		// Operator 1 allocates stake to operator set 0
+		{
+			"operator":         "0xa067defa8e919ebad10f3c4168a77e29a46e0b3f",
+			"avs":              "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+			"strategy":         "0x93c4b944d05dfe6df7645a86cd2206016c51564d",
+			"magnitude":        "1000000000000000000", // 1 ETH
+			"avs_directory":    "0x1234567890123456789012345678901234567890",
+			"operator_set_id":  0,
+			"effective_block":  100,
+			"block_time":       "2025-02-01 00:00:00",
+			"transaction_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+			"log_index":        1,
+			"block_number":     100,
+		},
+		// Operator 2 allocates stake to operator set 1
+		{
+			"operator":         "0x9e91cc6d7a6ada3e2f1f1c4eaa39e35d8e7a6c29",
+			"avs":              "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+			"strategy":         "0x93c4b944d05dfe6df7645a86cd2206016c51564d",
+			"magnitude":        "2000000000000000000", // 2 ETH
+			"avs_directory":    "0x1234567890123456789012345678901234567890",
+			"operator_set_id":  1,
+			"effective_block":  100,
+			"block_time":       "2025-02-01 00:00:00",
+			"transaction_hash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+			"log_index":        2,
+			"block_number":     100,
+		},
+	}
+
+	for _, record := range records {
+		res := grm.Exec(`
+			INSERT INTO operator_allocations 
+			(operator, avs, strategy, magnitude, avs_directory, operator_set_id, effective_block, block_time, transaction_hash, log_index, block_number)
+			VALUES (@operator, @avs, @strategy, @magnitude, @avs_directory, @operator_set_id, @effective_block, @block_time, @transaction_hash, @log_index, @block_number)
+		`,
+			sql.Named("operator", record["operator"]),
+			sql.Named("avs", record["avs"]),
+			sql.Named("strategy", record["strategy"]),
+			sql.Named("magnitude", record["magnitude"]),
+			sql.Named("avs_directory", record["avs_directory"]),
+			sql.Named("operator_set_id", record["operator_set_id"]),
+			sql.Named("effective_block", record["effective_block"]),
+			sql.Named("block_time", record["block_time"]),
+			sql.Named("transaction_hash", record["transaction_hash"]),
+			sql.Named("log_index", record["log_index"]),
+			sql.Named("block_number", record["block_number"]),
+		)
+		if res.Error != nil {
+			l.Sugar().Errorw("Failed to insert operator allocation", "error", res.Error)
+			return res.Error
+		}
+	}
+
+	return nil
 }

--- a/pkg/rewards/rewardsV2_2_test.go
+++ b/pkg/rewards/rewardsV2_2_test.go
@@ -241,45 +241,45 @@ func Test_RewardsV2_2(t *testing.T) {
 			assert.True(t, rewardsV2_2Enabled, "v2.2 should be enabled for this test")
 
 			fmt.Printf("Running gold_15_operator_od_operator_set_rewards_v2_2\n")
-			err = rc.GenerateGold15OperatorODOperatorSetRewardAmountsV2_2Table(snapshotDate)
+			err = rc.GenerateGold15OperatorOperatorSetUniqueStakeRewardsTable(snapshotDate)
 			assert.Nil(t, err)
 			if rewardsV2_2Enabled {
-				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_15_OperatorODOperatorSetRewardAmountsV2_2])
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_15_OperatorOperatorSetUniqueStakeRewards])
 				assert.Nil(t, err)
 				fmt.Printf("\tRows in gold_15_operator_od_operator_set_rewards_v2_2: %v - [time: %v]\n", rows, time.Since(testStart))
 			}
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_16_staker_od_operator_set_rewards_v2_2\n")
-			err = rc.GenerateGold16StakerODOperatorSetRewardAmountsV2_2Table(snapshotDate)
+			err = rc.GenerateGold16StakerOperatorSetUniqueStakeRewardsTable(snapshotDate)
 			assert.Nil(t, err)
 			if rewardsV2_2Enabled {
-				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_16_StakerODOperatorSetRewardAmountsV2_2])
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_16_StakerOperatorSetUniqueStakeRewards])
 				assert.Nil(t, err)
 				fmt.Printf("\tRows in gold_16_staker_od_operator_set_rewards_v2_2: %v - [time: %v]\n", rows, time.Since(testStart))
 			}
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_17_avs_od_operator_set_rewards_v2_2\n")
-			err = rc.GenerateGold17AvsODOperatorSetRewardAmountsV2_2Table(snapshotDate, forks)
+			err = rc.GenerateGold17AvsOperatorSetUniqueStakeRewardsTable(snapshotDate, forks)
 			assert.Nil(t, err)
 			if rewardsV2_2Enabled {
-				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_17_AvsODOperatorSetRewardAmountsV2_2])
+				rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_17_AvsOperatorSetUniqueStakeRewards])
 				assert.Nil(t, err)
 				fmt.Printf("\tRows in gold_17_avs_od_operator_set_rewards_v2_2: %v - [time: %v]\n", rows, time.Since(testStart))
 			}
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_18_staging\n")
-			err = rc.GenerateGold15StagingTable(snapshotDate)
+			err = rc.GenerateGold21StagingTable(snapshotDate)
 			assert.Nil(t, err)
-			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_18_GoldStaging])
+			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_21_GoldStaging])
 			assert.Nil(t, err)
 			fmt.Printf("\tRows in gold_18_staging: %v - [time: %v]\n", rows, time.Since(testStart))
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_final_table\n")
-			err = rc.GenerateGold16FinalTable(snapshotDate)
+			err = rc.GenerateGold22FinalTable(snapshotDate)
 			assert.Nil(t, err)
 			rows, err = getRowCountForTable(grm, "gold_table")
 			assert.Nil(t, err)

--- a/pkg/rewards/rewardsV2_test.go
+++ b/pkg/rewards/rewardsV2_test.go
@@ -242,7 +242,7 @@ func Test_RewardsV2(t *testing.T) {
 			fmt.Printf("Running gold_15_staging\n")
 			err = rc.GenerateGold15StagingTable(snapshotDate)
 			assert.Nil(t, err)
-			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_15_GoldStaging])
+			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_18_GoldStaging])
 			assert.Nil(t, err)
 			fmt.Printf("\tRows in gold_15_staging: %v - [time: %v]\n", rows, time.Since(testStart))
 			testStart = time.Now()

--- a/pkg/rewards/rewardsV2_test.go
+++ b/pkg/rewards/rewardsV2_test.go
@@ -240,15 +240,15 @@ func Test_RewardsV2(t *testing.T) {
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_15_staging\n")
-			err = rc.GenerateGold15StagingTable(snapshotDate)
+			err = rc.GenerateGold21StagingTable(snapshotDate)
 			assert.Nil(t, err)
-			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_18_GoldStaging])
+			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_21_GoldStaging])
 			assert.Nil(t, err)
 			fmt.Printf("\tRows in gold_15_staging: %v - [time: %v]\n", rows, time.Since(testStart))
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_final_table\n")
-			err = rc.GenerateGold16FinalTable(snapshotDate)
+			err = rc.GenerateGold22FinalTable(snapshotDate)
 			assert.Nil(t, err)
 			rows, err = getRowCountForTable(grm, "gold_table")
 			assert.Nil(t, err)

--- a/pkg/rewards/rewards_test.go
+++ b/pkg/rewards/rewards_test.go
@@ -397,15 +397,15 @@ func Test_Rewards(t *testing.T) {
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_15_staging\n")
-			err = rc.GenerateGold15StagingTable(snapshotDate)
+			err = rc.GenerateGold21StagingTable(snapshotDate)
 			assert.Nil(t, err)
-			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_18_GoldStaging])
+			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_21_GoldStaging])
 			assert.Nil(t, err)
 			fmt.Printf("\tRows in gold_15_staging: %v - [time: %v]\n", rows, time.Since(testStart))
 			testStart = time.Now()
 
 			fmt.Printf("Running gold_final_table\n")
-			err = rc.GenerateGold16FinalTable(snapshotDate)
+			err = rc.GenerateGold22FinalTable(snapshotDate)
 			assert.Nil(t, err)
 			rows, err = getRowCountForTable(grm, "gold_table")
 			assert.Nil(t, err)

--- a/pkg/rewards/rewards_test.go
+++ b/pkg/rewards/rewards_test.go
@@ -399,7 +399,7 @@ func Test_Rewards(t *testing.T) {
 			fmt.Printf("Running gold_15_staging\n")
 			err = rc.GenerateGold15StagingTable(snapshotDate)
 			assert.Nil(t, err)
-			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_15_GoldStaging])
+			rows, err = getRowCountForTable(grm, goldTableNames[rewardsUtils.Table_18_GoldStaging])
 			assert.Nil(t, err)
 			fmt.Printf("\tRows in gold_15_staging: %v - [time: %v]\n", rows, time.Since(testStart))
 			testStart = time.Now()

--- a/pkg/rewards/tables.go
+++ b/pkg/rewards/tables.go
@@ -122,10 +122,11 @@ type OperatorSetSplitSnapshots struct {
 }
 
 type OperatorSetOperatorRegistrationSnapshots struct {
-	Operator      string
-	Avs           string
-	OperatorSetId uint64
-	Snapshot      time.Time
+	Operator       string
+	Avs            string
+	OperatorSetId  uint64
+	Snapshot       time.Time
+	SlashableUntil *time.Time // NULL when operator is still active
 }
 
 type OperatorSetStrategyRegistrationSnapshots struct {

--- a/pkg/rewards/tables.go
+++ b/pkg/rewards/tables.go
@@ -161,5 +161,6 @@ type OperatorAllocationSnapshot struct {
 	Strategy      string
 	OperatorSetId uint64
 	Magnitude     string
+	MaxMagnitude  string
 	Snapshot      time.Time
 }

--- a/pkg/rewardsUtils/rewardsUtils.go
+++ b/pkg/rewardsUtils/rewardsUtils.go
@@ -12,22 +12,30 @@ import (
 )
 
 var (
-	Table_1_ActiveRewards                       = "gold_1_active_rewards"
-	Table_2_StakerRewardAmounts                 = "gold_2_staker_reward_amounts"
-	Table_3_OperatorRewardAmounts               = "gold_3_operator_reward_amounts"
-	Table_4_RewardsForAll                       = "gold_4_rewards_for_all"
-	Table_5_RfaeStakers                         = "gold_5_rfae_stakers"
-	Table_6_RfaeOperators                       = "gold_6_rfae_operators"
-	Table_7_ActiveODRewards                     = "gold_7_active_od_rewards"
-	Table_8_OperatorODRewardAmounts             = "gold_8_operator_od_reward_amounts"
-	Table_9_StakerODRewardAmounts               = "gold_9_staker_od_reward_amounts"
-	Table_10_AvsODRewardAmounts                 = "gold_10_avs_od_reward_amounts"
-	Table_11_ActiveODOperatorSetRewards         = "gold_11_active_od_operator_set_rewards"
-	Table_12_OperatorODOperatorSetRewardAmounts = "gold_12_operator_od_operator_set_reward_amounts"
-	Table_13_StakerODOperatorSetRewardAmounts   = "gold_13_staker_od_operator_set_reward_amounts"
-	Table_14_AvsODOperatorSetRewardAmounts      = "gold_14_avs_od_operator_set_reward_amounts"
-	Table_15_GoldStaging                        = "gold_15_staging"
-	Table_16_GoldTable                          = "gold_table"
+	Table_1_ActiveRewards                          = "gold_1_active_rewards"
+	Table_2_StakerRewardAmounts                    = "gold_2_staker_reward_amounts"
+	Table_3_OperatorRewardAmounts                  = "gold_3_operator_reward_amounts"
+	Table_4_RewardsForAll                          = "gold_4_rewards_for_all"
+	Table_5_RfaeStakers                            = "gold_5_rfae_stakers"
+	Table_6_RfaeOperators                          = "gold_6_rfae_operators"
+	Table_7_ActiveODRewards                        = "gold_7_active_od_rewards"
+	Table_8_OperatorODRewardAmounts                = "gold_8_operator_od_reward_amounts"
+	Table_9_StakerODRewardAmounts                  = "gold_9_staker_od_reward_amounts"
+	Table_10_AvsODRewardAmounts                    = "gold_10_avs_od_reward_amounts"
+	Table_11_ActiveODOperatorSetRewards            = "gold_11_active_od_operator_set_rewards"
+	Table_12_OperatorODOperatorSetRewardAmounts    = "gold_12_operator_od_operator_set_reward_amounts"
+	Table_13_StakerODOperatorSetRewardAmounts      = "gold_13_staker_od_operator_set_reward_amounts"
+	Table_14_AvsODOperatorSetRewardAmounts         = "gold_14_avs_od_operator_set_reward_amounts"
+	Table_15_OperatorOperatorSetUniqueStakeRewards = "gold_15_operator_operator_set_unique_stake_rewards"
+	Table_16_StakerOperatorSetUniqueStakeRewards   = "gold_16_staker_operator_set_unique_stake_rewards"
+	Table_17_AvsOperatorSetUniqueStakeRewards      = "gold_17_avs_operator_set_unique_stake_rewards"
+	Table_18_OperatorOperatorSetTotalStakeRewards  = "gold_18_operator_operator_set_total_stake_rewards"
+	Table_19_StakerOperatorSetTotalStakeRewards    = "gold_19_staker_operator_set_total_stake_rewards"
+	Table_20_AvsOperatorSetTotalStakeRewards       = "gold_20_avs_operator_set_total_stake_rewards"
+	Table_21_GoldStaging                           = "gold_21_staging"
+	Table_22_GoldTable                             = "gold_table"
+
+	Table_OperatorAllocationSnapshots = "operator_allocation_snapshots"
 
 	Sot_1_StakerStrategyPayouts                = "sot_1_staker_strategy_payouts"
 	Sot_2_OperatorStrategyPayouts              = "sot_2_operator_strategy_payouts"
@@ -45,22 +53,30 @@ var (
 )
 
 var goldTableBaseNames = map[string]string{
-	Table_1_ActiveRewards:                       Table_1_ActiveRewards,
-	Table_2_StakerRewardAmounts:                 Table_2_StakerRewardAmounts,
-	Table_3_OperatorRewardAmounts:               Table_3_OperatorRewardAmounts,
-	Table_4_RewardsForAll:                       Table_4_RewardsForAll,
-	Table_5_RfaeStakers:                         Table_5_RfaeStakers,
-	Table_6_RfaeOperators:                       Table_6_RfaeOperators,
-	Table_7_ActiveODRewards:                     Table_7_ActiveODRewards,
-	Table_8_OperatorODRewardAmounts:             Table_8_OperatorODRewardAmounts,
-	Table_9_StakerODRewardAmounts:               Table_9_StakerODRewardAmounts,
-	Table_10_AvsODRewardAmounts:                 Table_10_AvsODRewardAmounts,
-	Table_11_ActiveODOperatorSetRewards:         Table_11_ActiveODOperatorSetRewards,
-	Table_12_OperatorODOperatorSetRewardAmounts: Table_12_OperatorODOperatorSetRewardAmounts,
-	Table_13_StakerODOperatorSetRewardAmounts:   Table_13_StakerODOperatorSetRewardAmounts,
-	Table_14_AvsODOperatorSetRewardAmounts:      Table_14_AvsODOperatorSetRewardAmounts,
-	Table_15_GoldStaging:                        Table_15_GoldStaging,
-	Table_16_GoldTable:                          Table_16_GoldTable,
+	Table_1_ActiveRewards:                          Table_1_ActiveRewards,
+	Table_2_StakerRewardAmounts:                    Table_2_StakerRewardAmounts,
+	Table_3_OperatorRewardAmounts:                  Table_3_OperatorRewardAmounts,
+	Table_4_RewardsForAll:                          Table_4_RewardsForAll,
+	Table_5_RfaeStakers:                            Table_5_RfaeStakers,
+	Table_6_RfaeOperators:                          Table_6_RfaeOperators,
+	Table_7_ActiveODRewards:                        Table_7_ActiveODRewards,
+	Table_8_OperatorODRewardAmounts:                Table_8_OperatorODRewardAmounts,
+	Table_9_StakerODRewardAmounts:                  Table_9_StakerODRewardAmounts,
+	Table_10_AvsODRewardAmounts:                    Table_10_AvsODRewardAmounts,
+	Table_11_ActiveODOperatorSetRewards:            Table_11_ActiveODOperatorSetRewards,
+	Table_12_OperatorODOperatorSetRewardAmounts:    Table_12_OperatorODOperatorSetRewardAmounts,
+	Table_13_StakerODOperatorSetRewardAmounts:      Table_13_StakerODOperatorSetRewardAmounts,
+	Table_14_AvsODOperatorSetRewardAmounts:         Table_14_AvsODOperatorSetRewardAmounts,
+	Table_15_OperatorOperatorSetUniqueStakeRewards: Table_15_OperatorOperatorSetUniqueStakeRewards,
+	Table_16_StakerOperatorSetUniqueStakeRewards:   Table_16_StakerOperatorSetUniqueStakeRewards,
+	Table_17_AvsOperatorSetUniqueStakeRewards:      Table_17_AvsOperatorSetUniqueStakeRewards,
+	Table_18_OperatorOperatorSetTotalStakeRewards:  Table_18_OperatorOperatorSetTotalStakeRewards,
+	Table_19_StakerOperatorSetTotalStakeRewards:    Table_19_StakerOperatorSetTotalStakeRewards,
+	Table_20_AvsOperatorSetTotalStakeRewards:       Table_20_AvsOperatorSetTotalStakeRewards,
+	Table_21_GoldStaging:                           Table_21_GoldStaging,
+	Table_22_GoldTable:                             Table_22_GoldTable,
+
+	Table_OperatorAllocationSnapshots: Table_OperatorAllocationSnapshots,
 
 	Sot_1_StakerStrategyPayouts:                Sot_1_StakerStrategyPayouts,
 	Sot_2_OperatorStrategyPayouts:              Sot_2_OperatorStrategyPayouts,
@@ -78,21 +94,24 @@ var goldTableBaseNames = map[string]string{
 }
 
 var GoldTableNameSearchPattern = map[string]string{
-	Table_1_ActiveRewards:                       "gold_%_active_rewards",
-	Table_2_StakerRewardAmounts:                 "gold_%_staker_reward_amounts",
-	Table_3_OperatorRewardAmounts:               "gold_%_operator_reward_amounts",
-	Table_4_RewardsForAll:                       "gold_%_rewards_for_all",
-	Table_5_RfaeStakers:                         "gold_%_rfae_stakers",
-	Table_6_RfaeOperators:                       "gold_%_rfae_operators",
-	Table_7_ActiveODRewards:                     "gold_%_active_od_rewards",
-	Table_8_OperatorODRewardAmounts:             "gold_%_operator_od_reward_amounts",
-	Table_9_StakerODRewardAmounts:               "gold_%_staker_od_reward_amounts",
-	Table_10_AvsODRewardAmounts:                 "gold_%_avs_od_reward_amounts",
-	Table_11_ActiveODOperatorSetRewards:         "gold_%_active_od_operator_set_rewards",
-	Table_12_OperatorODOperatorSetRewardAmounts: "gold_%_operator_od_operator_set_reward_amounts",
-	Table_13_StakerODOperatorSetRewardAmounts:   "gold_%_staker_od_operator_set_reward_amounts",
-	Table_14_AvsODOperatorSetRewardAmounts:      "gold_%_avs_od_operator_set_reward_amounts",
-	Table_15_GoldStaging:                        "gold_%_staging",
+	Table_1_ActiveRewards:                          "gold_%_active_rewards",
+	Table_2_StakerRewardAmounts:                    "gold_%_staker_reward_amounts",
+	Table_3_OperatorRewardAmounts:                  "gold_%_operator_reward_amounts",
+	Table_4_RewardsForAll:                          "gold_%_rewards_for_all",
+	Table_5_RfaeStakers:                            "gold_%_rfae_stakers",
+	Table_6_RfaeOperators:                          "gold_%_rfae_operators",
+	Table_7_ActiveODRewards:                        "gold_%_active_od_rewards",
+	Table_8_OperatorODRewardAmounts:                "gold_%_operator_od_reward_amounts",
+	Table_9_StakerODRewardAmounts:                  "gold_%_staker_od_reward_amounts",
+	Table_10_AvsODRewardAmounts:                    "gold_%_avs_od_reward_amounts",
+	Table_11_ActiveODOperatorSetRewards:            "gold_%_active_od_operator_set_rewards",
+	Table_12_OperatorODOperatorSetRewardAmounts:    "gold_%_operator_od_operator_set_reward_amounts",
+	Table_13_StakerODOperatorSetRewardAmounts:      "gold_%_staker_od_operator_set_reward_amounts",
+	Table_14_AvsODOperatorSetRewardAmounts:         "gold_%_avs_od_operator_set_reward_amounts",
+	Table_15_OperatorOperatorSetUniqueStakeRewards: "gold_%_operator_operator_set_unique_stake_rewards",
+	Table_16_StakerOperatorSetUniqueStakeRewards:   "gold_%_staker_operator_set_unique_stake_rewards",
+	Table_17_AvsOperatorSetUniqueStakeRewards:      "gold_%_avs_operator_set_unique_stake_rewards",
+	Table_21_GoldStaging:                           "gold_%_staging",
 
 	Sot_1_StakerStrategyPayouts:                "sot_%_staker_strategy_payouts",
 	Sot_2_OperatorStrategyPayouts:              "sot_%_operator_strategy_payouts",

--- a/pkg/rewardsUtils/rewardsUtils.go
+++ b/pkg/rewardsUtils/rewardsUtils.go
@@ -111,6 +111,9 @@ var GoldTableNameSearchPattern = map[string]string{
 	Table_15_OperatorOperatorSetUniqueStakeRewards: "gold_%_operator_operator_set_unique_stake_rewards",
 	Table_16_StakerOperatorSetUniqueStakeRewards:   "gold_%_staker_operator_set_unique_stake_rewards",
 	Table_17_AvsOperatorSetUniqueStakeRewards:      "gold_%_avs_operator_set_unique_stake_rewards",
+	Table_18_OperatorOperatorSetTotalStakeRewards:  "gold_%_operator_operator_set_total_stake_rewards",
+	Table_19_StakerOperatorSetTotalStakeRewards:    "gold_%_staker_operator_set_total_stake_rewards",
+	Table_20_AvsOperatorSetTotalStakeRewards:       "gold_%_avs_operator_set_total_stake_rewards",
 	Table_21_GoldStaging:                           "gold_%_staging",
 
 	Sot_1_StakerStrategyPayouts:                "sot_%_staker_strategy_payouts",


### PR DESCRIPTION
## Description

Implements Rewards v2.2 - Operator Set rewards with automatic stake-weighted distribution for both unique allocated stake and total delegated stake. This brings forward-looking reward capabilities (up to 2 years) to operator sets managed via AllocationManager, closing the architectural gap where only AVSDirectory-based AVSs could create forward-looking rewards.

### Withdrawal Queue Integration (Sabine Fork)
14-day withdrawal delay now integrated into staker share snapshots:

- Withdrawals queued on Day 1 → shares removed starting Day 15
- Slashing during queue period adjusts withdrawable amounts
- Tracked via queued_slashing_withdrawals table
- Migration: 202512101500_queuedWithdrawalSlashingAdjustments

### Unique Stake Rewards (Tables 15-17)
Rewards based on allocated unique stake to operator sets:

- Table 15: Operator rewards - calculates pro-rata distribution based on (shares × magnitude / max_magnitude) × multiplier
- Table 16: Staker rewards - distributes staker portion from Table 15, respects withdrawal queue
- Table 17: AVS refunds - refunds for operators without unique stake allocations

### Total Stake Rewards (Tables 18-20)
Rewards based on total delegated stake (operator set analog to Rewards v1):

- Table 18: Operator rewards - calculates pro-rata distribution based on shares × multiplier
- Table 19: Staker rewards - distributes staker portion from Table 18, queue-aware
- Table 20: AVS refunds - refunds for operators without sufficient total stake

### Refund Logic
Tables 17 and 20 calculate separate refund buckets (not subtractions) for three scenarios:

- Operators not registered to operator set
- Operators registered but without required stake (unique stake for 15-17, total stake for 18-20)
- Operators with stake but strategies not registered

These refunds are tracked separately and combined in final staging tables (Table 21).

### Slashable Period Tracking
Enhanced operatorSetOperatorRegistrationSnapshots to track slashable_until:

- Operators remain in snapshots until deregistration + 14 days
- Ensures correct reward distribution during post-deregistration slashable period
- Migration: 202512160000_addSlashableUntilToOperatorRegistrationSnapshots

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Integration testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
