### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check-fmt.yml
+++ b/.github/workflows/check-fmt.yml
@@ -10,10 +10,10 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: '1.23'
       - name: Check formatting

--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Check if branch is up to date

--- a/.github/workflows/codeql-scanning.yaml
+++ b/.github/workflows/codeql-scanning.yaml
@@ -33,10 +33,10 @@ jobs:
         
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL with Trail of Bits Go Queries as well
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
       with:
         languages: go
         packs: trailofbits/go-queries
         
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,10 +19,10 @@ jobs:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
           cache: yarn
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: make docs/build
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/build
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install dependencies
         run: make deps
       - name: Run tests
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: '1.23'
       - name: Run linter
@@ -59,27 +59,27 @@ jobs:
     runs-on: protocol-gha-runners
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set release version
         env:
           REF: ${{ github.ref }}
         run: |
           ./scripts/version.sh $REF
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
         with:
           registry-type: public
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: "public.ecr.aws/z6g0f8n7"
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Check and set release version
         env:
           REF: ${{ github.ref }}
@@ -115,7 +115,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Check and set release version
         env:
           REF: ${{ github.ref }}
@@ -130,7 +130,7 @@ jobs:
           ./scripts/bundleReleases.sh $VERSION
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -169,7 +169,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Release Helm Chart
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,10 +8,10 @@ jobs:
   lint-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '18'
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions across 6 workflow files to their exact commit SHAs instead of mutable version tags
- Prevents supply chain attacks where a compromised tag could execute arbitrary code in CI
- Version comments added alongside each SHA for maintainability (e.g., `# v4.3.1`)

## Actions pinned

| Action | Version | Workflow(s) |
|--------|---------|-------------|
| `actions/checkout` | v4.3.1 | main, check-merge, deploy-pages |
| `actions/checkout` | v3.6.0 | pr-lint, check-fmt |
| `actions/setup-go` | v4.3.0 | main, check-fmt |
| `actions/setup-node` | v4.4.0 | deploy-pages |
| `actions/setup-node` | v3.9.1 | pr-lint |
| `actions/upload-pages-artifact` | v3.0.1 | deploy-pages |
| `actions/deploy-pages` | v4.0.5 | deploy-pages |
| `actions/create-release` | v1.1.4 | main |
| `aws-actions/configure-aws-credentials` | v4.3.1 | main |
| `aws-actions/amazon-ecr-login` | v2.1.2 | main |
| `docker/setup-qemu-action` | v2.2.0 | main |
| `docker/setup-buildx-action` | v3.12.0 | main |
| `github/codeql-action` | v3.35.2 | codeql-scanning |

## Test plan
- [ ] Verify all CI workflows pass on this PR (check-fmt, check-merge, pr-lint, main build/test/lint)
- [ ] Confirm no functional changes — only `uses:` references updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)