### PR TITLE
refactor(eigenState): extract generic ParseLogOutputAsType helper

### DIFF
--- a/pkg/eigenState/base/baseEigenState.go
+++ b/pkg/eigenState/base/baseEigenState.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+
 	"github.com/Layr-Labs/sidecar/pkg/parser"
 	"github.com/Layr-Labs/sidecar/pkg/storage"
 	"gorm.io/gorm/clause"
@@ -49,6 +51,36 @@ func (b *BaseEigenState) ParseLogOutput(log *storage.TransactionLog) (map[string
 			zap.Uint64("transactionIndex", log.TransactionIndex),
 		)
 		return nil, err
+	}
+	return outputData, nil
+}
+
+// ParseLogOutputAsType decodes a transaction log's OutputData JSON string into a new value
+// of type T.
+//
+// It decodes with a json.Decoder configured to UseNumber() so that large integer and decimal
+// values (such as share amounts) retain their full precision. Without UseNumber, JSON numbers
+// are decoded into float64, whose 53-bit mantissa cannot represent integers larger than 2^53
+// exactly, so large values would be silently rounded. Numeric fields on T that must preserve
+// precision should therefore be typed as json.Number.
+//
+// After decoding a single JSON value it confirms the input held nothing else, so trailing or
+// concatenated data is rejected rather than silently ignored.
+//
+// This is the generic form of the per-event parseLogOutputFor*Event helpers found across the
+// state models; callers apply any event-specific post-processing (e.g. lower-casing addresses,
+// hex-encoding roots) to the returned value.
+func ParseLogOutputAsType[T any](outputDataStr string) (*T, error) {
+	outputData := new(T)
+	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
+	decoder.UseNumber()
+	if err := decoder.Decode(outputData); err != nil {
+		return nil, err
+	}
+	// A single JSON value is expected; a second decode must hit EOF. Otherwise the input
+	// carried trailing or concatenated data, which we reject rather than silently ignore.
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("unexpected trailing data after JSON value")
 	}
 	return outputData, nil
 }

