### PR TITLE
feat: get ALL stakers for a strategy (undelegated)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
-	github.com/Layr-Labs/protocol-apis v1.19.1-0.20251103194738-844239e24bed
+	github.com/Layr-Labs/protocol-apis v1.19.1-0.20260205151336-7d96482b4d9f
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/akuity/grpc-gateway-client v0.0.0-20240912082144-55a48e8b4b89

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/Layr-Labs/protocol-apis v1.19.1-0.20251021154510-2a3d1f14d7c0 h1:0oQA
 github.com/Layr-Labs/protocol-apis v1.19.1-0.20251021154510-2a3d1f14d7c0/go.mod h1:ZJTZitWS+MnfHND/RF5DMQoFDXnjtP/Xu2Yoxf+hS+Q=
 github.com/Layr-Labs/protocol-apis v1.19.1-0.20251103194738-844239e24bed h1:d7xKb4M+2yk7FvJ5MxCtuO3bCQPpVQFzDQFJ1TR5Ep8=
 github.com/Layr-Labs/protocol-apis v1.19.1-0.20251103194738-844239e24bed/go.mod h1:ZJTZitWS+MnfHND/RF5DMQoFDXnjtP/Xu2Yoxf+hS+Q=
+github.com/Layr-Labs/protocol-apis v1.19.1-0.20260205151336-7d96482b4d9f h1:srHncqjoaQpMi9yAdwdRJrT8S8/NjwRzpXigJz+j1bw=
+github.com/Layr-Labs/protocol-apis v1.19.1-0.20260205151336-7d96482b4d9f/go.mod h1:ZJTZitWS+MnfHND/RF5DMQoFDXnjtP/Xu2Yoxf+hS+Q=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/pkg/rpcServer/protocolHandlers.go
+++ b/pkg/rpcServer/protocolHandlers.go
@@ -140,60 +140,56 @@ func (rpc *RpcServer) GetDelegatedStakersForOperator(ctx context.Context, reques
 	}, nil
 }
 
-// TODO: ListStakersForStrategy - Blocked on protocol-apis protobuf updates
-// Once the protobuf definitions are added to github.com/Layr-Labs/protocol-apis
-// uncomment and update this handler:
-//
-// func (rpc *RpcServer) ListStakersForStrategy(ctx context.Context, request *protocolV1.ListStakersForStrategyRequest) (*protocolV1.ListStakersForStrategyResponse, error) {
-//     strategy := request.GetStrategyAddress()
-//     if strategy == "" {
-//         return nil, errors.New("strategy address is required")
-//     }
-//
-//     var pagination *types.Pagination
-//     if p := request.GetPagination(); p != nil {
-//         pagination = types.NewDefaultPagination()
-//         pagination.Load(p.GetPageNumber(), p.GetPageSize())
-//     }
-//
-//     // Map protobuf delegation filter to service DelegationFilter
-//     delegationFilter := protocolDataService.DelegationFilterAll
-//     switch request.GetDelegationFilter() {
-//     case protocolV1.DelegationFilter_DELEGATION_FILTER_DELEGATED:
-//         delegationFilter = protocolDataService.DelegationFilterDelegated
-//     case protocolV1.DelegationFilter_DELEGATION_FILTER_UNDELEGATED:
-//         delegationFilter = protocolDataService.DelegationFilterUndelegated
-//     }
-//
-//     stakers, err := rpc.protocolDataService.ListStakersForStrategy(ctx, strategy, request.GetBlockHeight(), delegationFilter, pagination)
-//     if err != nil {
-//         return nil, err
-//     }
-//
-//     var nextPage *common.Pagination
-//     if pagination != nil && uint32(len(stakers)) == pagination.PageSize {
-//         nextPage = &common.Pagination{
-//             PageNumber: pagination.Page + 1,
-//             PageSize:   pagination.PageSize,
-//         }
-//     }
-//
-//     return &protocolV1.ListStakersForStrategyResponse{
-//         Stakers: utils.Map(stakers, func(s *protocolDataService.StakerForStrategy, i uint64) *protocolV1.StakerForStrategy {
-//             operatorAddr := ""
-//             if s.Operator != nil {
-//                 operatorAddr = *s.Operator
-//             }
-//             return &protocolV1.StakerForStrategy{
-//                 StakerAddress:   s.Staker,
-//                 Shares:          s.Shares,
-//                 OperatorAddress: operatorAddr,
-//                 Delegated:       s.Delegated,
-//             }
-//         }),
-//         NextPage: nextPage,
-//     }, nil
-// }
+func (rpc *RpcServer) ListStakersForStrategy(ctx context.Context, request *protocolV1.ListStakersForStrategyRequest) (*protocolV1.ListStakersForStrategyResponse, error) {
+	strategy := request.GetStrategyAddress()
+	if strategy == "" {
+		return nil, errors.New("strategy address is required")
+	}
+
+	var pagination *types.Pagination
+	if p := request.GetPagination(); p != nil {
+		pagination = types.NewDefaultPagination()
+		pagination.Load(p.GetPageNumber(), p.GetPageSize())
+	}
+
+	// Map protobuf delegation filter to service DelegationFilter
+	delegationFilter := protocolDataService.DelegationFilterAll
+	switch request.GetDelegationFilter() {
+	case protocolV1.DelegationFilter_DELEGATION_FILTER_DELEGATED:
+		delegationFilter = protocolDataService.DelegationFilterDelegated
+	case protocolV1.DelegationFilter_DELEGATION_FILTER_UNDELEGATED:
+		delegationFilter = protocolDataService.DelegationFilterUndelegated
+	}
+
+	stakers, err := rpc.protocolDataService.ListStakersForStrategy(ctx, strategy, request.GetBlockHeight(), delegationFilter, pagination)
+	if err != nil {
+		return nil, err
+	}
+
+	var nextPage *common.Pagination
+	if pagination != nil && uint32(len(stakers)) == pagination.PageSize {
+		nextPage = &common.Pagination{
+			PageNumber: pagination.Page + 1,
+			PageSize:   pagination.PageSize,
+		}
+	}
+
+	return &protocolV1.ListStakersForStrategyResponse{
+		Stakers: utils.Map(stakers, func(s *protocolDataService.StakerForStrategy, i uint64) *protocolV1.StakerForStrategy {
+			operatorAddr := ""
+			if s.Operator != nil {
+				operatorAddr = *s.Operator
+			}
+			return &protocolV1.StakerForStrategy{
+				StakerAddress:   s.Staker,
+				Shares:          s.Shares,
+				OperatorAddress: operatorAddr,
+				Delegated:       s.Delegated,
+			}
+		}),
+		NextPage: nextPage,
+	}, nil
+}
 
 func (rpc *RpcServer) GetStakerShares(ctx context.Context, request *protocolV1.GetStakerSharesRequest) (*protocolV1.GetStakerSharesResponse, error) {
 	shares, err := rpc.protocolDataService.ListStakerShares(ctx, request.GetStakerAddress(), request.GetBlockHeight())

--- a/pkg/rpcServer/protocolHandlers.go
+++ b/pkg/rpcServer/protocolHandlers.go
@@ -140,6 +140,61 @@ func (rpc *RpcServer) GetDelegatedStakersForOperator(ctx context.Context, reques
 	}, nil
 }
 
