### PR TITLE
fix: fix cross-strategy double-counting of netDeltas in slash processing

### DIFF
--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -1073,18 +1073,18 @@ func (ss *StakerSharesModel) prepareState(blockNumber uint64) ([]*StakerShareDel
 	// ensure our slashing events are ordered by transactionIndex asc, logIndex asc
 	orderedSlashes := orderSlashes(slashes)
 
-	// keep track of the running sum of deltas found in this current block, if any
-	netDeltas := make(map[string]*big.Int)
 	records := make([]*StakerShareDeltas, 0)
 
 	// copy share deltas to the new records result slice so we dont mutate the original list of deltas
 	records = append(records, shareDeltas...)
 
 	for _, slash := range orderedSlashes {
-		// Iterate over all of the in-memory deltas and find the ones that are before the slashing event
-		//
-		// For the records that DO come before the slashing event, capture their running share sum up to the slashing
-		// event so that we can add it to the existing sum from the database.
+		// Reset netDeltas on each iteration so base deltas are accumulated exactly once.
+		// Without this reset, the same shareDeltas would be added N times for N slashes
+		// from a single OperatorSlashed event, causing phantom positive shares.
+		netDeltas := make(map[string]*big.Int)
+
+		// Accumulate base share deltas (deposits, withdrawals) that occurred before this slash
 		for _, delta := range shareDeltas {
 			if delta.TransactionIndex > slash.TransactionIndex {
 				continue
@@ -1099,6 +1099,26 @@ func (ss *StakerSharesModel) prepareState(blockNumber uint64) ([]*StakerShareDel
 			shares, success := new(big.Int).SetString(delta.Shares, 10)
 			if !success {
 				return nil, fmt.Errorf("failed to convert shares to big.Int: %s", delta.Shares)
+			}
+			netDeltas[key] = netDeltas[key].Add(netDeltas[key], shares)
+		}
+
+		// Accumulate slash deltas from prior iterations that precede this slash,
+		// so that earlier slash events in the same block correctly affect later ones.
+		for _, rec := range records[len(shareDeltas):] {
+			if rec.TransactionIndex > slash.TransactionIndex {
+				continue
+			}
+			if rec.TransactionIndex == slash.TransactionIndex && rec.LogIndex > slash.LogIndex {
+				continue
+			}
+			key := getNetDeltaKey(rec.Staker, rec.Strategy)
+			if _, ok := netDeltas[key]; !ok {
+				netDeltas[key] = big.NewInt(0)
+			}
+			shares, success := new(big.Int).SetString(rec.Shares, 10)
+			if !success {
+				return nil, fmt.Errorf("failed to convert shares to big.Int: %s", rec.Shares)
 			}
 			netDeltas[key] = netDeltas[key].Add(netDeltas[key], shares)
 		}
@@ -1140,9 +1160,9 @@ func (ss *StakerSharesModel) prepareState(blockNumber uint64) ([]*StakerShareDel
 			// add any delta shares
 			shares = shares.Add(shares, newDeltaShares)
 
-			// if the delegated staker has 0 total shares after accounting for delta shares, skip them
-			if shares.Cmp(big.NewInt(0)) == 0 {
-				ss.logger.Sugar().Debugw("Staker shares are 0, skipping",
+			// if the delegated staker has 0 or negative total shares after accounting for delta shares, skip them
+			if shares.Cmp(big.NewInt(0)) <= 0 {
+				ss.logger.Sugar().Debugw("Staker shares are <= 0, skipping",
 					zap.String("staker", stakerShare.Staker),
 					zap.String("strategy", slash.Strategy),
 					zap.String("shares", shares.String()),


### PR DESCRIPTION
## Description

Fixes a bug in `prepareState()` where the netDeltas map was initialized once outside the slash loop, causing the inner loop to re-accumulate the same share deltas on every iteration. When an OperatorSlashed event contained N strategies, each delta was counted N times, making currentShares go negative and producing phantom positive slash deltas via division by -1e18. An attacker controlling an AVS could exploit this to inflate their reward share at the expense of other stakers.


**Changes:**

- Reset netDeltas on each outer slash iteration and explicitly carry forward prior slash-generated records, preventing base delta double-counting while preserving correct chaining of multiple slash events in the same block
- Tighten the shares guard from == 0 to <= 0 so negative currentShares are also skipped as defense-in-depth

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