--- a/pkg/eigenState/base/baseEigenState_test.go
+++ b/pkg/eigenState/base/baseEigenState_test.go
@@ -1,0 +1,51 @@
+package base
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseLogOutputAsType(t *testing.T) {
+	type sample struct {
+		Staker string      `json:"staker"`
+		Shares json.Number `json:"shares"`
+	}
+
+	t.Run("decodes JSON into the target type", func(t *testing.T) {
+		out, err := ParseLogOutputAsType[sample](`{"staker":"0xabc","shares":"100"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Staker != "0xabc" {
+			t.Errorf("Staker = %q, want %q", out.Staker, "0xabc")
+		}
+		if out.Shares.String() != "100" {
+			t.Errorf("Shares = %q, want %q", out.Shares.String(), "100")
+		}
+	})
+
+	// UseNumber() must be applied so that share values larger than 2^53 (where a float64
+	// would silently lose precision) survive the round-trip exactly.
+	t.Run("preserves precision of large numeric values", func(t *testing.T) {
+		const bigShares = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+		out, err := ParseLogOutputAsType[sample](`{"shares":` + bigShares + `}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Shares.String() != bigShares {
+			t.Errorf("Shares = %q, want %q", out.Shares.String(), bigShares)
+		}
+	})
+
+	t.Run("returns an error for malformed JSON", func(t *testing.T) {
+		if _, err := ParseLogOutputAsType[sample](`{"staker":`); err == nil {
+			t.Error("expected an error for malformed JSON, got nil")
+		}
+	})
+
+	t.Run("rejects trailing data after the JSON value", func(t *testing.T) {
+		if _, err := ParseLogOutputAsType[sample](`{"staker":"0xabc"}{"staker":"0xdef"}`); err == nil {
+			t.Error("expected an error for trailing data, got nil")
+		}
+	})
+}

--- a/pkg/eigenState/stakerShares/stakerShares.go
+++ b/pkg/eigenState/stakerShares/stakerShares.go
@@ -136,18 +136,14 @@ type depositOutputData struct {
 // Allowing the standard json.Unmarshal to parse the shares value to a float64 which
 // causes it to lose precision by being represented as scientific notation.
 func parseLogOutputForDepositEvent(outputDataStr string) (*depositOutputData, error) {
-	outputData := &depositOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[depositOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.Staker = strings.ToLower(outputData.Staker)
 	outputData.Depositor = strings.ToLower(outputData.Depositor)
 	outputData.Strategy = strings.ToLower(outputData.Strategy)
-	return outputData, err
+	return outputData, nil
 }
 
 func (ss *StakerSharesModel) handleStakerDepositEvent(log *storage.TransactionLog) (*StakerShareDeltas, error) {
@@ -192,15 +188,7 @@ type podSharesUpdatedOutputData struct {
 }
 
 func parseLogOutputForPodSharesUpdatedEvent(outputDataStr string) (*podSharesUpdatedOutputData, error) {
-	outputData := &podSharesUpdatedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
-	if err != nil {
-		return nil, err
-	}
-	return outputData, err
+	return base.ParseLogOutputAsType[podSharesUpdatedOutputData](outputDataStr)
 }
 
 func (ss *StakerSharesModel) handlePodSharesUpdatedEvent(log *storage.TransactionLog) (*StakerShareDeltas, error) {
@@ -281,17 +269,13 @@ type m2MigrationOutputData struct {
 }
 
 func parseLogOutputForM2MigrationEvent(outputDataStr string) (*m2MigrationOutputData, error) {
-	outputData := &m2MigrationOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[m2MigrationOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.OldWithdrawalRootString = hex.EncodeToString(outputData.OldWithdrawalRoot)
 	outputData.NewWithdrawalRootString = hex.EncodeToString(outputData.NewWithdrawalRoot)
-	return outputData, err
+	return outputData, nil
 }
 
 // handleMigratedM2StakerWithdrawals handles the WithdrawalMigrated event from the DelegationManager contract
@@ -365,17 +349,13 @@ type m2WithdrawalOutputData struct {
 }
 
 func parseLogOutputForM2WithdrawalEvent(outputDataStr string) (*m2WithdrawalOutputData, error) {
-	outputData := &m2WithdrawalOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[m2WithdrawalOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.Withdrawal.Staker = strings.ToLower(outputData.Withdrawal.Staker)
 	outputData.WithdrawalRootString = hex.EncodeToString(outputData.WithdrawalRoot)
-	return outputData, err
+	return outputData, nil
 }
 
 // handleM2QueuedWithdrawal handles the WithdrawalQueued event from the DelegationManager contract for M2.
@@ -424,17 +404,13 @@ type slashingWithdrawalQueuedOutputData struct {
 }
 
 func parseLogOutputForSlashingWithdrawalQueuedEvent(outputDataStr string) (*slashingWithdrawalQueuedOutputData, error) {
-	outputData := &slashingWithdrawalQueuedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
+	outputData, err := base.ParseLogOutputAsType[slashingWithdrawalQueuedOutputData](outputDataStr)
 	if err != nil {
 		return nil, err
 	}
 	outputData.Withdrawal.Staker = strings.ToLower(outputData.Withdrawal.Staker)
 	outputData.WithdrawalRootString = hex.EncodeToString(outputData.WithdrawalRoot)
-	return outputData, err
+	return outputData, nil
 }
 
 // handleSlashingWithdrawalQueued handles the WithdrawalQueued event from the DelegationManager contract for slashing
@@ -476,16 +452,7 @@ type OperatorSlashedOutputData struct {
 }
 
 func parseLogOutputForOperatorSlashedEvent(outputDataStr string) (*OperatorSlashedOutputData, error) {
-	outputData := &OperatorSlashedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
-	if err != nil {
-		return nil, err
-	}
-
-	return outputData, err
+	return base.ParseLogOutputAsType[OperatorSlashedOutputData](outputDataStr)
 }
 
 func (ss *StakerSharesModel) handleOperatorSlashedEvent(log *storage.TransactionLog) ([]*SlashDiff, error) {
@@ -530,16 +497,7 @@ type BeaconChainSlashingFactorDecreasedOutputData struct {
 }
 
 func parseLogOutputForBeaconChainSlashingFactorDecreasedEvent(outputDataStr string) (*BeaconChainSlashingFactorDecreasedOutputData, error) {
-	outputData := &BeaconChainSlashingFactorDecreasedOutputData{}
-	decoder := json.NewDecoder(strings.NewReader(outputDataStr))
-	decoder.UseNumber()
-
-	err := decoder.Decode(&outputData)
-	if err != nil {
-		return nil, err
-	}
-
-	return outputData, err
+	return base.ParseLogOutputAsType[BeaconChainSlashingFactorDecreasedOutputData](outputDataStr)
 }
 
 func (ss *StakerSharesModel) handleBeaconChainSlashingFactorDecreasedEvent(log *storage.TransactionLog) (*SlashDiff, error) {


### PR DESCRIPTION
## Description
The per-event `parseLogOutputFor*Event` helpers each repeated the same
`json.Decoder` + `UseNumber()` boilerplate, differing only in the target struct
type — duplication that appears across ~24 model files in the eigenState package.

This introduces a generic `base.ParseLogOutputAsType[T any]` that performs the
precision-preserving decode once, and migrates all seven call sites in the
`stakerShares` model. `UseNumber()` is retained so large share/slashing values
keep full precision (`json.Number`) rather than being coerced to a lossy
`float64` — behavior is unchanged. Scoped to one model file to stay reviewable;
the remaining 23 model files are mechanical follow-ups.

Refs #24

## Type of change
- [x] Refactor (non-breaking change which does not add or remove functionality)

## How Has This Been Tested?
- Added unit tests for the new helper (`baseEigenState_test.go`): normal decode,
  large-integer precision round-trip (>2^53), and malformed-JSON error.
- `gofmt -l`, `go vet`, and `go test ./pkg/eigenState/base/...` all pass locally.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