+// TODO: ListStakersForStrategy - Blocked on protocol-apis protobuf updates
+// Once the protobuf definitions are added to github.com/Layr-Labs/protocol-apis
+// uncomment and update this handler:
+//
+// func (rpc *RpcServer) ListStakersForStrategy(ctx context.Context, request *protocolV1.ListStakersForStrategyRequest) (*protocolV1.ListStakersForStrategyResponse, error) {
+//     strategy := request.GetStrategyAddress()
+//     if strategy == "" {
+//         return nil, errors.New("strategy address is required")
+//     }
+//
+//     var pagination *types.Pagination
+//     if p := request.GetPagination(); p != nil {
+//         pagination = types.NewDefaultPagination()
+//         pagination.Load(p.GetPageNumber(), p.GetPageSize())
+//     }
+//
+//     // Map protobuf delegation filter to service DelegationFilter
+//     delegationFilter := protocolDataService.DelegationFilterAll
+//     switch request.GetDelegationFilter() {
+//     case protocolV1.DelegationFilter_DELEGATION_FILTER_DELEGATED:
+//         delegationFilter = protocolDataService.DelegationFilterDelegated
+//     case protocolV1.DelegationFilter_DELEGATION_FILTER_UNDELEGATED:
+//         delegationFilter = protocolDataService.DelegationFilterUndelegated
+//     }
+//
+//     stakers, err := rpc.protocolDataService.ListStakersForStrategy(ctx, strategy, request.GetBlockHeight(), delegationFilter, pagination)
+//     if err != nil {
+//         return nil, err
+//     }
+//
+//     var nextPage *common.Pagination
+//     if pagination != nil && uint32(len(stakers)) == pagination.PageSize {
+//         nextPage = &common.Pagination{
+//             PageNumber: pagination.Page + 1,
+//             PageSize:   pagination.PageSize,
+//         }
+//     }
+//
+//     return &protocolV1.ListStakersForStrategyResponse{
+//         Stakers: utils.Map(stakers, func(s *protocolDataService.StakerForStrategy, i uint64) *protocolV1.StakerForStrategy {
+//             operatorAddr := ""
+//             if s.Operator != nil {
+//                 operatorAddr = *s.Operator
+//             }
+//             return &protocolV1.StakerForStrategy{
+//                 StakerAddress:   s.Staker,
+//                 Shares:          s.Shares,
+//                 OperatorAddress: operatorAddr,
+//                 Delegated:       s.Delegated,
+//             }
+//         }),
+//         NextPage: nextPage,
+//     }, nil
+// }
+
 func (rpc *RpcServer) GetStakerShares(ctx context.Context, request *protocolV1.GetStakerSharesRequest) (*protocolV1.GetStakerSharesResponse, error) {
 	shares, err := rpc.protocolDataService.ListStakerShares(ctx, request.GetStakerAddress(), request.GetBlockHeight())
 	if err != nil {


### PR DESCRIPTION
## Description

Added ListStakersForStrategy function to `protocol.go` that returns all stakers with deposits in a specific strategy, filterable by delegation status (ALL/DELEGATED/UNDELEGATED).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
