### PR TITLE
fix(rewardsHandlers): nil-deref on ctx cancel in GenerateRewards crashes sidecar

### DIFF
--- a/pkg/rpcServer/rewardsHandlers.go
+++ b/pkg/rpcServer/rewardsHandlers.go
@@ -68,8 +68,15 @@ func (rpc *RpcServer) GenerateRewards(ctx context.Context, req *rewardsV1.Genera
 
 	if waitForComplete {
 		data, qErr := rpc.rewardsQueue.EnqueueAndWait(ctx, msg)
-		cutoffDate = data.CutoffDate
 		err = qErr
+		// EnqueueAndWait returns (nil, ctx.Err()) when the caller's context is
+		// canceled (e.g. gRPC client disconnect while a long-running rewards
+		// generation is still queued). Reading data.CutoffDate before checking
+		// qErr caused a nil-pointer panic that crashed the entire sidecar
+		// process (exit code 2) and required a container restart.
+		if data != nil {
+			cutoffDate = data.CutoffDate
+		}
 	} else {
 		rpc.rewardsQueue.Enqueue(&rewardsCalculatorQueue.RewardsCalculationMessage{
 			Data:         msg,

--- a/pkg/rpcServer/rewardsHandlers_test.go
+++ b/pkg/rpcServer/rewardsHandlers_test.go
@@ -1,0 +1,56 @@
+package rpcServer
+
+import (
+	"context"
+	"testing"
+
+	rewardsV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/rewards"
+	"github.com/Layr-Labs/sidecar/internal/config"
+	"github.com/Layr-Labs/sidecar/pkg/logger"
+	"github.com/Layr-Labs/sidecar/pkg/rewardsCalculatorQueue"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGenerateRewards_ContextCanceled_NoPanic reproduces the crash that took
+// the sidecar down on 2026-07-29 03:09 UTC.
+//
+// When a gRPC client cancels its context mid-generation (e.g. the client pod
+// hits its k8s activeDeadlineSeconds), rewardsQueue.EnqueueAndWait returns
+// (nil, ctx.Err()). Before the fix, GenerateRewards read data.CutoffDate
+// unconditionally, causing a nil-pointer dereference (SIGSEGV) that crashed
+// the whole sidecar process.
+//
+// The queue is intentionally NOT started (no Process() goroutine), so the
+// enqueued message is never picked up. The buffered channel absorbs the write,
+// then EnqueueAndWait's select immediately fires on ctx.Done().
+func TestGenerateRewards_ContextCanceled_NoPanic(t *testing.T) {
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	assert.NoError(t, err)
+
+	// Queue with a nil calculator is safe here — the ctx.Done() path never
+	// touches the calculator. Process() is deliberately not started.
+	queue := rewardsCalculatorQueue.NewRewardsCalculatorQueue(nil, l)
+
+	rpc := &RpcServer{
+		Logger:       l,
+		rewardsQueue: queue,
+		globalConfig: &config.Config{
+			SidecarPrimaryConfig: config.SidecarPrimaryConfig{IsPrimary: true},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel BEFORE the call, so EnqueueAndWait sees ctx.Done() immediately
+
+	assert.NotPanics(t, func() {
+		resp, err := rpc.GenerateRewards(ctx, &rewardsV1.GenerateRewardsRequest{
+			CutoffDate:      "2026-07-28",
+			WaitForComplete: true,
+		})
+		// With the fix, we should get a clean error return (canceled context
+		// bubbles up as codes.Internal). Response payload is not meaningful here;
+		// we only care that we didn't panic.
+		assert.Error(t, err)
+		_ = resp
+	})
+}


### PR DESCRIPTION
## Summary
`GenerateRewards` reads `data.CutoffDate` unconditionally after
`rewardsQueue.EnqueueAndWait(ctx, msg)`. When the caller's context is canceled
mid-generation, that call returns `(nil, ctx.Err())` and the subsequent field
access panics with `SIGSEGV`, taking the whole sidecar process down (exit 2 + k8s
restart), stalling block indexing and downstream RPC.

## Repro on mainnet (v4.1.1_e6ffd25)
A gRPC client (an eigenlayer-rewards-updater CronJob pod) invoked
`GenerateRewards(cutoff="latest", waitForComplete=true)` during a fresh snapshot
generation. K8s hit the pod's `activeDeadlineSeconds` at 15min and killed it →
gRPC context cancel → sidecar crashed. Last two log lines before the panic:

```
{"caller":"rewardsCalculatorQueue/queue.go:68","msg":"Received context.Done()"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11e5bcd]
goroutine 1084798 [running]:
github.com/Layr-Labs/sidecar/pkg/rpcServer.(*RpcServer).GenerateRewards(0x2642790?, {0x1c3aa98?, 0xc0278e0b40?}, 0xc012aac2c0?)
    /build/pkg/rpcServer/rewardsHandlers.go:71 +0x8d
```

## Fix
Check `err` first; only dereference the response payload when it's non-nil. The
other three `EnqueueAndWait` call sites in this file already discard `data` via
`_, err := ...` and were unaffected — this was the only site with the bug.

```go
if waitForComplete {
    data, qErr := rpc.rewardsQueue.EnqueueAndWait(ctx, msg)
    err = qErr
    if data != nil {
        cutoffDate = data.CutoffDate
    }
}
```

## Test
Added `TestGenerateRewards_ContextCanceled_NoPanic`:
- Cancels the context before invoking the handler with `WaitForComplete: true`.
- Queue is intentionally not `Process()`'d, so `EnqueueAndWait`'s `select` fires
  immediately on `ctx.Done()` and returns `(nil, ctx.Err())`.
- Asserts the handler doesn't panic and returns a non-nil error.

Verified: fails on master (reproduces the exact stack, `rewardsHandlers.go:71`
nil-deref), passes with the fix.

\`\`\`
=== fix applied ===
ok  github.com/Layr-Labs/sidecar/pkg/rpcServer  0.703s

=== fix reverted ===
panic: runtime error: invalid memory address or nil pointer dereference
    at rewardsHandlers.go:71
FAIL
\`\`\`