### PR TITLE
refactor(eigenState): extract generic ParseLogOutputAsType helper

### DIFF
--- a/pkg/eigenState/base/baseEigenState.go
+++ b/pkg/eigenState/base/baseEigenState.go
@@ -53,6 +53,28 @@ func (b *BaseEigenState) ParseLogOutput(log *storage.TransactionLog) (map[string
 	return outputData, nil
 }
 
+// ParseLogOutputAsType decodes a transaction log's OutputData JSON string into a new value
+// of type T.
+//
+// It decodes with a json.Decoder configured to UseNumber() so that large integer and decimal
+// values (such as share amounts) retain their full precision. Without this, the standard
+// decoder would parse them into a float64 and lose precision by representing them in
+// scientific notation. Numeric fields on T that must preserve precision should therefore be
+// typed as json.Number.
+//
+// This is the generic form of the per-event parseLogOutputFor*Event helpers found across the
+// state models; callers apply any event-specific post-processing (e.g. lower-casing addresses,
+// hex-encoding roots) to the returned value.
+func ParseLogOutputAsType[T any](outputDataStr string) (*T, error) {
+	outputData := new(T)
+	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
+	decoder.UseNumber()
+	if err := decoder.Decode(outputData); err != nil {
+		return nil, err
+	}
+	return outputData, nil
+}
+
 // Include the block number as the first item in the tree.
 // This does two things:
 // 1. Ensures that the tree is always different for different blocks

--- a/pkg/eigenState/base/baseEigenState_test.go
+++ b/pkg/eigenState/base/baseEigenState_test.go
@@ -1,0 +1,45 @@
+package base
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseLogOutputAsType(t *testing.T) {
+	type sample struct {
+		Staker string      `json:"staker"`
+		Shares json.Number `json:"shares"`
+	}
+
+	t.Run("decodes JSON into the target type", func(t *testing.T) {
+		out, err := ParseLogOutputAsType[sample](`{"staker":"0xabc","shares":"100"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Staker != "0xabc" {
+			t.Errorf("Staker = %q, want %q", out.Staker, "0xabc")
+		}
+		if out.Shares.String() != "100" {
+			t.Errorf("Shares = %q, want %q", out.Shares.String(), "100")
+		}
+	})
+
+	// UseNumber() must be applied so that share values larger than 2^53 (where a float64
+	// would silently lose precision) survive the round-trip exactly.
+	t.Run("preserves precision of large numeric values", func(t *testing.T) {
+		const bigShares = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+		out, err := ParseLogOutputAsType[sample](`{"shares":` + bigShares + `}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Shares.String() != bigShares {
+			t.Errorf("Shares = %q, want %q", out.Shares.String(), bigShares)
+		}
+	})
+
+	t.Run("returns an error for malformed JSON", func(t *testing.T) {
+		if _, err := ParseLogOutputAsType[sample](`{"staker":`); err == nil {
+			t.Error("expected an error for malformed JSON, got nil")
+		}
+	})
+}

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -136,18 +136,14 @@ type depositOutputData struct {
 // Allowing the standard json.Unmarshal to parse the shares value to a float64 which
 // causes it to lose precision by being represented as scientific notation.
 func parseLogOutputForDepositEvent(outputDataStr string) (*depositOutputData, error) {
-	outputData := &depositOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[depositOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.Staker = strings.ToLower(outputData.Staker)
 	outputData.Depositor = strings.ToLower(outputData.Depositor)
 	outputData.Strategy = strings.ToLower(outputData.Strategy)
-	return outputData, err
+	return outputData, nil
 }
 
 func (ss *StakerSharesModel) handleStakerDepositEvent(log *storage.TransactionLog) (*StakerShareDeltas, error) {
@@ -192,15 +188,7 @@ type podSharesUpdatedOutputData struct {
 }
 
 func parseLogOutputForPodSharesUpdatedEvent(outputDataStr string) (*podSharesUpdatedOutputData, error) {
-	outputData := &podSharesUpdatedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
-	if err != nil {
-		return nil, err
-	}
-	return outputData, err
+	return base.ParseLogOutputAsType[podSharesUpdatedOutputData](outputDataStr)
 }
 
 func (ss *StakerSharesModel) handlePodSharesUpdatedEvent(log *storage.TransactionLog) (*StakerShareDeltas, error) {
@@ -281,17 +269,13 @@ type m2MigrationOutputData struct {
 }
 
 func parseLogOutputForM2MigrationEvent(outputDataStr string) (*m2MigrationOutputData, error) {
-	outputData := &m2MigrationOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[m2MigrationOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.OldWithdrawalRootString = hex.EncodeToString(outputData.OldWithdrawalRoot)
 	outputData.NewWithdrawalRootString = hex.EncodeToString(outputData.NewWithdrawalRoot)
-	return outputData, err
+	return outputData, nil
 }
 
 // handleMigratedM2StakerWithdrawals handles the WithdrawalMigrated event from the DelegationManager contract
@@ -365,17 +349,13 @@ type m2WithdrawalOutputData struct {
 }
 
 func parseLogOutputForM2WithdrawalEvent(outputDataStr string) (*m2WithdrawalOutputData, error) {
-	outputData := &m2WithdrawalOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[m2WithdrawalOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.Withdrawal.Staker = strings.ToLower(outputData.Withdrawal.Staker)
 	outputData.WithdrawalRootString = hex.EncodeToString(outputData.WithdrawalRoot)
-	return outputData, err
+	return outputData, nil
 }
 
 // handleM2QueuedWithdrawal handles the WithdrawalQueued event from the DelegationManager contract for M2.
@@ -424,17 +404,13 @@ type slashingWithdrawalQueuedOutputData struct {
 }
 
 func parseLogOutputForSlashingWithdrawalQueuedEvent(outputDataStr string) (*slashingWithdrawalQueuedOutputData, error) {
-	outputData := &slashingWithdrawalQueuedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[slashingWithdrawalQueuedOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.Withdrawal.Staker = strings.ToLower(outputData.Withdrawal.Staker)
 	outputData.WithdrawalRootString = hex.EncodeToString(outputData.WithdrawalRoot)
-	return outputData, err
+	return outputData, nil
 }
 
 // handleSlashingWithdrawalQueued handles the WithdrawalQueued event from the DelegationManager contract for slashing
@@ -476,16 +452,7 @@ type OperatorSlashedOutputData struct {
 }
 
 func parseLogOutputForOperatorSlashedEvent(outputDataStr string) (*OperatorSlashedOutputData, error) {
-	outputData := &OperatorSlashedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
-	if err != nil {
-		return nil, err
-	}
-
-	return outputData, err
+	return base.ParseLogOutputAsType[OperatorSlashedOutputData](outputDataStr)
 }
 
 func (ss *StakerSharesModel) handleOperatorSlashedEvent(log *storage.TransactionLog) ([]*SlashDiff, error) {
@@ -530,16 +497,7 @@ type BeaconChainSlashingFactorDecreasedOutputData struct {
 }
 
 func parseLogOutputForBeaconChainSlashingFactorDecreasedEvent(outputDataStr string) (*BeaconChainSlashingFactorDecreasedOutputData, error) {
-	outputData := &BeaconChainSlashingFactorDecreasedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
-	if err != nil {
-		return nil, err
-	}
-
-	return outputData, err
+	return base.ParseLogOutputAsType[BeaconChainSlashingFactorDecreasedOutputData](outputDataStr)
 }
 
 func (ss *StakerSharesModel) handleBeaconChainSlashingFactorDecreasedEvent(log *storage.TransactionLog) (*SlashDiff, error) {


### PR DESCRIPTION
The per-event parseLogOutputFor*Event helpers each repeated the same json.Decoder + UseNumber() boilerplate, differing only in the target struct type. This duplication appears across ~24 model files in the eigenState package.

Introduce a generic base.ParseLogOutputAsType[T any] that performs the precision-preserving decode once, and migrate all seven call sites in the stakerShares model to use it. UseNumber() is retained so large share/slashing values keep full precision (json.Number) rather than being coerced to a lossy float64 — behavior is unchanged.

The remaining 23 model files can be migrated mechanically in follow-ups.

Refs #24

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (non-breaking change which does not add functionality)
- [ ] Docs (documentation updates)
- [ ] Performance improvement
- [ ] Refactor (non-breaking change which does not add or remove functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
